### PR TITLE
Include attestation request name in endorsement request

### DIFF
--- a/kata/pkg/proto/domainapi.proto
+++ b/kata/pkg/proto/domainapi.proto
@@ -94,6 +94,7 @@ message EndorseTransactionRequest {
     repeated EndorsableState inputs = 4; // Input states for the transaction
     repeated EndorsableState outputs = 5; // Output states for the transaction
     repeated AttestationResult signatures = 6; // All SIGN attestation results (required from submitting node before endorsement)
+    string name = 7; // Allows correlation of endorsement request to the original attestation request
 }
 
 message EndorseTransactionResponse {

--- a/kata/testbed/testbed_private_smart_contracts.go
+++ b/kata/testbed/testbed_private_smart_contracts.go
@@ -191,6 +191,7 @@ func (psc *tbPrivateSmartContract) gatherEndorsements(ctx context.Context,
 				}
 				// Build the input
 				endorseReq := &proto.EndorseTransactionRequest{
+					Name:              ar.Name,
 					Transaction:       txSpec,
 					ResolvedVerifiers: resolvedVerifiers,
 					Inputs:            psc.toEndorsableList(inputStates),


### PR DESCRIPTION
For transactions that require multiple endorsements, this can help the domain to understand which endorsement is being processed with each endorsement request.