### PR TITLE
Preparing Paladin for Docker Image Build

### DIFF
--- a/.github/workflows/paladin-PR-build.yml
+++ b/.github/workflows/paladin-PR-build.yml
@@ -40,4 +40,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
-        run: ./gradlew -PcomposeLogs=true -PverboseTests=true --no-daemon --parallel build
+        run: ./gradlew -PcomposeLogs=true -PverboseTests=true -PjarVersion=v0.0.0 --no-daemon --parallel 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,22 @@
-plugins {
-    id 'java'
-}
-
 group = 'io.kaleido'
-version = '1.0-SNAPSHOT'
 
+// Define core projects to be assembled and built
+def coreProjects = [
+    ':core:go',
+    ':toolkit:go',
+    ':core:java'
+]
+
+// Define a list of source directories to copy from
+def buildLibs = [
+    'core/go/build/libs',
+    'core/java/build/libs',
+    'toolkit/go/build/libs'
+]
+
+def artifacts = [
+    'solidity/artifacts'
+]
 ext {
     helpers = [
         lockResource: { task, lockFile ->
@@ -32,4 +44,85 @@ ext {
             }
         }
     ]
+}
+
+subprojects {
+    apply plugin: 'base'
+
+    repositories {
+        mavenCentral()
+    }
+}
+
+// Task to copy all executables and binaries to the root-level build/libs directory
+task copyExecutables(type: Copy) {
+
+    // Define the root build directory
+    def libsDir = file("${buildDir}/libs")
+
+    doFirst {
+        libsDir.mkdirs()
+    }
+
+    // copy binaries from the defined directories
+    buildLibs.each { dir ->
+        from dir
+    }
+    into libsDir
+ 
+    // Ensure this task always runs
+    outputs.upToDateWhen { false }
+    
+    doLast {
+        println "Copied executables to ${libsDir}"
+    }
+}
+
+// Task to copy all executables and binaries to the root-level build/libs directory
+task copyArtifacts(type: Copy) {
+
+    // Define the root build directory
+    def artifactsDir = file("${buildDir}/artifacts")
+
+    doFirst {
+        artifactsDir.mkdirs()
+    }
+
+    // copy binaries from the defined directories
+    artifacts.each { dir ->
+        from dir
+    }
+    into artifactsDir
+
+    // Ensure this task always runs
+    outputs.upToDateWhen { false }
+    
+    doLast {
+        println "Copied artifacts to ${artifactsDir}"
+    }
+}
+
+// Root-level `assemble` task, only for core projects
+task assemble {
+    
+    // Ensure root assemble task depends on subprojects' assemble tasks
+    coreProjects.each { projectPath ->
+        dependsOn "${projectPath}:assemble"
+    }
+    
+    finalizedBy copyExecutables, copyArtifacts  // Ensure executables are copied after assembly
+    
+}
+
+// Root-level `build` task, only for core projects
+task build {
+
+}
+
+// Set default tasks
+defaultTasks 'build'
+
+// Clean task to clean all projects
+task clean {
+    delete "${buildDir}"
 }

