### PR TITLE
Adding release action

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,0 +1,33 @@
+name: 'Install pre-requisites'
+description: 'Install pre-requisites for building paladin'
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Install protoc
+    shell: bash
+    run: |
+      PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+      curl -LO $PB_REL/download/v25.1/protoc-25.1-linux-x86_64.zip
+      unzip protoc-25.1-linux-x86_64.zip -d protoc
+      echo "${PWD}/protoc/bin" >> $GITHUB_PATH
+
+  # Set up Java
+  - name: Setup Java
+    uses: actions/setup-java@v4
+    with:
+      distribution: 'temurin'
+      java-version: 21
+
+  # Set up Go
+  - name: Set up Go
+    uses: actions/setup-go@v5
+    with:
+      go-version: '1.22'
+      check-latest: true
+      cache-dependency-path: |
+        **/*.sum
+
+  # Set up Gradle
+  - name: Setup Gradle
+    uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -24,33 +24,8 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      # Install protoc only on non-Windows systems
-      - name: Install protoc
-        run: |
-          PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-          curl -LO $PB_REL/download/v25.1/protoc-25.1-linux-x86_64.zip
-          unzip protoc-25.1-linux-x86_64.zip -d protoc
-          echo "${PWD}/protoc/bin" >> $GITHUB_PATH
-
-      # Set up Java
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      # Set up Go
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-          check-latest: true
-          cache-dependency-path: |
-            **/*.sum
-
-      # Set up Gradle
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Install pre-requisites
+        uses: ./.github/actions/setup
 
       # - name: Go Lint
       #   working-directory: operator

--- a/.github/workflows/paladin-PR-build.yml
+++ b/.github/workflows/paladin-PR-build.yml
@@ -30,33 +30,8 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      # Install protoc only on non-Windows systems
-      - name: Install protoc
-        run: |
-          PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-          curl -LO $PB_REL/download/v25.1/protoc-25.1-linux-x86_64.zip
-          unzip protoc-25.1-linux-x86_64.zip -d protoc
-          echo "${PWD}/protoc/bin" >> $GITHUB_PATH
-
-      # Set up Java
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      # Set up Go
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-          check-latest: true
-          cache-dependency-path: |
-            **/*.sum
-
-      # Set up Gradle
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Install pre-requisites
+        uses: ./.github/actions/setup
 
       # Build with Gradle
       # This does not build any docker images, and does not run any dockerized tests.

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -1,31 +1,43 @@
 name: Helm Chart release
 
 on:
+  workflow_call:
+    inputs:
+      latest:
+        required: false
+        type: boolean
+        default: false
+      images_tag:
+        required: true
+        type: string
+        description: 'The images tags to patch the chart with'
+      chart_tag:
+        required: true
+        type: string
+        description: 'Chart release tag'
+    secrets:
+      CR_TOKEN:
+        description: 'The GitHub token to use for the helm chart release'
+        required: true
+
   workflow_dispatch:
     inputs:
       latest:
         required: false
         type: boolean
         default: false
-      tag:
+      images_tag:
         required: true
         type: string
-        description: 'The tag to release the chart and images with'
+        description: 'The images tags to patch the chart with'
+      chart_tag:
+        required: true
+        type: string
+        description: 'The helm chart tag to release the chart'
   
 jobs:
-  build-images:
-    # build and release images
-    uses: ./.github/workflows/release-images.yaml
-    with:
-      tag: ${{ inputs.tag }}
-      latest: ${{ inputs.latest }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-
   helm-chart-release:
     runs-on: ubuntu-latest
-    needs: build-images
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -33,33 +45,8 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      # Install protoc only on non-Windows systems
-      - name: Install protoc
-        run: |
-          PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-          curl -LO $PB_REL/download/v25.1/protoc-25.1-linux-x86_64.zip
-          unzip protoc-25.1-linux-x86_64.zip -d protoc
-          echo "${PWD}/protoc/bin" >> $GITHUB_PATH
-
-      # Set up Java
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      # Set up Go
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-          check-latest: true
-          cache-dependency-path: |
-            **/*.sum
-
-      # Set up Gradle
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Install pre-requisites
+        uses: ./.github/actions/setup
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -90,17 +77,17 @@ jobs:
             operator:
               image:
                 repository: docker.io/${{ env.LOWER_REPOSITORY_OWNER }}/paladin-operator
-                tag: ${{ inputs.tag }}
+                tag: ${{ inputs.images_tag }}
             paladin:
               image:
                 repository: docker.io/${{ env.LOWER_REPOSITORY_OWNER }}/paladin
-                tag: ${{ inputs.tag }}
+                tag: ${{ inputs.images_tag }}
       
       # Remove 'v' prefix from the tag
       - name: Process Tag
         shell: bash
         run: |
-          TAG="${{ inputs.tag }}"
+          TAG="${{ inputs.chart_tag }}"
           PROCESSED_TAG="${TAG#v}"
           echo "PROCESSED_TAG=${PROCESSED_TAG}" >> $GITHUB_ENV
 
@@ -111,7 +98,7 @@ jobs:
           file: 'operator/charts/paladin-operator/Chart.yaml'
           updates: |
             version: ${{ env.PROCESSED_TAG }}
-            appVersion: ${{ inputs.tag }}
+            appVersion: ${{ inputs.chart_tag }}
 
       - name: Confirm Helm temapltes
         working-directory: operator/charts/paladin-operator
