### PR TITLE
skip probabilistic test

### DIFF
--- a/core/go/internal/engine/sequencer/contention_resolver_test.go
+++ b/core/go/internal/engine/sequencer/contention_resolver_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 func TestContentionResolver_2TransactionsDeterministicResults(t *testing.T) {
-	t.Skip("This test has non zero probability of failing")
-	// ... which means it has a high probabiliy of failing at some point in time if we run it on every CI build
+	t.Skip("this test should be run manually when the algorithm is changed. ")
+	// see https://github.com/kaleido-io/paladin/pull/145 for background
 
 	// create 2 ids at random (representing bidding transactions),
 	// then iterate over 100 random state ids and check that there is a fair distribution of winners


### PR DESCRIPTION
Fixes #132 I don’t think this is a timing thing, It is more a case of not being as fair as the test asserts.  We could change the threshold and/or tight up the algorithm to be more deterministic but at the end of the day we are dealing with probabilities and there is a non zero chance that this test will fail. 

Decided to skip this in CI builds and keep it around as a tool for developers to run manually if we ever do change that algorithm. What we lose by doing this is the opportunity to spot a degradation in fairness caused by new versions of the "[github.com/serialx/hashring](http://github.com/serialx/hashring)" package.