### PR TITLE
Domains zeto 2

### DIFF
--- a/core/java/src/test/java/io/kaleido/paladin/TestDomain.java
+++ b/core/java/src/test/java/io/kaleido/paladin/TestDomain.java
@@ -29,7 +29,6 @@ public class TestDomain extends DomainInstance {
     @Override
     protected CompletableFuture<ToDomain.ConfigureDomainResponse> configureDomain(ToDomain.ConfigureDomainRequest request) {
         ToDomain.DomainConfig domainConfig = ToDomain.DomainConfig.newBuilder()
-                .setFactoryContractAddress("0x1000000000000000000000000000000000000001")
                 .setBaseLedgerSubmitConfig(ToDomain.BaseLedgerSubmitConfig.newBuilder()
                         .setSubmitMode(ToDomain.BaseLedgerSubmitConfig.Mode.ONE_TIME_USE_KEYS)
                         .build())

--- a/domains/noto/build.gradle
+++ b/domains/noto/build.gradle
@@ -71,6 +71,7 @@ task test(type: Exec) {
     workingDir '.'
     executable 'go'
     args 'test'
+    args '-v'
     args './internal/...'
     args './pkg/...'
     args '-cover'

--- a/domains/noto/internal/noto/e2e_noto_test.go
+++ b/domains/noto/internal/noto/e2e_noto_test.go
@@ -18,6 +18,7 @@ package noto
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -87,11 +88,13 @@ func newNotoDomain(t *testing.T, config *types.DomainConfig) (*Noto, *testbed.Te
 			domain.Callbacks = callbacks
 			return &domain
 		}),
+		RegistryAddress: tktypes.MustEthAddress(config.FactoryAddress),
 	}
 }
 
 func newTestbed(t *testing.T, domains map[string]*testbed.TestbedDomain) (context.CancelFunc, testbed.Testbed, rpcbackend.Backend) {
 	tb := testbed.NewTestBed()
+	fmt.Printf("tb: %+v, domains: %+v\n", tb, domains)
 	url, done, err := tb.StartForTest("../../testbed.config.yaml", domains)
 	assert.NoError(t, err)
 	rpc := rpcbackend.NewRPCClient(resty.New().SetBaseURL(url))

--- a/domains/noto/internal/noto/noto.go
+++ b/domains/noto/internal/noto/noto.go
@@ -89,8 +89,7 @@ func (n *Noto) ConfigureDomain(ctx context.Context, req *pb.ConfigureDomainReque
 
 	return &pb.ConfigureDomainResponse{
 		DomainConfig: &pb.DomainConfig{
-			FactoryContractAddress: n.config.FactoryAddress,
-			AbiStateSchemasJson:    []string{string(schemaJSON)},
+			AbiStateSchemasJson: []string{string(schemaJSON)},
 			BaseLedgerSubmitConfig: &pb.BaseLedgerSubmitConfig{
 				SubmitMode: pb.BaseLedgerSubmitConfig_ENDORSER_SUBMISSION,
 			},

--- a/domains/test/pvp_test.go
+++ b/domains/test/pvp_test.go
@@ -126,7 +126,7 @@ func newNotoDomain(t *testing.T, config *types.DomainConfig) (*noto.Noto, *testb
 			domain = noto.New(callbacks)
 			return domain
 		}),
-		FactoryAddress: tktypes.MustEthAddress(config.FactoryAddress),
+		RegistryAddress: tktypes.MustEthAddress(config.FactoryAddress),
 	}
 }
 

--- a/domains/zeto/go.mod
+++ b/domains/zeto/go.mod
@@ -3,6 +3,7 @@ module github.com/kaleido-io/paladin/domains/zeto
 go 1.22.5
 
 require (
+	github.com/go-resty/resty/v2 v2.14.0
 	github.com/hyperledger-labs/zeto/go-sdk v0.0.0-20240905213624-43a614759076
 	github.com/hyperledger/firefly-signer v1.1.14
 	github.com/iden3/go-iden3-crypto v0.0.16
@@ -10,6 +11,7 @@ require (
 	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/protobuf v1.34.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -30,7 +32,6 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-openapi/jsonpointer v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.7 // indirect
-	github.com/go-resty/resty/v2 v2.14.0 // indirect
 	github.com/golang-migrate/migrate/v4 v4.17.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
@@ -102,7 +103,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/postgres v1.5.9 // indirect
 	gorm.io/driver/sqlite v1.5.6 // indirect
 	gorm.io/gorm v1.25.11 // indirect

--- a/domains/zeto/integration-test/e2e_test.go
+++ b/domains/zeto/integration-test/e2e_test.go
@@ -122,12 +122,13 @@ func newZetoDomain(t *testing.T, config *types.DomainFactoryConfig) (zeto.Zeto, 
 			domain.Callbacks = callbacks
 			return &domain
 		}),
+		RegistryAddress: tktypes.MustEthAddress(config.FactoryAddress),
 	}
 }
 
 func newTestbed(t *testing.T, domains map[string]*testbed.TestbedDomain) (context.CancelFunc, testbed.Testbed, rpcbackend.Backend) {
 	tb := testbed.NewTestBed()
-	url, done, err := tb.StartForTest("../../testbed.config.yaml", domains)
+	url, done, err := tb.StartForTest("./testbed.config.yaml", domains)
 	assert.NoError(t, err)
 	rpc := rpcbackend.NewRPCClient(resty.New().SetBaseURL(url))
 	return done, tb, rpc

--- a/domains/zeto/internal/zeto/zeto.go
+++ b/domains/zeto/internal/zeto/zeto.go
@@ -70,8 +70,7 @@ func (z *Zeto) ConfigureDomain(ctx context.Context, req *pb.ConfigureDomainReque
 
 	return &pb.ConfigureDomainResponse{
 		DomainConfig: &pb.DomainConfig{
-			FactoryContractAddress: config.FactoryAddress,
-			AbiStateSchemasJson:    []string{string(schemaJSON)},
+			AbiStateSchemasJson: []string{string(schemaJSON)},
 			BaseLedgerSubmitConfig: &pb.BaseLedgerSubmitConfig{
 				SubmitMode: pb.BaseLedgerSubmitConfig_ENDORSER_SUBMISSION,
 			},

--- a/solidity/test/shared/atom/Atom.ts
+++ b/solidity/test/shared/atom/Atom.ts
@@ -111,15 +111,8 @@ describe("Atom", function () {
     const Atom = await ethers.getContractFactory("Atom");
 
     // Deploy noto contract
-<<<<<<< HEAD
-    const noto = await Noto.connect(notary1).deploy(
-      randomBytes32(),
-      notary1.address,
-      "0x"
-=======
     const noto: Noto = Noto.attach(
       await deployNotoInstance(notoFactory, Noto.interface, notary1.address)
->>>>>>> main
     );
 
     // Fake up a delegation


### PR DESCRIPTION
Reconciled content from `domains-zeto` and `pente-lifecycle`, and rebased on latest `main`