### PR TITLE
Fix zeto tests to keep the amount within range of current zeto circuits

### DIFF
--- a/operator/test/e2e/e2e_noto_pente_test.go
+++ b/operator/test/e2e/e2e_noto_pente_test.go
@@ -71,6 +71,14 @@ func with18Decimals(x int64) *tktypes.HexUint256 {
 	return (*tktypes.HexUint256)(bx)
 }
 
+func with10Decimals(x int64) *tktypes.HexUint256 {
+	bx := new(big.Int).Mul(
+		big.NewInt(x),
+		new(big.Int).Exp(big.NewInt(10), big.NewInt(10), big.NewInt(0)),
+	)
+	return (*tktypes.HexUint256)(bx)
+}
+
 func getJSONPropertyAs(jsonData tktypes.RawJSON, name string, toValue any) {
 	var mapProp map[string]tktypes.RawJSON
 	err := json.Unmarshal(jsonData, &mapProp)

--- a/operator/test/e2e/e2e_zeto_test.go
+++ b/operator/test/e2e/e2e_zeto_test.go
@@ -151,10 +151,10 @@ var _ = Describe(fmt.Sprintf("zeto - %s", tokenType), Ordered, func() {
 
 		It("mints some zetos to bob on node1", func() {
 			for _, amount := range []*tktypes.HexUint256{
-				with18Decimals(15),
-				with18Decimals(25), // 40
-				with18Decimals(30), // 70
-				with18Decimals(42), // 112
+				with10Decimals(15),
+				with10Decimals(25), // 40
+				with10Decimals(30), // 70
+				with10Decimals(42), // 112
 			} {
 				txn := rpc["node1"].ForABI(ctx, zetotypes.ZetoABI).
 					Private().
@@ -179,11 +179,9 @@ var _ = Describe(fmt.Sprintf("zeto - %s", tokenType), Ordered, func() {
 		})
 
 		It("sends some zetos to sally on node2", func() {
-			Skip("for now")
-
 			for _, amount := range []*tktypes.HexUint256{
-				with18Decimals(33), // 79
-				with18Decimals(66), // 13
+				with10Decimals(33), // 79
+				with10Decimals(66), // 13
 			} {
 				txn := rpc["node1"].ForABI(ctx, zetotypes.ZetoABI).
 					Private().
@@ -208,25 +206,29 @@ var _ = Describe(fmt.Sprintf("zeto - %s", tokenType), Ordered, func() {
 			}
 		})
 
-		// It("sally on node2 sends some zetos to fred on node3", func() {
-		// 	txn := rpc["node2"].ForABI(ctx, zetotypes.NotoABI).
-		// 		Private().
-		// 		Domain("zeto").
-		// 		Function("transfer").
-		// 		To(zetoContract).
-		// 		From("sally@node2").
-		// 		Inputs(&zetotypes.TransferParams{
-		// 			To:     "fred@node3",
-		// 			Amount: with18Decimals(6),
-		// 		}).
-		// 		Send().
-		// 		Wait(5 * time.Second)
-		// 	testLog("Noto transfer transaction %s", txn.ID())
-		// 	Expect(txn.Error()).To(BeNil())
-		// 	logWallet("sally", "node2")
-		// 	logWallet("fred", "node3")
-		// 	testLog("done testing zeto in isolation")
-		// })
+		It("sally on node2 sends some zetos to fred on node3", func() {
+			txn := rpc["node2"].ForABI(ctx, zetotypes.ZetoABI).
+				Private().
+				Domain("zeto").
+				Function("transfer").
+				To(zetoContract).
+				From("sally@node2").
+				Inputs(&zetotypes.TransferParams{
+					Transfers: []*zetotypes.TransferParamEntry{
+						{
+							To:     "fred@node3",
+							Amount: with10Decimals(20),
+						},
+					},
+				}).
+				Send().
+				Wait(5 * time.Second)
+			testLog("Noto transfer transaction %s", txn.ID())
+			Expect(txn.Error()).To(BeNil())
+			logWallet("sally", "node2")
+			logWallet("fred", "node3")
+			testLog("done testing zeto in isolation")
+		})
 
 	})
 })


### PR DESCRIPTION
```
[2024-11-04T06:11:15.136Z] ERROR failed to sign for party bob@node1 (verifier=0xc055f2944badf1b900f343115f9f0b4c5d94b0c6bb123350f80da419c8840e23,algorithm=domain:zeto:snark:babyjubjub): PD011206: DOMAIN zeto returned error: PD210023: Failed to sign. PD210100: failed to calculate the witness. Assert Failed.
Error in template Num2Bits_12 line: 38
Error in template LessThan_13 line: 96
Error in template GreaterEqThan_14 line: 138
Error in template CheckPositive_15 line: 36
Error in template Zeto_94 line: 55
```

this is due to a (somewhat arbitrary) current setting in the ZKP circuit, where a value must be smaller than 2^40-1. it’s necessary to avoid overflows, since ZKP only deal with unsigned numbers

we can discuss later if the range needs to be enlarged