### PR TITLE
fix: Only accept TLS Connections on the HTTP Server

### DIFF
--- a/toolkit/go/pkg/httpserver/httpserver.go
+++ b/toolkit/go/pkg/httpserver/httpserver.go
@@ -19,6 +19,7 @@ package httpserver
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -26,9 +27,9 @@ import (
 	"time"
 
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/kaleido-io/paladin/toolkit/pkg/tkmsgs"
 	"github.com/kaleido-io/paladin/toolkit/pkg/confutil"
 	"github.com/kaleido-io/paladin/toolkit/pkg/log"
+	"github.com/kaleido-io/paladin/toolkit/pkg/tkmsgs"
 	"github.com/kaleido-io/paladin/toolkit/pkg/tktypes"
 	"github.com/kaleido-io/paladin/toolkit/pkg/tlsconf"
 )
@@ -72,6 +73,11 @@ func NewServer(ctx context.Context, description string, conf *Config, handler ht
 	tlsConfig, err := tlsconf.BuildTLSConfig(ctx, &conf.TLS, tlsconf.ServerType)
 	if err != nil {
 		return nil, err
+	}
+
+	// If TLS Config is provided, only accept connections doing TLS
+	if tlsConfig != nil {
+		s.listener = tls.NewListener(s.listener, tlsConfig)
 	}
 
 	maxRequestTimeout := confutil.DurationMin(conf.MaxRequestTimeout, 1*time.Second, *HTTPDefaults.MaxRequestTimeout)

--- a/toolkit/go/pkg/httpserver/httpserver_test.go
+++ b/toolkit/go/pkg/httpserver/httpserver_test.go
@@ -151,6 +151,26 @@ func TestParseCustomTimeout(t *testing.T) {
 	assert.Equal(t, 10*time.Second, s.calcRequestTimeout(req, 10*time.Second, 20*time.Second))
 }
 
+func TestOnlyAcceptsTLSConnectionsWhenTLSConfigProvided(t *testing.T) {
+	tlsConfig := tlsconf.Config{
+		Enabled: true,
+	}
+	config := &Config{
+		TLS: tlsConfig,
+	}
+	
+	url, _, done := newTestServer(t, config, func(w http.ResponseWriter, r *http.Request) {})
+	defer done()
+
+	// Make a HTTP request to the server and check that we get a 400 (client speaking HTTP to a HTTPS server)
+	req, err := http.NewRequest(http.MethodPut, url, nil)
+	require.NoError(t, err)
+	res, err := http.DefaultClient.Do(req)
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, 400, res.StatusCode)
+}
+
 type mockResponseWriter struct{}
 
 func (*mockResponseWriter) Header() http.Header { return nil }


### PR DESCRIPTION
When doing some testing it looked like plain HTTP connections could be made to a Paladin RPC Server configured with an mTLS TLS Config. This PR ensures that if a TLS Config is set, only TLS connections will be accepted.