### PR TITLE
sign on assembling node

### DIFF
--- a/core/go/componenttest/domains/simple_domain.go
+++ b/core/go/componenttest/domains/simple_domain.go
@@ -918,6 +918,7 @@ func SimpleTokenDomain(t *testing.T, ctx context.Context) plugintk.PluginBase {
 
 				// There would need to be minting/spending rules here - we just check the signature
 				assert.Equal(t, signerAddr.String(), signerVerification.Verifier.Verifier)
+				assert.Equal(t, signerAddr.String(), senderAddr.String(), "signer and sender should match")
 
 				// Check the math
 				if fromAddr != nil && toAddr != nil {

--- a/core/go/internal/msgs/en_errors.go
+++ b/core/go/internal/msgs/en_errors.go
@@ -74,6 +74,7 @@ var (
 	MsgComponentAdditionalMgrInitError          = ffe("PD010031", "Error initializing %s manager")
 	MsgComponentAdditionalMgrStartError         = ffe("PD010032", "Error initializing %s manager")
 	MsgPrivateTxManagerInvalidEventMissingField = ffe("PD010033", "Invalid event: missing field %s")
+	MsgPrivateTxManagerSignRemoteError          = ffe("PD010034", "Attempt to sign a transaction with an identity from a remote node: %s")
 
 	// States PD0101XX
 	MsgStateInvalidLength             = ffe("PD010101", "Invalid hash len expected=%d actual=%d")


### PR DESCRIPTION
Fixes the issue where a transaction is delegated to the notary for coordination before the transaction was signed by the sender.


Changes
 - reorder the flow of actions in [transaction_flow_actions.go](https://github.com/kaleido-io/paladin/pull/357/files#diff-e5f0920d104dfe3c7fa0a181460b19589b1f91bfa477ae5d6e6191ea072fcc6aR80) to gather signature before considering whether to delegate
 - add assertion to simple domain used in component tests to assert that the address recovered from the signature matches the sender
 - make the signing code stricter about looking up identities that appear to be qualified as being on a different node