--- a/core/go/build.gradle
+++ b/core/go/build.gradle
@@ -132,8 +132,8 @@ task copyContracts(dependsOn:[
 
 task protoc(type: ProtoCompile, dependsOn: [
         ":toolkit:go:protoc",
-        tasks.installTools,
-        tasks.copyTestContracts,
+        installTools,
+        copyTestContracts,
     ]) {
     protocPath "bin"
     protoPath projectDir
@@ -150,7 +150,7 @@ task protoc(type: ProtoCompile, dependsOn: [
     }
 }
 
-task goGet(type:Exec, dependsOn:[tasks.protoc,tasks.copyContracts,":toolkit:go:goGet"]) {
+task goGet(type:Exec, dependsOn:[protoc, copyContracts, ":toolkit:go:goGet"]) {
     workingDir '.'
 
     inputs.files('go.mod')
@@ -161,7 +161,7 @@ task goGet(type:Exec, dependsOn:[tasks.protoc,tasks.copyContracts,":toolkit:go:g
     args 'get'
 }
 
-task makeMocks(type: Mockery, dependsOn: [tasks.installTools, tasks.protoc, tasks.goGet]) {
+task makeMocks(type: Mockery, dependsOn: [installTools, protoc, goGet]) {
     mockery 'bin/mockery'
     args '--case', 'underscore'
     mock {
@@ -244,8 +244,11 @@ task makeMocks(type: Mockery, dependsOn: [tasks.installTools, tasks.protoc, task
     }
 }
 
-task clean(type: Delete, dependsOn: ':testinfra:stopTestInfra') {
-    delete 'libcore.dylib', 'libcore.so', 'libcore.dll', 'libcore.h'
+tasks.named('clean') {
+    dependsOn ':testinfra:stopTestInfra'
+
+    delete "${buildDir}/libs"
+
     delete fileTree("bin") {
         exclude "README.md", ".gitignore"
     }
@@ -258,7 +261,7 @@ task clean(type: Delete, dependsOn: ':testinfra:stopTestInfra') {
     delete 'componenttest/abis'
 }
 
-task lint(type: Exec, dependsOn:[tasks.protoc,tasks.makeMocks,tasks.copyContracts]) {
+task lint(type: Exec, dependsOn:[protoc, makeMocks, copyContracts]) {
     workingDir '.'
 
     helpers.lockResource(it, "lint.lock")
@@ -272,7 +275,7 @@ task lint(type: Exec, dependsOn:[tasks.protoc,tasks.makeMocks,tasks.copyContract
     args '--timeout', '5m'
 }
 
-task buildSharedLibrary(type:Exec, dependsOn:[tasks.goGet, tasks.makeMocks]) {
+task buildSharedLibrary(type:Exec, dependsOn:[goGet, makeMocks]) {
     workingDir '.'
 
     def libName
@@ -284,19 +287,24 @@ task buildSharedLibrary(type:Exec, dependsOn:[tasks.goGet, tasks.makeMocks]) {
         libName = "libcore.so"
     }
 
+     // Updated paths for outputs
+    def outputDir = "${buildDir}/libs"
+    def outputLib = "${outputDir}/${libName}"
+    def outputHeader = "${outputDir}/libcore.h"
+
     inputs.files(goFiles)
-    outputs.files(libName, 'libcore.h')
+    outputs.files(outputLib, outputHeader)
 
     environment("CGO_ENABLED", "1")
 
     executable 'go'
     args 'build'
-    args '-o', libName
+    args '-o', outputLib
     args '-buildmode=c-shared'
     args 'core.go'
 }
 
-task buildTestbed(type:Exec, dependsOn: [tasks.goGet, tasks.makeMocks, tasks.copyContracts]) {
+task buildTestbed(type:Exec, dependsOn: [goGet, makeMocks, copyContracts]) {
     workingDir '.'
 
     inputs.files(goFiles)
@@ -339,7 +347,7 @@ task buildTestPluginsSharedLibraryGRPCTransport(type:Exec) {
 }
 
 task buildTestPluginsSharedLibraries {
-    dependsOn tasks.buildTestPluginsSharedLibraryGRPCTransport
+    dependsOn buildTestPluginsSharedLibraryGRPCTransport
 }
 
 abstract class UnitTests extends Exec {
@@ -386,7 +394,7 @@ abstract class ComponentTest extends Exec {
     }
 }
 
-task setupCoverage(dependsOn: [tasks.protoc, tasks.copyContracts, tasks.makeMocks]) {
+task setupCoverage(dependsOn: [protoc, copyContracts, makeMocks]) {
     inputs.files(goFiles)
     outputs.dir('coverage')
     doLast {
@@ -416,19 +424,19 @@ task unitTestPostgres(type: UnitTests, dependsOn: [
 
 task componentTestSQLite(type: ComponentTest, dependsOn: [
         ':testinfra:startTestInfra',
-        tasks.setupCoverage,
-        tasks.goGet,
-        tasks.copyContracts,
+        setupCoverage,
+        goGet,
+        copyContracts,
     ]) {
     mustRunAfter 'unitTestPostgres' // these tests cannot run concurrently
 }
 
 task buildCoverageTxt(type: Exec, dependsOn: [
-        tasks.protoc,
-        tasks.unitTestSQLite,
-        tasks.unitTestPostgres,
-        tasks.componentTestSQLite,
-        // tasks.componentTestPostgres
+        protoc,
+        unitTestSQLite,
+        unitTestPostgres,
+        componentTestSQLite,
+        // componentTestPostgres
     ]) {
     inputs.files(fileTree(project.mkdir('coverage')) {
         include "covcounters.*"
@@ -470,14 +478,21 @@ task testcov(type: Exec, dependsOn: [test, aggregateCoverage]) {
     args '-html=coverage/coverage.txt'
 }
 
-task build {
-    dependsOn tasks.lint
-    dependsOn tasks.test
-    dependsOn tasks.aggregateCoverage
-    dependsOn tasks.checkCoverage
+tasks.named('build') {
+    dependsOn lint
+    dependsOn test
+    dependsOn aggregateCoverage
+    dependsOn checkCoverage
 }
 
 dependencies {
     libcore files(buildSharedLibrary)
     goSource files(goFiles, protoc, makeMocks, copyContracts)
+}
+
+assemble {
+    dependsOn buildSharedLibrary
+    doLast {
+        println "Assembling Go binaries without running tests"
+    }
 }

--- a/core/java/build.gradle
+++ b/core/java/build.gradle
@@ -6,22 +6,79 @@ plugins {
     id 'com.google.protobuf' version '0.9.4'
 }
 
-mainClassName = 'io.kaleido.Main'
 group = 'io.kaleido'
-version = '1.0-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+// Set the main class for the JAR
+jar {
+    dependsOn 'classes'  // Ensure the classes are compiled before creating the JAR
+
+    manifest {
+        attributes(
+            'Main-Class': 'io.kaleido.paladin.Main'
+        )
+    }
+
+    if (project.hasProperty('jarVersion')) {
+        archiveVersion = project.jarVersion
+    } else {
+        archiveVersion = ''
+    }
+
+    archiveBaseName = 'paladin'  // Base name of the JAR, the version will be added to this
+
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+
+    from sourceSets.main.output
+
+    // Exclude signature files from dependencies
+    exclude 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA'
+    
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
 
 task wrapper(type: Wrapper){}
 
+assemble.dependsOn jar
+
 application {
+    mainClassName = 'io.kaleido.paladin.Main'  // Your main class
     applicationDefaultJvmArgs = ["-Djna.library.path=" +
         file("${rootDir}/core/go").absolutePath + ":" + file("${rootDir}/toolkit/go").absolutePath ]
+} 
+
+// run -PconfigFile=config.paladin.yaml -Pmode=node to override the default values
+tasks.named('run') {
+    // Check if 'configFile' and 'mode' properties are passed via the command line
+    def configFile = project.hasProperty('configFile') ? project.getProperty('configFile') : 'config.paladin.yaml'
+    def mode = project.hasProperty('mode') ? project.getProperty('mode') : 'node'
+    
+    // Pass these arguments to the Java application
+    args = [configFile, mode]
+    
+    doFirst {
+        println "Running with config file: $configFile and mode: $mode"
+    }
 }
+
 
 repositories {
     mavenCentral()
 }
 
 test {
+    // Skip tests if the task graph includes the 'assemble' task
+    // onlyIf {
+    //     !gradle.taskGraph.hasTask(':assemble')
+    // }
+    
     dependsOn ':testinfra:startTestInfra'
     testLogging {
         showStandardStreams = true
@@ -122,6 +179,7 @@ protobuf {
 sourceSets {
     main {
         java {
+            srcDirs 'src/main/java'
             srcDirs 'build/generated/source/proto/main/grpc'
             srcDirs 'build/generated/source/proto/main/java'
         }

--- a/domains/integration-test/build.gradle
+++ b/domains/integration-test/build.gradle
@@ -85,11 +85,11 @@ task test(type: Exec) {
     helpers.dumpLogsOnFailure(it, ':testinfra:startTestInfra')
 }
 
-task build {
+tasks.named('build') {
     dependsOn test
 }
 
-task clean(type: Delete) {
+tasks.named('clean') {
     delete 'coverage'
     delete 'abis'
 }

--- a/domains/noto/build.gradle
+++ b/domains/noto/build.gradle
@@ -87,11 +87,11 @@ task test(type: Exec) {
     helpers.dumpLogsOnFailure(it, ':testinfra:startTestInfra')
 }
 
-task build {
+tasks.named('build') {
     dependsOn test
 }
 
-task clean(type: Delete) {
+tasks.named('clean') {
     delete 'coverage'
     delete 'internal/noto/abis'
 }

--- a/domains/pente/build.gradle
+++ b/domains/pente/build.gradle
@@ -3,7 +3,13 @@ plugins {
 }
 
 group = 'io.kaleido'
-version = '1.0-SNAPSHOT'
+version = ''
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
 
 configurations {
     // Resolvable configurations
@@ -76,4 +82,13 @@ dependencies {
     implementation 'io.tmio:tuweni-units:2.4.2'
 
     implementation project(path: ":core:java")
+}
+
+// Disable compileJava when assemble is called
+gradle.taskGraph.whenReady { taskGraph ->
+    if (taskGraph.hasTask(assemble)) {
+        tasks.named('compileJava').configure {
+            enabled = false
+        }
+    }
 }

--- a/domains/zeto/build.gradle
+++ b/domains/zeto/build.gradle
@@ -171,12 +171,12 @@ task test(type: Exec) {
     helpers.dumpLogsOnFailure(it, ':testinfra:startTestInfra')
 }
 
-task build {
+tasks.named('build') {
     dependsOn test
     dependsOn testE2E
 }
 
-task clean(type: Delete) {
+tasks.named('clean') {
     delete 'coverage'
     delete 'internal/zeto/abis'
     delete zkpOut

--- a/registries/static/build.gradle
+++ b/registries/static/build.gradle
@@ -84,11 +84,11 @@ task test(type: Exec) {
     dependsOn ':testinfra:startTestInfra'
 }
 
-task build {
+tasks.named('build') {
     dependsOn lint
     dependsOn test
 }
 
-task clean(type: Delete) {
+tasks.named('clean') {
     delete 'coverage'
 }

--- a/solidity/build.gradle
+++ b/solidity/build.gradle
@@ -66,12 +66,21 @@ task test(type: Exec, dependsOn: compile) {
     outputs.file(testResults)
 }
 
-task build(dependsOn: test) {}
+// This task builds everything, including running the tests
+tasks.named('build') {
+    dependsOn test
+}
 
-task clean(type: Delete) {
+// Define the clean task
+tasks.named('clean') {
     delete "node_modules"
     delete buildOutput, "cache", "typechain-types"
     delete testResults
+}
+
+// Assemble task that only compiles and generates artifacts, without running tests
+tasks.named('assemble') {
+    dependsOn compile  // Only runs the compile task
 }
 
 artifacts {

--- a/testinfra/build.gradle
+++ b/testinfra/build.gradle
@@ -21,7 +21,7 @@ task besuBootstrapTool(type: Exec) {
     args "."
 }
 
-task startTestInfra(type: DockerCompose, dependsOn: tasks.besuBootstrapTool) {
+task startTestInfra(type: DockerCompose, dependsOn: besuBootstrapTool) {
     composeFile 'docker-compose-test.yml'
     projectName 'paladin-testinfra'
     args 'up', '-d', '--wait', '--wait-timeout', 60
@@ -41,6 +41,7 @@ task removeBesuBootstrapTool(type: Exec, dependsOn: stopTestInfra) {
     ignoreExitValue true
 }
 
-task clean(type: Delete, dependsOn: [tasks.removeBesuBootstrapTool, tasks.stopTestInfra]) {
+tasks.named('clean') {
+    dependsOn removeBesuBootstrapTool
+    dependsOn stopTestInfra
 }
-

--- a/toolkit/go/build.gradle
+++ b/toolkit/go/build.gradle
@@ -98,8 +98,11 @@ task protoc(type: ProtoCompile, dependsOn: [installTools]) {
     }
 }
 
-task clean(type: Delete, dependsOn: ':testinfra:stopTestInfra') {
-    delete 'libstarter.dylib', 'libstarter.so', 'libstarter.dll', 'libstarter.h'
+tasks.named('clean') {
+    dependsOn ':testinfra:stopTestInfra'
+
+    delete "${buildDir}/libs"
+
     delete fileTree("bin") {
         exclude "README.md", ".gitignore"
     }
@@ -110,7 +113,7 @@ task clean(type: Delete, dependsOn: ':testinfra:stopTestInfra') {
     delete 'componenttest/abis'
 }
 
-task goGet(type:Exec, dependsOn:tasks.protoc) {
+task goGet(type:Exec, dependsOn: protoc) {
     workingDir '.'
 
     inputs.files('go.mod')
@@ -165,9 +168,9 @@ task test(type: Exec, dependsOn: [tasks.goGet,tasks.makeMocks]) {
 }
 
 task buildCoverageTxt(type: Exec, dependsOn: [
-        tasks.protoc,
-        tasks.lint,
-        tasks.test,
+        protoc,
+        lint,
+        test,
     ]) {
     inputs.files(fileTree(project.mkdir('coverage')) {
         include "covcounters.*"
@@ -181,7 +184,7 @@ task buildCoverageTxt(type: Exec, dependsOn: [
 
 }
 
-task aggregateCoverage(type: Copy, dependsOn: tasks.buildCoverageTxt) {
+task aggregateCoverage(type: Copy, dependsOn: buildCoverageTxt) {
     from 'coverage/coverage_unfiltered.txt'
     into 'coverage'
     outputs.files('coverage/coverage.txt')
@@ -191,16 +194,16 @@ task aggregateCoverage(type: Copy, dependsOn: tasks.buildCoverageTxt) {
     filter(LineContains, negate: true, contains: getProject().ext.coverageExcludedPackages, matchAny: true) 
 }
 
-task checkCoverage(type: GoCheckCoverage, dependsOn: [tasks.aggregateCoverage]) {
+task checkCoverage(type: GoCheckCoverage, dependsOn: [aggregateCoverage]) {
     coverageFile('coverage/coverage.txt')
     target = targetCoverage
     maxGap = maxCoverageBarGap
 }
 
-task buildStarterLibrary(type:Exec, dependsOn:[tasks.goGet]) {
+task buildStarterLibrary(type:Exec, dependsOn:[goGet]) {
     workingDir '.'
-
-    def libName;
+ 
+    def libName
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         libName = "libstarter.dll"
     } else if (Os.isFamily(Os.FAMILY_MAC)) {
@@ -209,26 +212,38 @@ task buildStarterLibrary(type:Exec, dependsOn:[tasks.goGet]) {
         libName = "libstarter.so"
     }
 
+    // Updated paths for outputs
+    def outputDir = "${buildDir}/libs"
+    def outputLib = "${outputDir}/${libName}"
+    def outputHeader = "${outputDir}/libstarter.h"
+
     inputs.files(goFiles)
-    outputs.files(libName, 'libstarter.h')
+    outputs.files(outputLib, outputHeader)
 
     environment("CGO_ENABLED", "1")
 
     executable 'go'
     args 'build'
-    args '-o', libName
+    args '-o', outputLib
     args '-buildmode=c-shared'
     args './domainstarter'
 }
 
-task build {
-    dependsOn tasks.lint
-    dependsOn tasks.test
-    dependsOn tasks.checkCoverage
-    dependsOn tasks.buildStarterLibrary
+tasks.named('build') {
+    dependsOn lint
+    dependsOn test
+    dependsOn checkCoverage
+    dependsOn buildStarterLibrary
 }
 
 dependencies {
     libstarter files(buildStarterLibrary)
     goSource files(goFiles, protoc)
+}
+
+assemble {
+    dependsOn buildStarterLibrary
+    doLast {
+        println "Assembling Go binaries without running tests"
+    }
 }

--- a/transports/grpc/build.gradle
+++ b/transports/grpc/build.gradle
@@ -53,7 +53,7 @@ task installTools(type: Exec) {
     args 'github.com/vektra/mockery/v2'
 }
 
-task protoc(type: ProtoCompile, dependsOn: [tasks.installTools]) {
+task protoc(type: ProtoCompile, dependsOn: [installTools]) {
     protocPath "bin"
     protoPath projectDir
     protoFiles fileTree("pkg/proto") {
@@ -69,7 +69,7 @@ task protoc(type: ProtoCompile, dependsOn: [tasks.installTools]) {
     }
 }
 
-task lint(type: Exec, dependsOn:[installTools, tasks.protoc]) {
+task lint(type: Exec, dependsOn:[installTools, protoc]) {
     workingDir '.'
 
     helpers.lockResource(it, "lint.lock")
@@ -84,7 +84,7 @@ task lint(type: Exec, dependsOn:[installTools, tasks.protoc]) {
     args '--timeout', '5m'
 }
 
-task test(type: Exec, dependsOn:[tasks.protoc]) {
+task test(type: Exec, dependsOn:[protoc]) {
     inputs.files(configurations.toolkitGo)
     inputs.files(goFiles)
     outputs.dir('coverage')
@@ -104,11 +104,11 @@ task test(type: Exec, dependsOn:[tasks.protoc]) {
     dependsOn ':testinfra:startTestInfra'
 }
 
-task build {
+tasks.named('build') {
     dependsOn lint
     dependsOn test
 }
 
-task clean(type: Delete) {
+tasks.named('clean') {
     delete 'coverage'
 }


### PR DESCRIPTION
### Preparing Paladin for Docker Image Build

This PR introduces changes to streamline the process of building the Paladin project into a Docker image. The main change is ensuring all libraries (both Go and Java) are compiled into the same directory, making it easier to package everything into the Docker image.

### Changes:
- **Unified Build Directory:** The shared libraries and the Java JAR are now built into a single directory located at `build/libs/`. Here’s an example of the new structure:

    ```
    % ls build/libs/
    libcore.dylib
    libcore.h
    libstarter.dylib
    libstarter.h
    paladin<version>.jar
    ```

- **Next Steps:** The next step is to add a Dockerfile to the CI pipeline. The build process in CI will consist of the following steps:
  1. **Run `./gradlew`:** This step will run unit tests, linter checks, and compile both Go and Java code.
  2. **Build the Docker image:** The compiled artifacts (JAR and Go shared libraries) will be copied from the `build/libs/` directory into the Docker image.

These changes prepare the project for smoother Docker image creation and deployment as part of the CI/CD pipeline.