### PR TITLE
Ensure we only update ABI cache on success path

### DIFF
--- a/core/go/internal/components/txmgr.go
+++ b/core/go/internal/components/txmgr.go
@@ -97,11 +97,11 @@ type TXManager interface {
 	GetPreparedTransactionByID(ctx context.Context, dbTX *gorm.DB, id uuid.UUID) (*pldapi.PreparedTransaction, error)
 	QueryPreparedTransactions(ctx context.Context, dbTX *gorm.DB, jq *query.QueryJSON) ([]*pldapi.PreparedTransaction, error)
 	CallTransaction(ctx context.Context, result any, tx *pldapi.TransactionCall) (err error)
-	UpsertABI(ctx context.Context, dbTX *gorm.DB, a abi.ABI) (*pldapi.StoredABI, error)
+	UpsertABI(ctx context.Context, dbTX *gorm.DB, a abi.ABI) (func(), *pldapi.StoredABI, error)
 
 	// These functions for use of the private TX manager for chaining private transactions.
 
-	PrepareInternalPrivateTransaction(ctx context.Context, dbTX *gorm.DB, tx *pldapi.TransactionInput, submitMode pldapi.SubmitMode) (*ValidatedTransaction, error)
+	PrepareInternalPrivateTransaction(ctx context.Context, dbTX *gorm.DB, tx *pldapi.TransactionInput, submitMode pldapi.SubmitMode) (func(), *ValidatedTransaction, error)
 	UpsertInternalPrivateTxsFinalizeIDs(ctx context.Context, dbTX *gorm.DB, txis []*ValidatedTransaction) error
-	WritePreparedTransactions(ctx context.Context, dbTX *gorm.DB, prepared []*PrepareTransactionWithRefs) (err error)
+	WritePreparedTransactions(ctx context.Context, dbTX *gorm.DB, prepared []*PrepareTransactionWithRefs) (postCommit func(), err error)
 }

--- a/core/go/internal/domainmgr/domain.go
+++ b/core/go/internal/domainmgr/domain.go
@@ -154,9 +154,11 @@ func (d *domain) processDomainConfig(confRes *prototk.ConfigureDomainResponse) (
 		}
 		stream.Sources = append(stream.Sources, blockindexer.EventStreamSource{ABI: eventsABI})
 
-		if _, err := d.dm.txManager.UpsertABI(d.ctx, d.dm.persistence.DB(), eventsABI); err != nil {
+		postCommit, _, err := d.dm.txManager.UpsertABI(d.ctx, d.dm.persistence.DB(), eventsABI)
+		if err != nil {
 			return nil, err
 		}
+		postCommit() // we didn't actually use a coordinated TX to call immediately
 	}
 
 	// We build a stream name in a way assured to result in a new stream if the ABI changes

