### PR TITLE
add WSHandler to rpcserver interface

### DIFF
--- a/toolkit/go/pkg/rpcserver/rpcserver.go
+++ b/toolkit/go/pkg/rpcserver/rpcserver.go
@@ -37,6 +37,7 @@ type RPCServer interface {
 	EthPublish(eventType string, result interface{}) // Note this is an `eth_` specific extension, with no ack or reliability
 	HTTPAddr() net.Addr
 	WSAddr() net.Addr
+	WSHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func NewRPCServer(ctx context.Context, conf *pldconf.RPCServerConfig) (_ RPCServer, err error) {
@@ -92,6 +93,10 @@ func (s *rpcServer) WSAddr() (a net.Addr) {
 		a = s.wsServer.Addr()
 	}
 	return a
+}
+
+func (s *rpcServer) WSHandler(res http.ResponseWriter, req *http.Request) {
+	s.wsHandler(res, req)
 }
 
 func (s *rpcServer) httpHandler(res http.ResponseWriter, req *http.Request) {

--- a/toolkit/go/pkg/rpcserver/rpcserver_test.go
+++ b/toolkit/go/pkg/rpcserver/rpcserver_test.go
@@ -116,3 +116,18 @@ func TestBadWSUpgrade(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 
 }
+
+func TestWSHandler(t *testing.T) {
+	rpcServer, err := NewRPCServer(context.Background(), &pldconf.RPCServerConfig{
+		HTTP: pldconf.RPCServerConfigHTTP{Disabled: true},
+		WS: pldconf.RPCServerConfigWS{
+			HTTPServerConfig: pldconf.HTTPServerConfig{
+				Port: confutil.P(0),
+			},
+		},
+	})
+	require.NoError(t, err)
+	defer rpcServer.Stop()
+
+	assert.NotNil(t, rpcServer.WSHandler)
+}


### PR DESCRIPTION
To expose the websocket handler for a server.