### PR TITLE
Core go component test

### DIFF
--- a/core/go/build.gradle
+++ b/core/go/build.gradle
@@ -96,6 +96,19 @@ task copyTestContracts(type: Copy) {
     includeEmptyDirs = false
 }
 
+task copyTestDomainContracts(type: Copy) {
+    inputs.files(configurations.compiledContracts)
+    from fileTree(configurations.compiledContracts.asPath) {
+        include 'contracts/domains/testbed_sim/SIMDomain.sol/SIMDomain.json'
+        include 'contracts/domains/testbed_sim/SIMToken.sol/SIMToken.json'
+    }
+    into 'componenttest/domains/abis'
+
+    // Flatten all paths into the destination folder
+    eachFile { path = name }
+    includeEmptyDirs = false
+}
+
 task copyTestbedContracts(type: Copy) {
     inputs.files(configurations.compiledContracts)
     from fileTree(configurations.compiledContracts.asPath) {
@@ -125,6 +138,7 @@ task copyDomainManagerContracts(type: Copy) {
 
 task copyContracts(dependsOn:[
     copyTestContracts,
+    copyTestDomainContracts,
     copyTestbedContracts,
     copyDomainManagerContracts,
 ])

--- a/core/go/componenttest/component_test.go
+++ b/core/go/componenttest/component_test.go
@@ -23,14 +23,33 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-signer/pkg/abi"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
+	"github.com/kaleido-io/paladin/core/componenttest/domains"
 	"github.com/kaleido-io/paladin/core/internal/componentmgr"
+	"github.com/kaleido-io/paladin/core/internal/components"
+	"github.com/kaleido-io/paladin/core/internal/domainmgr"
+	"github.com/kaleido-io/paladin/core/internal/msgs"
+	"github.com/kaleido-io/paladin/core/internal/plugins"
 	"github.com/kaleido-io/paladin/core/pkg/blockindexer"
 	"github.com/kaleido-io/paladin/core/pkg/ethclient"
 	"github.com/kaleido-io/paladin/core/pkg/persistence"
+	"github.com/kaleido-io/paladin/toolkit/pkg/confutil"
+	"github.com/kaleido-io/paladin/toolkit/pkg/log"
+	"github.com/kaleido-io/paladin/toolkit/pkg/plugintk"
+	"github.com/kaleido-io/paladin/toolkit/pkg/prototk"
+	"github.com/kaleido-io/paladin/toolkit/pkg/ptxapi"
+	"github.com/kaleido-io/paladin/toolkit/pkg/query"
+	"github.com/kaleido-io/paladin/toolkit/pkg/rpcclient"
 	"github.com/kaleido-io/paladin/toolkit/pkg/tktypes"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -153,4 +172,371 @@ signer:
 	event2 := <-eventStreamEvents
 	assert.JSONEq(t, `{"x":"99887766"}`, string(event2.Data))
 
+}
+
+func TestCoreGoComponent(t *testing.T) {
+	// Coarse grained black box test of the core component manager
+	// no mocking although it does use a simple domain implementation that exists solely for testing
+	// and is loaded directly through go function calls via the unit test plugin loader
+	// (as opposed to compiling as a sepraate shared library)
+	// Even though the domain is a fake, the test does deploy a real contract to the blockchain and the domain
+	// manager does communicate with it via the grpc inteface.
+	// The bootstrap code that is the entry point to the java side is not tested here, we bootstrap the component manager by hand
+
+	ctx := context.Background()
+	instance, cm := newInstanceForComponentTesting(t, ctx)
+
+	// send JSON RPC message to check the status of the server
+	rpcClient, err := rpcclient.NewHTTPClient(ctx, &rpcclient.HTTPConfig{URL: "http://localhost:" + strconv.Itoa(*instance.conf.RPCServer.HTTP.Port)})
+	require.NoError(t, err)
+
+	// Check there are no transactions before we start
+	var txns []*ptxapi.TransactionFull
+	err = rpcClient.CallRPC(ctx, &txns, "ptx_queryTransactions", query.NewQueryBuilder().Limit(1).Query(), true)
+	require.NoError(t, err)
+	assert.Len(t, txns, 0)
+
+	//scaffolding for deploy here - in lieu of implementing HandleDeployTx in privatetxmgr
+	domainName := "domain1"
+
+	deployTx := &components.PrivateContractDeploy{
+		ID:     uuid.New(),
+		Domain: domainName,
+		Inputs: tktypes.RawJSON(`{
+		"notary": "domain1.contract1.notary",
+		"name": "FakeToken1",
+		"symbol": "FT1"
+	}`),
+	}
+
+	_, contractAddress, err := deployDomainInstance(ctx, cm, deployTx)
+	require.NoError(t, err)
+	/* to be replace with something like...
+	err = rpcClient.CallRPC(ctx, &tx1ID, "ptx_sendTransaction", &ptxapi.TransactionInput{
+		ABI:       ...,
+		Bytecode:  ...,
+		Transaction: ptxapi.Transaction{
+			IdempotencyKey: "deploy1",
+			Type:           ptxapi.TransactionTypePrivate.Enum(),
+			Data:           ...,
+		},
+	})
+	*/
+
+	// Start a private transaction
+	var tx1ID uuid.UUID
+	err = rpcClient.CallRPC(ctx, &tx1ID, "ptx_sendTransaction", &ptxapi.TransactionInput{
+		ABI: *domains.FakeCoinTransferABI(),
+		Transaction: ptxapi.Transaction{
+			To:             contractAddress,
+			Domain:         "domain1", //TODO comments say that this is inferred from `to` for invoke
+			IdempotencyKey: "tx1",
+			Type:           ptxapi.TransactionTypePrivate.Enum(),
+			From:           "wallets.org1.aaaaaa",
+			Data: tktypes.RawJSON(`{
+				"from": "",
+				"to": "wallets.org1.aaaaaa",
+				"amount": "123000000000000000000"
+			}`),
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.UUID{}, tx1ID)
+
+	err = rpcClient.CallRPC(ctx, &txns, "ptx_queryTransactions", query.NewQueryBuilder().Limit(1).Query(), true)
+	require.NoError(t, err)
+	assert.Len(t, txns, 1)
+
+	deadline, ok := t.Deadline()
+	if !ok {
+		//enough time for a debug session
+		deadline = time.Now().Add(30 * time.Minute)
+	}
+	deadlineRemaining := time.Until(deadline) - (2 * time.Second)
+	timeoutChan := time.NewTimer(deadlineRemaining).C
+
+	// Create a 2 second polling
+	timer := time.NewTicker(1 * time.Second)
+	defer timer.Stop()
+	txFull := ptxapi.TransactionFull{}
+	err = rpcClient.CallRPC(ctx, &txFull, "ptx_getTransaction", tx1ID, true)
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, txFull.Created)
+
+out:
+	for {
+		select {
+		case <-timer.C:
+			err = rpcClient.CallRPC(ctx, &txFull, "ptx_getTransaction", tx1ID, true)
+			require.NoError(t, err)
+			if txFull.Receipt != nil {
+				break out
+			}
+			t.Log("No transaction receipt received")
+		case <-timeoutChan:
+			break out
+		}
+
+	}
+	require.NotNil(t, txFull.Receipt)
+	require.True(t, txFull.Receipt.Success)
+
+}
+
+func deployDomainInstance(ctx context.Context, cm componentmgr.ComponentManager, tx *components.PrivateContractDeploy) (string, *tktypes.EthAddress, error) {
+	log.L(ctx).Debugf("Handling new private contract deploy transaction: %v", tx)
+	if tx.Domain == "" {
+		return "", nil, i18n.NewError(ctx, msgs.MsgDomainNotProvided)
+	}
+
+	domain, err := cm.DomainManager().GetDomainByName(ctx, tx.Domain)
+	if err != nil {
+		return "", nil, i18n.WrapError(ctx, err, msgs.MsgDomainNotFound, tx.Domain)
+	}
+
+	err = domain.InitDeploy(ctx, tx)
+	if err != nil {
+		return "", nil, i18n.WrapError(ctx, err, msgs.MsgDeployInitFailed)
+	}
+
+	keyMgr := cm.KeyManager()
+	tx.Verifiers = make([]*prototk.ResolvedVerifier, len(tx.RequiredVerifiers))
+	for i, v := range tx.RequiredVerifiers {
+		_, verifier, err := keyMgr.ResolveKey(ctx, v.Lookup, v.Algorithm)
+		if err != nil {
+			return "", nil, i18n.WrapError(ctx, err, msgs.MsgKeyResolutionFailed, v.Lookup, v.Algorithm)
+		}
+		tx.Verifiers[i] = &prototk.ResolvedVerifier{
+			Lookup:    v.Lookup,
+			Algorithm: v.Algorithm,
+			Verifier:  verifier,
+		}
+	}
+
+	err = domain.PrepareDeploy(ctx, tx)
+	if err != nil {
+		return "", nil, i18n.WrapError(ctx, err, msgs.MsgDeployPrepareFailed)
+	}
+
+	if tx.DeployTransaction != nil && tx.InvokeTransaction == nil {
+		err = execBaseLedgerDeployTransaction(ctx, cm, tx.Signer, tx.DeployTransaction)
+	} else if tx.InvokeTransaction != nil && tx.DeployTransaction == nil {
+		err = execBaseLedgerTransaction(ctx, cm, tx.Signer, tx.InvokeTransaction)
+	} else {
+		return "", nil, i18n.NewError(ctx, msgs.MsgDeployPrepareIncomplete)
+	}
+	if err != nil {
+		return "", nil, i18n.WrapError(ctx, err, msgs.MsgBaseLedgerTransactionFailed)
+	}
+
+	psc, err := cm.DomainManager().WaitForDeploy(ctx, tx.ID)
+	if err != nil {
+		return "", nil, i18n.WrapError(ctx, err, msgs.MsgBaseLedgerTransactionFailed)
+	}
+	addr := psc.Address()
+
+	return tx.ID.String(), &addr, nil
+
+}
+
+func execBaseLedgerDeployTransaction(ctx context.Context, cm componentmgr.ComponentManager, signer string, txInstruction *components.EthDeployTransaction) error {
+
+	var abiFunc ethclient.ABIFunctionClient
+	ec := cm.EthClientFactory().HTTPClient()
+	abiFunc, err := ec.ABIConstructor(ctx, txInstruction.ConstructorABI, tktypes.HexBytes(txInstruction.Bytecode))
+	if err != nil {
+		return err
+	}
+
+	// Send the transaction
+	txHash, err := abiFunc.R(ctx).
+		Signer(signer).
+		Input(txInstruction.Inputs).
+		SignAndSend()
+	if err == nil {
+		_, err = cm.BlockIndexer().WaitForTransactionAnyResult(ctx, *txHash)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to send base deploy ledger transaction: %s", err)
+	}
+	return nil
+}
+
+func execBaseLedgerTransaction(ctx context.Context, cm componentmgr.ComponentManager, signer string, txInstruction *components.EthTransaction) error {
+
+	var abiFunc ethclient.ABIFunctionClient
+	ec := cm.EthClientFactory().HTTPClient()
+	abiFunc, err := ec.ABIFunction(ctx, txInstruction.FunctionABI)
+	if err != nil {
+		return err
+	}
+
+	// Send the transaction
+	addr := ethtypes.Address0xHex(txInstruction.To)
+	txHash, err := abiFunc.R(ctx).
+		Signer(signer).
+		To(&addr).
+		Input(txInstruction.Inputs).
+		SignAndSend()
+	if err == nil {
+		_, err = cm.BlockIndexer().WaitForTransactionAnyResult(ctx, *txHash)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to send base ledger transaction: %s", err)
+	}
+	return nil
+}
+
+type componentTestInstance struct {
+	grpcTarget string
+	engineName string
+	id         uuid.UUID
+	conf       *componentmgr.Config
+	ctx        context.Context
+	cancelCtx  context.CancelFunc
+}
+
+func newInstanceForComponentTesting(t *testing.T, ctx context.Context) (*componentTestInstance, componentmgr.ComponentManager) {
+	f, err := os.CreateTemp("", "component-test.*.sock")
+	require.NoError(t, err)
+
+	grpcTarget := f.Name()
+
+	err = f.Close()
+	require.NoError(t, err)
+
+	err = os.Remove(grpcTarget)
+	require.NoError(t, err)
+
+	//Little bit of a chicken and egg situation here.
+	// We need an engine so that we can deploy the base ledger contract for the domain
+	// and then we need the address of that contract for the config file we use to iniitialize the engine
+	//Actually in the first instance, we only need a bare bones engine that is capable of deploying the base ledger contracts
+	// could make do with assembling some core components like key manager, eth client factory, block indexer, persistence and any other dependencies they pull in
+	// but is easier to just create a throwaway component manager with no domains
+
+	i := &componentTestInstance{
+		grpcTarget: grpcTarget,
+		id:         uuid.New(),
+		conf:       testConfig(t),
+		engineName: "",
+	}
+	i.ctx, i.cancelCtx = context.WithCancel(log.WithLogField(context.Background(), "pid", strconv.Itoa(os.Getpid())))
+
+	tmpConf := testConfig(t)
+	cmTmp := componentmgr.NewComponentManager(i.ctx, i.grpcTarget, i.id, tmpConf, &componentTestEngine{})
+	err = cmTmp.Init()
+	require.NoError(t, err)
+	err = cmTmp.StartComponents()
+	require.NoError(t, err)
+	domainRegistryAddress := domains.DeploySmartContract(t, cmTmp.BlockIndexer(), cmTmp.EthClientFactory())
+
+	cmTmp.Stop()
+
+	i.conf.DomainManagerConfig.Domains = make(map[string]*domainmgr.DomainConfig, 1)
+	i.conf.DomainManagerConfig.Domains["domain1"] = &domainmgr.DomainConfig{
+		Plugin: components.PluginConfig{
+			Type:    components.LibraryTypeCShared.Enum(),
+			Library: "loaded/via/unit/test/loader",
+		},
+		Config:          map[string]any{"some": "config"},
+		RegistryAddress: domainRegistryAddress.String(),
+	}
+
+	var pl plugins.UnitTestPluginLoader
+
+	cm := componentmgr.NewComponentManager(i.ctx, i.grpcTarget, i.id, i.conf, &componentTestEngine{})
+	// Start it up
+	err = cm.Init()
+	require.NoError(t, err)
+
+	err = cm.StartComponents()
+	require.NoError(t, err)
+
+	err = cm.StartManagers()
+	require.NoError(t, err)
+
+	loaderMap := map[string]plugintk.Plugin{
+		"domain1": domains.FakeCoinDomain(t, i.ctx),
+	}
+	pc := cm.PluginManager()
+	pl, err = plugins.NewUnitTestPluginLoader(pc.GRPCTargetURL(), pc.LoaderID().String(), loaderMap)
+	require.NoError(t, err)
+	go pl.Run()
+
+	err = cm.CompleteStart()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		pl.Stop()
+		cm.Stop()
+	})
+
+	return i, cm
+
+}
+
+// TODO should not need an engine at all. It is only in the component manager interface to enable the testbed to integrate with domain manager etc
+// need to make this optional in the component manager interface or re-write the testbed to integrate with components
+// in a different way
+type componentTestEngine struct {
+}
+
+// EngineName implements components.Engine.
+func (c *componentTestEngine) EngineName() string {
+	return "component-test-engine"
+}
+
+// Init implements components.Engine.
+func (c *componentTestEngine) Init(components.PreInitComponentsAndManagers) (*components.ManagerInitResult, error) {
+	return &components.ManagerInitResult{}, nil
+}
+
+// ReceiveTransportMessage implements components.Engine.
+func (c *componentTestEngine) ReceiveTransportMessage(context.Context, *components.TransportMessage) {
+	panic("unimplemented")
+}
+
+// Start implements components.Engine.
+func (c *componentTestEngine) Start() error {
+	return nil
+}
+
+// Stop implements components.Engine.
+func (c *componentTestEngine) Stop() {
+
+}
+
+func testConfig(t *testing.T) *componentmgr.Config {
+	ctx := context.Background()
+	log.SetLevel("debug")
+
+	var conf *componentmgr.Config
+	err := componentmgr.ReadAndParseYAMLFile(ctx, "../test/config/sqlite.memory.config.yaml", &conf)
+	assert.NoError(t, err)
+
+	// For running in this unit test the dirs are different to the sample config
+	conf.DB.SQLite.MigrationsDir = "../db/migrations/sqlite"
+	conf.DB.Postgres.MigrationsDir = "../db/migrations/postgres"
+
+	port, err := getFreePort()
+	require.NoError(t, err, "Error finding a free port")
+	conf.RPCServer.HTTP.Port = &port
+	conf.RPCServer.HTTP.Address = confutil.P("127.0.0.1")
+
+	return conf
+
+}
+
+// getFreePort finds an available TCP port and returns it.
+func getFreePort() (int, error) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	return port, nil
 }

