### PR TITLE
Minor link update

### DIFF
--- a/doc-site/docs/architecture/pente.md
+++ b/doc-site/docs/architecture/pente.md
@@ -202,7 +202,7 @@ Other fields:
 
 ## Public ABI
 
-The public ABI of Pente is implemented in Solidity by [PentePrivacyGroup.sol](../../solidity/contracts/domains/pente/PentePrivacyGroup.sol),
+The public ABI of Pente is implemented in Solidity by [PentePrivacyGroup.sol](../../../solidity/contracts/domains/pente/PentePrivacyGroup.sol),
 and can be accessed by calling `ptx_sendTransaction` with `"type": "public"`. However, it is not often required
 to invoke the public ABI directly.
 


### PR DESCRIPTION
Link appears to be broken in the docs. It seems it's just a matter of going 1 level higher in the directory hierarchy.