### PR TITLE
Minor fix for PR 422

### DIFF
--- a/.github/workflows/cross-build-images.yaml
+++ b/.github/workflows/cross-build-images.yaml
@@ -107,21 +107,15 @@ jobs:
           password: ${{ secrets.password }}
 
       - name: Create and push core manifest
-        run: |
-          docker manifest create $TEMP_IMAGE \
-            --amend $TEMP_IMAGE-arm64 \
-            --amend $TEMP_IMAGE-amd64
-          docker manifest push $TEMP_IMAGE
-
-      - name: Retag and push core image
         env:
           IMAGE_TAGS: ${{ inputs.image_tags }}
         run: |
-          docker pull $TEMP_IMAGE
           IFS=',' read -ra TAG_ARRAY <<< "$IMAGE_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
-            docker tag $TEMP_IMAGE $IMAGE:$tag
-            docker push $IMAGE:$tag
+            docker manifest create $IMAGE:$tag \
+            --amend $TEMP_IMAGE-arm64 \
+            --amend $TEMP_IMAGE-amd64
+            docker manifest push $IMAGE:$tag
           done
 
   operator-docker-manifest:
@@ -149,19 +143,14 @@ jobs:
           password: ${{ secrets.password }}
 
       - name: Create and push operator manifest
-        run: |
-          docker manifest create $TEMP_IMAGE \
-            --amend $TEMP_IMAGE-arm64 \
-            --amend $TEMP_IMAGE-amd64
-          docker manifest push $TEMP_IMAGE
-
-      - name: Retag and push operator image
         env:
           IMAGE_TAGS: ${{ inputs.image_tags }}
         run: |
-          docker pull $TEMP_IMAGE
           IFS=',' read -ra TAG_ARRAY <<< "$IMAGE_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
-            docker tag $TEMP_IMAGE $IMAGE:$tag
-            docker push $IMAGE:$tag
+            docker manifest create $IMAGE:$tag \
+            --amend $TEMP_IMAGE-arm64 \
+            --amend $TEMP_IMAGE-amd64
+            docker manifest push $IMAGE:$tag
           done
+          


### PR DESCRIPTION
In Pull Request #422, we first pulled the image before retagging it. This caused the image to be downloaded based on the architecture of the runner, meaning the ARM64 version was not published under the final tag. In this Pull Request, I fixed the issue by creating the manifest for each tag instead of pulling and retagging

<img width="469" alt="image" src="https://github.com/user-attachments/assets/c02b8d83-8501-4f78-9b71-f922b8e160d4">