--- a/core/go/componenttest/domains/fake_coin_domain.go
+++ b/core/go/componenttest/domains/fake_coin_domain.go
@@ -1,0 +1,653 @@
+/*
+ * Copyright © 2024 Kaleido, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package domains
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/hyperledger/firefly-signer/pkg/abi"
+	"github.com/hyperledger/firefly-signer/pkg/eip712"
+	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
+	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
+	"github.com/kaleido-io/paladin/core/pkg/blockindexer"
+	"github.com/kaleido-io/paladin/core/pkg/ethclient"
+	"github.com/kaleido-io/paladin/toolkit/pkg/algorithms"
+	"github.com/kaleido-io/paladin/toolkit/pkg/confutil"
+	"github.com/kaleido-io/paladin/toolkit/pkg/plugintk"
+	"github.com/kaleido-io/paladin/toolkit/pkg/prototk"
+	"github.com/kaleido-io/paladin/toolkit/pkg/query"
+	"github.com/kaleido-io/paladin/toolkit/pkg/tktypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed abis/SIMDomain.json
+var simDomainBuild []byte // comes from Hardhat build
+
+//go:embed abis/SIMToken.json
+var simTokenBuild []byte // comes from Hardhat build
+
+func toJSONString(t *testing.T, v interface{}) string {
+	b, err := json.Marshal(v)
+	assert.NoError(t, err)
+	return string(b)
+}
+
+type UTXOTransfer_Event struct {
+	TX        tktypes.Bytes32   `json:"txId"`
+	Inputs    []tktypes.Bytes32 `json:"inputs"`
+	Outputs   []tktypes.Bytes32 `json:"outputs"`
+	Signature tktypes.HexBytes  `json:"signature"`
+}
+
+func parseStatesFromEvent(txID tktypes.Bytes32, states []tktypes.Bytes32) []*prototk.StateUpdate {
+	refs := make([]*prototk.StateUpdate, len(states))
+	for i, state := range states {
+		refs[i] = &prototk.StateUpdate{
+			Id:            state.String(),
+			TransactionId: txID.String(),
+		}
+	}
+	return refs
+}
+
+func mustParseBuildABI(buildJSON []byte) abi.ABI {
+	var buildParsed map[string]tktypes.RawJSON
+	var buildABI abi.ABI
+	err := json.Unmarshal(buildJSON, &buildParsed)
+	if err == nil {
+		err = json.Unmarshal(buildParsed["abi"], &buildABI)
+	}
+	if err != nil {
+		panic(err)
+	}
+	return buildABI
+}
+
+func mustParseBuildBytecode(buildJSON []byte) tktypes.HexBytes {
+	var buildParsed map[string]tktypes.RawJSON
+	var byteCode tktypes.HexBytes
+	err := json.Unmarshal(buildJSON, &buildParsed)
+	if err == nil {
+		err = json.Unmarshal(buildParsed["bytecode"], &byteCode)
+	}
+	if err != nil {
+		panic(err)
+	}
+	return byteCode
+}
+
+func DeploySmartContract(t *testing.T, bi blockindexer.BlockIndexer, ecf ethclient.EthClientFactory) *tktypes.EthAddress {
+	ctx := context.Background()
+
+	simDomainABI := mustParseBuildABI(simDomainBuild)
+
+	// In this test we deploy the factory in-line
+	ec, err := ecf.HTTPClient().ABI(ctx, simDomainABI)
+	require.NoError(t, err)
+
+	cc, err := ec.Constructor(ctx, mustParseBuildBytecode(simDomainBuild))
+	require.NoError(t, err)
+
+	deployTXHash, err := cc.R(ctx).
+		Signer("domain1_admin").
+		Input(`{}`).
+		SignAndSend()
+	require.NoError(t, err)
+
+	deployTx, err := bi.WaitForTransactionSuccess(ctx, *deployTXHash, simDomainABI)
+	require.NoError(t, err)
+	require.Equal(t, deployTx.Result.V(), blockindexer.TXResult_SUCCESS)
+	return deployTx.ContractAddress
+}
+
+// Note, here we're simulating a domain that choose to support versions of a "Transfer" function
+// with "string" types (rather than "address") for the from/to address and to ask Paladin to do
+// verifier resolution for these. The same domain could also support "address" type inputs/outputs
+// in the same ABI.
+const fakeCoinTransferABI = `{
+		"type": "function",
+		"name": "transfer",
+		"inputs": [
+		  {
+		    "name": "from",
+			"type": "string"
+		  },
+		  {
+		    "name": "to",
+			"type": "string"
+		  },
+		  {
+		    "name": "amount",
+			"type": "uint256"
+		  }
+		],
+		"outputs": null
+	}`
+
+func FakeCoinTransferABI() *abi.ABI {
+	return &abi.ABI{mustParseABIEntry(fakeCoinTransferABI)}
+}
+
+func FakeCoinDomain(t *testing.T, ctx context.Context) plugintk.PluginBase {
+	simDomainABI := mustParseBuildABI(simDomainBuild)
+	simTokenABI := mustParseBuildABI(simTokenBuild)
+
+	transferABI := simTokenABI.Events()["UTXOTransfer"]
+	require.NotEmpty(t, transferABI)
+	transferSignature := transferABI.SolString()
+
+	fakeCoinStateSchema := `{
+		"type": "tuple",
+		"internalType": "struct FakeCoin",
+		"components": [
+			{
+				"name": "salt",
+				"type": "bytes32"
+			},
+			{
+				"name": "owner",
+				"type": "address",
+				"indexed": true
+			},
+			{
+				"name": "amount",
+				"type": "uint256",
+				"indexed": true
+			}
+		]
+	}`
+
+	fakeDeployPayload := `{
+		"notary": "domain1.contract1.notary",
+		"name": "FakeToken1",
+		"symbol": "FT1"
+	}`
+
+	type fakeTransferParser struct {
+		From   string               `json:"from,omitempty"`
+		To     string               `json:"to,omitempty"`
+		Amount *ethtypes.HexInteger `json:"amount"`
+	}
+
+	type fakeCoinParser struct {
+		Salt   tktypes.HexBytes      `json:"salt"`
+		Owner  ethtypes.Address0xHex `json:"owner"`
+		Amount *ethtypes.HexInteger  `json:"amount"`
+	}
+
+	contractDataABI := &abi.ParameterArray{
+		{Name: "notaryLocator", Type: "string"},
+	}
+
+	type fakeCoinConfigParser struct {
+		NotaryLocator string `json:"notaryLocator"`
+	}
+
+	return plugintk.NewDomain(func(callbacks plugintk.DomainCallbacks) plugintk.DomainAPI {
+
+		var fakeCoinSchemaID string
+		var chainID int64
+		fakeCoinSelection := func(ctx context.Context, fromAddr *ethtypes.Address0xHex, contractAddr string, amount *big.Int) ([]*fakeCoinParser, []*prototk.StateRef, *big.Int, error) {
+			var lastStateTimestamp int64
+			total := big.NewInt(0)
+			coins := []*fakeCoinParser{}
+			stateRefs := []*prototk.StateRef{}
+			for {
+				// Simple oldest coin first algo
+				jq := &query.QueryJSON{
+					Limit: confutil.P(10),
+					Sort:  []string{".created"},
+					Statements: query.Statements{
+						Ops: query.Ops{
+							Eq: []*query.OpSingleVal{
+								{Op: query.Op{Field: "owner"}, Value: tktypes.JSONString(fromAddr.String())},
+							},
+						},
+					},
+				}
+				if lastStateTimestamp > 0 {
+					jq.GT = []*query.OpSingleVal{
+						{Op: query.Op{Field: ".created"}, Value: tktypes.RawJSON(strconv.FormatInt(lastStateTimestamp, 10))},
+					}
+				}
+				res, err := callbacks.FindAvailableStates(ctx, &prototk.FindAvailableStatesRequest{
+					ContractAddress: contractAddr,
+					SchemaId:        fakeCoinSchemaID,
+					QueryJson:       tktypes.JSONString(jq).String(),
+				})
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				states := res.States
+				if len(states) == 0 {
+					return nil, nil, nil, fmt.Errorf("insufficient funds (available=%s)", total.Text(10))
+				}
+				for _, state := range states {
+					lastStateTimestamp = state.StoredAt
+					// Note: More sophisticated coin selection might prefer states that aren't locked to a sequence
+					var coin fakeCoinParser
+					if err := json.Unmarshal([]byte(state.DataJson), &coin); err != nil {
+						return nil, nil, nil, fmt.Errorf("coin %s is invalid: %s", state.Id, err)
+					}
+					total = total.Add(total, coin.Amount.BigInt())
+					stateRefs = append(stateRefs, &prototk.StateRef{
+						Id:       state.Id,
+						SchemaId: state.SchemaId,
+					})
+					coins = append(coins, &coin)
+					if total.Cmp(amount) >= 0 {
+						// We've got what we need - return how much over we are
+						return coins, stateRefs, new(big.Int).Sub(total, amount), nil
+					}
+				}
+			}
+		}
+
+		validateTransferTransactionInput := func(tx *prototk.TransactionSpecification) (*ethtypes.Address0xHex, string, *fakeTransferParser) {
+			assert.JSONEq(t, fakeCoinTransferABI, tx.FunctionAbiJson)
+			assert.Equal(t, "function transfer(string memory from, string memory to, uint256 amount) external { }", tx.FunctionSignature)
+			var inputs fakeTransferParser
+			err := json.Unmarshal([]byte(tx.FunctionParamsJson), &inputs)
+			require.NoError(t, err)
+			assert.Greater(t, inputs.Amount.BigInt().Sign(), 0)
+			contractAddr, err := ethtypes.NewAddress(tx.ContractAddress)
+			require.NoError(t, err)
+			configValues, err := contractDataABI.DecodeABIData(tx.ContractConfig, 0)
+			require.NoError(t, err)
+			configJSON, err := tktypes.StandardABISerializer().SerializeJSON(configValues)
+			require.NoError(t, err)
+			var config fakeCoinConfigParser
+			err = json.Unmarshal(configJSON, &config)
+			require.NoError(t, err)
+			assert.NotEmpty(t, config.NotaryLocator)
+			return contractAddr, config.NotaryLocator, &inputs
+		}
+
+		extractTransferVerifiers := func(txSpec *prototk.TransactionSpecification, txInputs *fakeTransferParser, verifiers []*prototk.ResolvedVerifier) (senderAddr, fromAddr, toAddr *ethtypes.Address0xHex) {
+			for _, v := range verifiers {
+				if txSpec.From != "" && v.Lookup == txSpec.From {
+					senderAddr = ethtypes.MustNewAddress(v.Verifier)
+				}
+				if txInputs.From != "" && v.Lookup == txInputs.From {
+					fromAddr = ethtypes.MustNewAddress(v.Verifier)
+				}
+				if txInputs.To != "" && v.Lookup == txInputs.To {
+					toAddr = ethtypes.MustNewAddress(v.Verifier)
+				}
+			}
+			assert.True(t, txInputs.From == "" || (fromAddr != nil && *fromAddr != ethtypes.Address0xHex{}))
+			assert.True(t, txInputs.To == "" || (toAddr != nil && *toAddr != ethtypes.Address0xHex{}))
+			return
+		}
+
+		typedDataV4TransferWithSalts := func(contract *ethtypes.Address0xHex, inputs, outputs []*fakeCoinParser) (tktypes.HexBytes, error) {
+			typeSet := eip712.TypeSet{
+				"FakeTransfer": {
+					{Name: "inputs", Type: "Coin[]"},
+					{Name: "outputs", Type: "Coin[]"},
+				},
+				"Coin": {
+					{Name: "salt", Type: "bytes32"},
+					{Name: "owner", Type: "address"},
+					{Name: "amount", Type: "uint256"},
+				},
+				eip712.EIP712Domain: {
+					{Name: "name", Type: "string"},
+					{Name: "version", Type: "string"},
+					{Name: "chainId", Type: "uint256"},
+					{Name: "verifyingContract", Type: "address"},
+				},
+			}
+			messageInputs := make([]interface{}, len(inputs))
+			for i, input := range inputs {
+				messageInputs[i] = map[string]interface{}{
+					"salt":   input.Salt.String(),
+					"owner":  input.Owner.String(),
+					"amount": input.Amount.String(),
+				}
+			}
+			messageOutputs := make([]interface{}, len(outputs))
+			for i, output := range outputs {
+				messageOutputs[i] = map[string]interface{}{
+					"salt":   output.Salt.String(),
+					"owner":  output.Owner.String(),
+					"amount": output.Amount.String(),
+				}
+			}
+			tdv4, err := eip712.EncodeTypedDataV4(context.Background(), &eip712.TypedData{
+				Types:       typeSet,
+				PrimaryType: "FakeTransfer",
+				Domain: map[string]interface{}{
+					"name":              "FakeTransfer",
+					"version":           "0.0.1",
+					"chainId":           chainID,
+					"verifyingContract": contract,
+				},
+				Message: map[string]interface{}{
+					"inputs":  messageInputs,
+					"outputs": messageOutputs,
+				},
+			})
+			return tktypes.HexBytes(tdv4), err
+		}
+
+		//---
+
+		return &plugintk.DomainAPIBase{Functions: &plugintk.DomainAPIFunctions{
+
+			ConfigureDomain: func(ctx context.Context, req *prototk.ConfigureDomainRequest) (*prototk.ConfigureDomainResponse, error) {
+				assert.Equal(t, "domain1", req.Name)
+				assert.JSONEq(t, `{"some":"config"}`, req.ConfigJson)
+				assert.Equal(t, int64(1337), req.ChainId) // from tools/besu_bootstrap
+				chainID = req.ChainId
+
+				var eventsABI abi.ABI
+				eventsABI = append(eventsABI, transferABI)
+				eventsJSON, err := json.Marshal(eventsABI)
+				require.NoError(t, err)
+
+				return &prototk.ConfigureDomainResponse{
+					DomainConfig: &prototk.DomainConfig{
+						BaseLedgerSubmitConfig: &prototk.BaseLedgerSubmitConfig{
+							SubmitMode: prototk.BaseLedgerSubmitConfig_ENDORSER_SUBMISSION,
+						},
+						AbiStateSchemasJson: []string{fakeCoinStateSchema},
+						AbiEventsJson:       string(eventsJSON),
+					},
+				}, nil
+			},
+
+			InitDomain: func(ctx context.Context, req *prototk.InitDomainRequest) (*prototk.InitDomainResponse, error) {
+				assert.Len(t, req.AbiStateSchemas, 1)
+				fakeCoinSchemaID = req.AbiStateSchemas[0].Id
+				assert.Equal(t, "type=FakeCoin(bytes32 salt,address owner,uint256 amount),labels=[owner,amount]", req.AbiStateSchemas[0].Signature)
+				return &prototk.InitDomainResponse{}, nil
+			},
+
+			InitDeploy: func(ctx context.Context, req *prototk.InitDeployRequest) (*prototk.InitDeployResponse, error) {
+				assert.JSONEq(t, fakeDeployPayload, req.Transaction.ConstructorParamsJson)
+				return &prototk.InitDeployResponse{
+					RequiredVerifiers: []*prototk.ResolveVerifierRequest{
+						{
+							Lookup:    "domain1.contract1.notary",
+							Algorithm: algorithms.ECDSA_SECP256K1_PLAINBYTES,
+						},
+					},
+				}, nil
+			},
+
+			PrepareDeploy: func(ctx context.Context, req *prototk.PrepareDeployRequest) (*prototk.PrepareDeployResponse, error) {
+				assert.JSONEq(t, `{
+					"notary": "domain1.contract1.notary",
+					"name": "FakeToken1",
+					"symbol": "FT1"
+				}`, req.Transaction.ConstructorParamsJson)
+				assert.Len(t, req.ResolvedVerifiers, 1)
+				assert.Equal(t, algorithms.ECDSA_SECP256K1_PLAINBYTES, req.ResolvedVerifiers[0].Algorithm)
+				assert.Equal(t, "domain1.contract1.notary", req.ResolvedVerifiers[0].Lookup)
+				assert.NotEmpty(t, req.ResolvedVerifiers[0].Verifier)
+				return &prototk.PrepareDeployResponse{
+					Signer: confutil.P(fmt.Sprintf("domain1/transactions/%s", req.Transaction.TransactionId)),
+					Transaction: &prototk.BaseLedgerTransaction{
+						FunctionAbiJson: toJSONString(t, simDomainABI.Functions()["newSIMTokenNotarized"]),
+						ParamsJson: fmt.Sprintf(`{
+							"txId": "%s",
+							"notary": "%s",
+							"notaryLocator": "domain1.contract1.notary"
+						}`, req.Transaction.TransactionId, req.ResolvedVerifiers[0].Verifier),
+					},
+				}, nil
+			},
+
+			InitTransaction: func(ctx context.Context, req *prototk.InitTransactionRequest) (*prototk.InitTransactionResponse, error) {
+				_, notaryLocator, txInputs := validateTransferTransactionInput(req.Transaction)
+
+				// We require ethereum addresses for the "from" and "to" addresses to actually
+				// execute the transaction. See notes above about this.
+				requiredVerifiers := []*prototk.ResolveVerifierRequest{
+					{
+						Lookup:    req.Transaction.From,
+						Algorithm: algorithms.ECDSA_SECP256K1_PLAINBYTES,
+					},
+					{
+						Lookup:    notaryLocator,
+						Algorithm: algorithms.ECDSA_SECP256K1_PLAINBYTES,
+					},
+				}
+				if txInputs.From != "" {
+					requiredVerifiers = append(requiredVerifiers, &prototk.ResolveVerifierRequest{
+						Lookup:    txInputs.From,
+						Algorithm: algorithms.ECDSA_SECP256K1_PLAINBYTES,
+					})
+				}
+				if txInputs.To != "" && (txInputs.From == "" || txInputs.From != txInputs.To) {
+					requiredVerifiers = append(requiredVerifiers, &prototk.ResolveVerifierRequest{
+						Lookup:    txInputs.To,
+						Algorithm: algorithms.ECDSA_SECP256K1_PLAINBYTES,
+					})
+				}
+				return &prototk.InitTransactionResponse{
+					RequiredVerifiers: requiredVerifiers,
+				}, nil
+			},
+
+			AssembleTransaction: func(ctx context.Context, req *prototk.AssembleTransactionRequest) (_ *prototk.AssembleTransactionResponse, err error) {
+				contractAddr, notaryLocator, txInputs := validateTransferTransactionInput(req.Transaction)
+				_, fromAddr, toAddr := extractTransferVerifiers(req.Transaction, txInputs, req.ResolvedVerifiers)
+				amount := txInputs.Amount.BigInt()
+				toKeep := new(big.Int)
+				coinsToSpend := []*fakeCoinParser{}
+				stateRefsToSpend := []*prototk.StateRef{}
+				if txInputs.From != "" {
+					coinsToSpend, stateRefsToSpend, toKeep, err = fakeCoinSelection(ctx, fromAddr, req.Transaction.ContractAddress, amount)
+					if err != nil {
+						return nil, err
+					}
+				}
+				newStates := []*prototk.NewState{}
+				newCoins := []*fakeCoinParser{}
+				if fromAddr != nil && toKeep.Sign() > 0 {
+					// Generate a state to keep for ourselves
+					coin := fakeCoinParser{
+						Salt:   tktypes.RandBytes(32),
+						Owner:  *fromAddr,
+						Amount: (*ethtypes.HexInteger)(toKeep),
+					}
+					newCoins = append(newCoins, &coin)
+					newStates = append(newStates, &prototk.NewState{
+						SchemaId:      fakeCoinSchemaID,
+						StateDataJson: toJSONString(t, &coin),
+					})
+				}
+				if toAddr != nil && amount.Sign() > 0 {
+					// Generate the coin to transfer
+					coin := fakeCoinParser{
+						Salt:   tktypes.RandBytes(32),
+						Owner:  *toAddr,
+						Amount: (*ethtypes.HexInteger)(amount),
+					}
+					newCoins = append(newCoins, &coin)
+					newStates = append(newStates, &prototk.NewState{
+						SchemaId:      fakeCoinSchemaID,
+						StateDataJson: toJSONString(t, &coin),
+					})
+				}
+				eip712Payload, err := typedDataV4TransferWithSalts(contractAddr, coinsToSpend, newCoins)
+				require.NoError(t, err)
+				return &prototk.AssembleTransactionResponse{
+					AssembledTransaction: &prototk.AssembledTransaction{
+						InputStates:  stateRefsToSpend,
+						OutputStates: newStates,
+					},
+					AssemblyResult: prototk.AssembleTransactionResponse_OK,
+					AttestationPlan: []*prototk.AttestationRequest{
+						{
+							Name:            "sender",
+							AttestationType: prototk.AttestationType_SIGN,
+							Algorithm:       algorithms.ECDSA_SECP256K1_PLAINBYTES,
+							Payload:         eip712Payload,
+							Parties: []string{
+								req.Transaction.From,
+							},
+						},
+						{
+							Name:            "notary",
+							AttestationType: prototk.AttestationType_ENDORSE,
+							// we expect an endorsement is of the form ENDORSER_SUBMIT - so we need an eth signing key to exist
+							Algorithm: algorithms.ECDSA_SECP256K1_PLAINBYTES,
+							Parties: []string{
+								notaryLocator,
+							},
+						},
+					},
+				}, nil
+			},
+
+			EndorseTransaction: func(ctx context.Context, req *prototk.EndorseTransactionRequest) (*prototk.EndorseTransactionResponse, error) {
+				contractAddr, notaryLocator, txInputs := validateTransferTransactionInput(req.Transaction)
+				senderAddr, fromAddr, toAddr := extractTransferVerifiers(req.Transaction, txInputs, req.ResolvedVerifiers)
+				assert.Equal(t, req.EndorsementVerifier.Lookup, req.EndorsementRequest.Parties[0])
+				assert.Equal(t, req.EndorsementVerifier.Lookup, notaryLocator)
+
+				inCoins := make([]*fakeCoinParser, len(req.Inputs))
+				for i, input := range req.Inputs {
+					assert.Equal(t, fakeCoinSchemaID, input.SchemaId)
+					if err := json.Unmarshal([]byte(input.StateDataJson), &inCoins[i]); err != nil {
+						return nil, fmt.Errorf("invalid input[%d] (%s): %s", i, input.Id, err)
+					}
+				}
+				outCoins := make([]*fakeCoinParser, len(req.Outputs))
+				for i, output := range req.Outputs {
+					assert.Equal(t, fakeCoinSchemaID, output.SchemaId)
+					if err := json.Unmarshal([]byte(output.StateDataJson), &outCoins[i]); err != nil {
+						return nil, fmt.Errorf("invalid output[%d] (%s): %s", i, output.Id, err)
+					}
+				}
+
+				// Recover the signature
+				signaturePayload, err := typedDataV4TransferWithSalts(contractAddr, inCoins, outCoins)
+				require.NoError(t, err)
+				var signerVerification *prototk.AttestationResult
+				for _, ar := range req.Signatures {
+					if ar.AttestationType == prototk.AttestationType_SIGN &&
+						ar.Name == "sender" &&
+						ar.Verifier.Algorithm == algorithms.ECDSA_SECP256K1_PLAINBYTES {
+						signerVerification = ar
+						break
+					}
+				}
+				assert.NotNil(t, signerVerification)
+				sig, err := secp256k1.DecodeCompactRSV(context.Background(), signerVerification.Payload)
+				require.NoError(t, err)
+				signerAddr, err := sig.RecoverDirect(signaturePayload, chainID)
+				require.NoError(t, err)
+
+				// There would need to be minting/spending rules here - we just check the signature
+				assert.Equal(t, signerAddr.String(), signerVerification.Verifier.Verifier)
+
+				// Check the math
+				if fromAddr != nil && toAddr != nil {
+					assert.Equal(t, senderAddr, fromAddr)
+					inTotal := big.NewInt(0)
+					for _, c := range inCoins {
+						inTotal = inTotal.Add(inTotal, c.Amount.BigInt())
+					}
+					outTotal := big.NewInt(0)
+					for _, c := range outCoins {
+						outTotal = outTotal.Add(outTotal, c.Amount.BigInt())
+					}
+					assert.True(t, inTotal.Cmp(outTotal) == 0)
+				} else {
+					// NOTE: No minting controls in this demo example
+					if fromAddr == nil {
+						assert.Len(t, inCoins, 0)
+					}
+					if toAddr == nil {
+						assert.Len(t, outCoins, 0)
+					}
+				}
+
+				return &prototk.EndorseTransactionResponse{
+					EndorsementResult: prototk.EndorseTransactionResponse_ENDORSER_SUBMIT,
+				}, nil
+			},
+
+			PrepareTransaction: func(ctx context.Context, req *prototk.PrepareTransactionRequest) (*prototk.PrepareTransactionResponse, error) {
+				var signerSignature tktypes.HexBytes
+				for _, att := range req.AttestationResult {
+					if att.AttestationType == prototk.AttestationType_SIGN && att.Name == "sender" {
+						signerSignature = att.Payload
+					}
+				}
+				spentStateIds := make([]string, len(req.InputStates))
+				for i, s := range req.InputStates {
+					spentStateIds[i] = s.Id
+				}
+				newStateIds := make([]string, len(req.OutputStates))
+				for i, s := range req.OutputStates {
+					newStateIds[i] = s.Id
+				}
+				return &prototk.PrepareTransactionResponse{
+					Transaction: &prototk.BaseLedgerTransaction{
+						FunctionAbiJson: toJSONString(t, simTokenABI.Functions()["executeNotarized"]),
+						ParamsJson: toJSONString(t, map[string]interface{}{
+							"txId":      req.Transaction.TransactionId,
+							"inputs":    spentStateIds,
+							"outputs":   newStateIds,
+							"signature": signerSignature,
+						}),
+					},
+				}, nil
+			},
+
+			HandleEventBatch: func(ctx context.Context, req *prototk.HandleEventBatchRequest) (*prototk.HandleEventBatchResponse, error) {
+				var events []*blockindexer.EventWithData
+				if err := json.Unmarshal([]byte(req.JsonEvents), &events); err != nil {
+					return nil, err
+				}
+
+				var res prototk.HandleEventBatchResponse
+				for _, ev := range events {
+					switch ev.SoliditySignature {
+					case transferSignature:
+						var transfer UTXOTransfer_Event
+						if err := json.Unmarshal(ev.Data, &transfer); err == nil {
+							res.TransactionsComplete = append(res.TransactionsComplete, transfer.TX.String())
+							res.SpentStates = append(res.SpentStates, parseStatesFromEvent(transfer.TX, transfer.Inputs)...)
+							res.ConfirmedStates = append(res.ConfirmedStates, parseStatesFromEvent(transfer.TX, transfer.Outputs)...)
+						}
+					}
+				}
+				return &res, nil
+			},
+		}}
+	})
+}
+
+func mustParseABIEntry(abiEntryJSON string) *abi.Entry {
+	var abiEntry abi.Entry
+	err := json.Unmarshal([]byte(abiEntryJSON), &abiEntry)
+	if err != nil {
+		panic(err)
+	}
+	return &abiEntry
+}


### PR DESCRIPTION
Adding a component test for the whole of the core/go component.  Nothing is mocked and only the main `Run` entry point and instance bootstrapping wrapper is emulated.  A fake (sim) domain is used and loaded via the unit test plugin loader but otherwise all integration with that domain is as per any real domain.

I decided to take a wholesale copy of the sim domain go code from the testbed tests rather than going to some effort to repackage it for re-use because I didn't want to impede either usage from evolving as needs dictate.  However, we are sharing the same solidity base ledger contract and ABI so there may be a need to separate that out in future too. 