@@ -120,6 +107,18 @@ jobs:
           helm template .
           rm -rf charts
           rm Chart.lock
+      
+      # TODO: Add e2e tests for the helm chart
+
+      # set CR_TOKEN env with the GitHub token secret when it is workflow_dispatch action
+      - name: Set CR_TOKEN
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" == 'workflow_call' ]; then
+            echo "CR_TOKEN=${{ secrets.CR_TOKEN }}" >> $GITHUB_ENV
+          else
+            echo "CR_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+          fi
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
@@ -128,4 +127,4 @@ jobs:
           charts_dir: "operator/charts"
           skip_existing: true
         env: 
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: "${{ env.CR_TOKEN }}"

--- a/.github/workflows/release-cli-sdk.yaml
+++ b/.github/workflows/release-cli-sdk.yaml
@@ -1,0 +1,28 @@
+name: CLI SDK Release
+on:
+  workflow_call:
+    secrets:
+      NPM_TOKEN:
+        description: 'NPM token'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Install pre-requisites
+        uses: ./.github/actions/setup
+       
+      - name: Publish to npm
+        working-directory: sdk/typescript
+        shell: bash
+        run: |
+          set -e
+          ../../gradlew build
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -24,6 +24,17 @@ on:
       DOCKERHUB_TOKEN:
         description: 'DockerHub token'
         required: true
+  workflow_dispatch:
+    inputs:
+      latest:
+        required: false
+        type: boolean
+        description: 'Whether to also tag the images with "latest"'
+        default: false
+      tag:
+        required: true
+        type: string
+        description: 'The tag to release the images with'
 
 jobs:
   image-tags:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      latest:
+        required: false
+        type: boolean
+        default: false
+      tag:
+        required: true
+        type: string
+        description: 'Release tag (chart and images)'
+        
+jobs:
+  set-variables:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set-vars.outputs.tag }}
+      latest: ${{ steps.set-vars.outputs.latest }}
+    steps:
+      - id: set-vars
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          INPUT_LATEST: ${{ github.event.inputs.latest }}
+        run: |
+          if [[ "$EVENT_NAME" == "push" && "$REF" == refs/tags/v* ]]; then
+            echo "Tag push event"
+            TAG="${REF##*/}"
+            LATEST="true"
+          else
+            echo "Workflow dispatch or other event"
+            TAG="$INPUT_TAG"
+            # Ensure INPUT_LATEST is 'true' or 'false' string
+            if [[ "$INPUT_LATEST" == "true" ]]; then
+              LATEST="true"
+            else
+              LATEST="false"
+            fi
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+
+
+  release-images:
+    needs: set-variables
+    uses: ./.github/workflows/release-images.yaml
+    with:
+      tag: ${{ needs.set-variables.outputs.tag }}
+      latest: '${{ fromJSON(needs.set-variables.outputs.latest) }}'
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  release-charts:
+    needs: [set-variables, release-images]
+    uses: ./.github/workflows/release-charts.yaml
+    with:
+      chart_tag: ${{ needs.set-variables.outputs.tag }}
+      images_tag: ${{ needs.set-variables.outputs.tag }}
+      latest: '${{ fromJSON(needs.set-variables.outputs.latest) }}'
+    secrets:
+      CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-cli-sdk:
+    needs: release-charts
+    uses: ./.github/workflows/release-cli-sdk.yaml
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,13 +1,9 @@
-# VERSION defines the project version for the bundle.
-VERSION ?= 0.0.1
-
 CLUSTER_NAME ?= paladin
 NAMESPACE ?= default
 
-# IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
-IMAGE_TAG_BASE ?= paladin-operator
-OPERATOR_IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
-BUNDLE_OPERATOR_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
+OPERATOR_IMG_NAME ?= paladin-operator
+OPERATOR_IMG_TAG ?= test
+OPERATOR_IMG ?= ${OPERATOR_IMG_NAME}:${OPERATOR_IMG_TAG}
 PALADIN_IMG_NAME ?= paladin
 PALADIN_IMG_TAG ?= test 
 
@@ -209,9 +205,9 @@ helm-install: helm-install-dependencies ## Install operator using Helm.
 	$(HELM) upgrade --install ${CHART_NAME_OPERATOR} ${CHART_PATH_OPERATOR} \
 		-n ${NAMESPACE} --create-namespace \
 		--set operator.namespace=${NAMESPACE} \
-		--set operator.image.repository=${IMAGE_TAG_BASE} \
+		--set operator.image.repository=${OPERATOR_IMG_NAME} \
 		--set operator.image.pullPolicy=IfNotPresent \
-		--set operator.image.tag=${VERSION} \
+		--set operator.image.tag=${OPERATOR_IMG_TAG} \
 		--set paladin.image.repository=${PALADIN_IMG_NAME} \
 		--set paladin.image.tag=${PALADIN_IMG_TAG} \
 		--set paladin.image.pullPolicy=IfNotPresent \


### PR DESCRIPTION
### Overview

This PR introduces a new GitHub Action workflow called `release`, which can be triggered either by creating a tag or manually.

The `release` action orchestrates the following release steps:

1. **Release Images** – Builds and releases Docker images.
2. **Release Charts** – Packages and releases Helm charts.
3. **Release CLI SDK** – Publishes the CLI SDK.

Each release step is modular and can also be executed independently as a manual action.