### PR TITLE
E2E run out of band from main

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -1,16 +1,15 @@
 name: Paladin Operator Build
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'operator/**'
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'operator/**'
   # pull_request:
   #   paths:
   #     - 'operator/**'
   workflow_dispatch:
-
 
 jobs:
   operator-build:


### PR DESCRIPTION
The E2E is not fully worked through to run in github actions, but it currently runs on every push currently.
Which means there is a misleading red cross on the `main` branch.