--- a/core/go/internal/domainmgr/domain_test.go
+++ b/core/go/internal/domainmgr/domain_test.go
@@ -286,7 +286,7 @@ func TestDomainInitStates(t *testing.T) {
 
 }
 func mockUpsertABIOk(mc *mockComponents) {
-	mc.txManager.On("UpsertABI", mock.Anything, mock.Anything, mock.Anything).Return(&pldapi.StoredABI{
+	mc.txManager.On("UpsertABI", mock.Anything, mock.Anything, mock.Anything).Return(func() {}, &pldapi.StoredABI{
 		Hash: tktypes.Bytes32(tktypes.RandBytes(32)),
 	}, nil)
 }
@@ -380,7 +380,7 @@ func TestDomainInitUpsertEventsABIFail(t *testing.T) {
 			}
 		]`,
 	}, func(mc *mockComponents) {
-		mc.txManager.On("UpsertABI", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop"))
+		mc.txManager.On("UpsertABI", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, fmt.Errorf("pop"))
 	})
 	defer done()
 	assert.Regexp(t, "pop", *td.d.initError.Load())

--- a/core/go/internal/privatetxnmgr/sequencer_dispatch.go
+++ b/core/go/internal/privatetxnmgr/sequencer_dispatch.go
@@ -78,12 +78,13 @@ func (s *Sequencer) DispatchTransactions(ctx context.Context, dispatchableTransa
 				})
 			case preparedTransaction.Inputs.Intent == prototk.TransactionSpecification_SEND_TRANSACTION && hasPrivateTransaction && !hasPublicTransaction:
 				log.L(ctx).Infof("Result of transaction %s is a chained private transaction", preparedTransaction.ID)
-				validatedPrivateTx, err := s.components.TxManager().PrepareInternalPrivateTransaction(ctx, s.components.Persistence().DB(), preparedTransaction.PreparedPrivateTransaction, pldapi.SubmitModeAuto)
+				preparePostCommit, validatedPrivateTx, err := s.components.TxManager().PrepareInternalPrivateTransaction(ctx, s.components.Persistence().DB(), preparedTransaction.PreparedPrivateTransaction, pldapi.SubmitModeAuto)
 				if err != nil {
 					log.L(ctx).Errorf("Error preparing transaction %s: %s", preparedTransaction.ID, err)
 					// TODO: this is just an error situation for one transaction - this function is a batch function
 					return err
 				}
+				preparePostCommit() // we didn't use a coordinated TX to call immediately
 				dispatchBatch.PrivateDispatches = append(dispatchBatch.PrivateDispatches, validatedPrivateTx)
 			case preparedTransaction.Inputs.Intent == prototk.TransactionSpecification_PREPARE_TRANSACTION && (hasPublicTransaction || hasPrivateTransaction):
 				log.L(ctx).Infof("Result of transaction %s is a prepared transaction public=%t private=%t", preparedTransaction.ID, hasPublicTransaction, hasPrivateTransaction)

--- a/core/go/internal/txmgr/block_indexing_test.go
+++ b/core/go/internal/txmgr/block_indexing_test.go
@@ -98,8 +98,9 @@ func TestPublicConfirmWithErrorDecodeRealDB(t *testing.T) {
 		})
 	defer done()
 
-	abiRef, err := txm.storeABI(ctx, txm.p.DB(), testABI)
+	postCommit, abiRef, err := txm.storeABI(ctx, txm.p.DB(), testABI)
 	require.NoError(t, err)
+	postCommit()
 
 	txID, err = txm.SendTransaction(ctx, &pldapi.TransactionInput{
 		TransactionBase: pldapi.TransactionBase{
@@ -111,7 +112,7 @@ func TestPublicConfirmWithErrorDecodeRealDB(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	postCommit, err := txm.blockIndexerPreCommit(ctx, txm.p.DB(), []*pldapi.IndexedBlock{},
+	postCommit, err = txm.blockIndexerPreCommit(ctx, txm.p.DB(), []*pldapi.IndexedBlock{},
 		[]*blockindexer.IndexedTransactionNotify{txi})
 	require.NoError(t, err)
 	postCommit()

--- a/core/go/internal/txmgr/persisted_abi_test.go
+++ b/core/go/internal/txmgr/persisted_abi_test.go
@@ -83,7 +83,7 @@ func TestUpsertABIBadData(t *testing.T) {
 	ctx, txm, done := newTestTransactionManager(t, false)
 	defer done()
 
-	_, err := txm.UpsertABI(ctx, txm.p.DB(), abi.ABI{{Inputs: abi.ParameterArray{{Type: "wrong"}}}})
+	_, _, err := txm.UpsertABI(ctx, txm.p.DB(), abi.ABI{{Inputs: abi.ParameterArray{{Type: "wrong"}}}})
 	assert.Regexp(t, "PD012201", err)
 
 }
@@ -95,7 +95,7 @@ func TestUpsertABIFail(t *testing.T) {
 	})
 	defer done()
 
-	_, err := txm.storeABI(ctx, txm.p.DB(), abi.ABI{{Type: abi.Function, Name: "get"}})
+	_, _, err := txm.storeABI(ctx, txm.p.DB(), abi.ABI{{Type: abi.Function, Name: "get"}})
 	assert.Regexp(t, "pop", err)
 
 }

--- a/core/go/internal/txmgr/persisted_receipt_test.go
+++ b/core/go/internal/txmgr/persisted_receipt_test.go
@@ -167,7 +167,7 @@ func TestFinalizeTransactionsInsertOkOffChain(t *testing.T) {
 		},
 		ABI: exampleABI,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = txm.p.DB().Transaction(func(tx *gorm.DB) error {
 		return txm.FinalizeTransactions(ctx, tx, []*components.ReceiptInput{
@@ -355,8 +355,9 @@ func TestDecodeCall(t *testing.T) {
 	ctx, txm, done := newTestTransactionManager(t, true)
 	defer done()
 
-	_, err := txm.storeABI(ctx, txm.p.DB(), sampleABI)
+	postCommit, _, err := txm.storeABI(ctx, txm.p.DB(), sampleABI)
 	require.NoError(t, err)
+	postCommit()
 
 	validCall, err := sampleABI.Functions()["set"].EncodeCallDataJSON([]byte(`[12345]`))
 	require.NoError(t, err)
@@ -390,8 +391,9 @@ func TestDecodeEvent(t *testing.T) {
 	ctx, txm, done := newTestTransactionManager(t, true)
 	defer done()
 
-	_, err := txm.storeABI(ctx, txm.p.DB(), sampleABI)
+	postCommit, _, err := txm.storeABI(ctx, txm.p.DB(), sampleABI)
 	require.NoError(t, err)
+	postCommit()
 
 	validTopic0 := tktypes.Bytes32(sampleABI.Events()["Updated"].SignatureHashBytes())
 	validTopic1, err := (&abi.ParameterArray{{Type: "uint256"}}).EncodeABIDataJSON([]byte(`["12345"]`))

--- a/core/go/internal/txmgr/rpcmodule.go
+++ b/core/go/internal/txmgr/rpcmodule.go
@@ -259,7 +259,11 @@ func (tm *txManager) rpcStoreABI() rpcserver.RPCHandler {
 	return rpcserver.RPCMethod1(func(ctx context.Context,
 		a abi.ABI,
 	) (*tktypes.Bytes32, error) {
-		return tm.storeABI(ctx, tm.p.DB(), a)
+		postCommit, abiHashRef, err := tm.storeABI(ctx, tm.p.DB(), a)
+		if err == nil {
+			postCommit()
+		}
+		return abiHashRef, err
 	})
 }
 


### PR DESCRIPTION
Regression caused by #441 means we could see this error after failing to submit a transaction:

```
ERROR: insert or update on table "transactions" violates foreign key constraint "transactions_abi_ref_fkey" (SQLSTATE 23503)
```

This was because we were updating the cache still on all paths, even though the `UpsertABI` function had been moved inside of an atomic transaction that might rollback.

The logs confirm the invalid cache is the reason for the error:

```
2024-12-03T17:01:28.690Z] DEBUG ABI 0xeb909c4af5902b1495bf9a68b110641f0e90242c35c0f0cb59addcedd6740355 already cached pid=1 req=UUSGtkki
```

Fix is to defer the cache update to the post-commit.
