### PR TITLE
fix log format json tag

### DIFF
--- a/config/pkg/pldconf/log.go
+++ b/config/pkg/pldconf/log.go
@@ -22,7 +22,7 @@ type LogConfig struct {
 	// the logging level
 	Level *string `json:"level"`
 	// the format ('simple', 'json')
-	Format *string `json:"simple"`
+	Format *string `json:"format"`
 	// the output location ('stdout','stderr','file')
 	Output *string `json:"output"`
 	// forces color to be enabled, even if we do not detect a TTY


### PR DESCRIPTION
Correct json tag for config `log.format`