### PR TITLE
propagate public tx options

### DIFF
--- a/core/go/internal/privatetxnmgr/sequencer_dispatch.go
+++ b/core/go/internal/privatetxnmgr/sequencer_dispatch.go
@@ -161,7 +161,7 @@ func (s *Sequencer) DispatchTransactions(ctx context.Context, dispatchableTransa
 				PublicTxInput: pldapi.PublicTxInput{
 					From:            resolvedAddrs[i],
 					To:              &s.contractAddress,
-					PublicTxOptions: pldapi.PublicTxOptions{}, // TODO: Consider propagation from paladin transaction input
+					PublicTxOptions: pt.PublicTxOptions,
 				},
 			}
 


### PR DESCRIPTION
When invoking a contract on the pente domain, if I try to submit 2 transactions in quick succession, I am seeing error 
```
ERROR Error dispatching transaction: PD011812: Public transaction rejected: PD012216: Transaction reverted PenteInputNotAvailable
```

I believe the reason for this is that we are estimating the gas based on the current committed block but my first transaction has not been added to a block yet so the 2nd transaction revers because it attempts to spend the states produced by the first.

This highlights the need for a conversation about what the default approach should be for gas estimation for the domain.  The domain specific contracts should be fairly predictable in terms of the gas usage so it is not clear to me that we should be estimating gas for every transaction. 

In lieu of that conversation, in the meantime, this PR enables the `PublicTxOptions` ( including `gas`)  to be specified on input to `ptx_sendTransaction`.  It is already part of the input type for `ptx_sendTransaction` but we were just not propagating it.