### PR TITLE
Update getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Learn more about Paladin here:
 
 Get a 3-node Paladin network running with Besu on your laptop:
 
-- https://lf-decentralized-trust-labs.github.io/paladin/head/getting-started
+- https://lf-decentralized-trust-labs.github.io/paladin/head/getting-started/installation
 
 ![Paladin](doc-site/docs/images/paladin_deployment.svg)
 

--- a/doc-site/docs/getting-started/running.md
+++ b/doc-site/docs/getting-started/running.md
@@ -1,3 +1,2 @@
 # Running
 
-Explain how to run the project here.


### PR DESCRIPTION
# Overview
This PR adds a comprehensive `Getting Started` guide for installing the Paladin operator and its dependencies in a Kubernetes cluster.

> For some reason, the dependency-based installation did not work properly with `cert-manager`, so it has been added as a separate step.
