### PR TITLE
Update examples and run during e2e build

### DIFF
--- a/doc-site/docs/tutorials/bond-issuance.md
+++ b/doc-site/docs/tutorials/bond-issuance.md
@@ -83,7 +83,7 @@ await paladin1.sendTransaction({
   abi: bondTrackerPublicJson.abi,
   bytecode: bondTrackerPublicJson.bytecode,
   function: "",
-  from: bondIssuerUnqualified,
+  from: bondIssuer.lookup,
   data: {
     owner: issuerCustodianGroup.address,
     issueDate_: issueDate,
@@ -108,7 +108,7 @@ events throughout the bond's lifetime.
 await newBondTracker(issuerCustodianGroup, bondIssuer, {
   name: "BOND",
   symbol: "BOND",
-  custodian: bondCustodianAddress,
+  custodian: await bondCustodian.address(),
   publicTracker: bondTrackerPublicAddress,
 });
 ```
@@ -149,7 +149,7 @@ await paladin1.sendTransaction({
   abi: atomFactoryJson.abi,
   bytecode: atomFactoryJson.bytecode,
   function: "",
-  from: bondIssuerUnqualified,
+  from: bondIssuer.lookup,
   data: {},
 });
 ```
@@ -189,7 +189,7 @@ await bondTracker.using(paladin2).beginDistribution(bondCustodian, {
 const investorList = await bondTracker.investorList(bondIssuer);
 await investorList
   .using(paladin2)
-  .addInvestor(bondCustodian, { addr: investorAddress });
+  .addInvestor(bondCustodian, { addr: await investor.address() });
 ```
 
 This allows the bond custodian to begin distributing the bond to potential investors. Each investor must be added
@@ -227,7 +227,7 @@ const bondSubscription = await newBondSubscription(
   {
     bondAddress_: notoBond.address,
     units_: 100,
-    custodian_: bondCustodianAddress,
+    custodian_: await bondCustodian.address(),
     atomFactory_: atomFactoryAddress,
   }
 );
@@ -336,7 +336,7 @@ await paladin2.sendTransaction({
   type: TransactionType.PUBLIC,
   abi: atomJson.abi,
   function: "execute",
-  from: bondCustodianUnqualified,
+  from: bondCustodian.lookup,
   to: atomAddress,
   data: {},
 });

--- a/example/bond/build.gradle
+++ b/example/bond/build.gradle
@@ -26,8 +26,8 @@ configurations {
 }
 
 dependencies {
-    contractCompile project(path: ":solidity", configuration: "compiledContracts")
-    buildSDK project(path: ":sdk:typescript", configuration: "buildSDK")
+    contractCompile project(path: ':solidity', configuration: 'compiledContracts')
+    buildSDK project(path: ':sdk:typescript', configuration: 'buildSDK')
 }
 
 task install(type: Exec) {
@@ -35,9 +35,9 @@ task install(type: Exec) {
     args 'install'
 
     inputs.files(configurations.buildSDK)
-    inputs.files("package.json")
-    outputs.files("package-lock.json")
-    outputs.dir("node_modules")
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
 }
 
 task copyABI(type: Exec, dependsOn: install) {
@@ -46,6 +46,7 @@ task copyABI(type: Exec, dependsOn: install) {
     args 'abi'
 
     inputs.files(configurations.contractCompile)
+    inputs.dir('scripts')
     outputs.dir('src/abis')
 }
 
@@ -54,11 +55,19 @@ task build(type: Exec, dependsOn: [install, copyABI]) {
     args 'run'
     args 'build'
 
-    inputs.dir("src")
-    outputs.dir("build")
+    inputs.dir('src')
+    outputs.dir('build')
+}
+
+task e2e(type: Exec, dependsOn: [build]) {
+    dependsOn ':operator:deploy'
+
+    executable 'npm'
+    args 'run'
+    args 'start'
 }
 
 task clean(type: Delete) {
-    delete "node_modules"
-    delete "build"
+    delete 'node_modules'
+    delete 'build'
 }

--- a/example/bond/package-lock.json
+++ b/example/bond/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../sdk/typescript": {
       "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.6-alpha.1",
+      "version": "0.0.6-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.7",

--- a/example/bond/package-lock.json
+++ b/example/bond/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "paladin-sdk": "file:../../sdk/typescript"
+        "@lfdecentralizedtrust-labs/paladin-sdk": "file:../../sdk/typescript"
       },
       "devDependencies": {
         "@types/node": "^22.8.7",
@@ -69,6 +69,10 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@lfdecentralizedtrust-labs/paladin-sdk": {
+      "resolved": "../../sdk/typescript",
+      "link": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -202,10 +206,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/paladin-sdk": {
-      "resolved": "../../sdk/typescript",
-      "link": true
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/example/bond/package.json
+++ b/example/bond/package.json
@@ -18,6 +18,6 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "paladin-sdk": "file:../../sdk/typescript"
+    "@lfdecentralizedtrust-labs/paladin-sdk": "file:../../sdk/typescript"
   }
 }

--- a/example/bond/src/helpers/bondsubscription.ts
+++ b/example/bond/src/helpers/bondsubscription.ts
@@ -1,7 +1,8 @@
 import PaladinClient, {
+  PaladinVerifier,
   PentePrivacyGroup,
   PentePrivateContract,
-} from "paladin-sdk";
+} from "@lfdecentralizedtrust-labs/paladin-sdk";
 import bondSubscription from "../abis/BondSubscription.json";
 
 const bondSubscriptionConstructor = bondSubscription.abi.find(
@@ -27,7 +28,7 @@ export interface PrepareBondParams {
 
 export const newBondSubscription = async (
   pente: PentePrivacyGroup,
-  from: string,
+  from: PaladinVerifier,
   params: BondSubscriptionConstructorParams
 ) => {
   if (bondSubscriptionConstructor === undefined) {
@@ -54,15 +55,15 @@ export class BondSubscription extends PentePrivateContract<BondSubscriptionConst
     return new BondSubscription(this.evm.using(paladin), this.address);
   }
 
-  preparePayment(from: string, params: PreparePaymentParams) {
+  preparePayment(from: PaladinVerifier, params: PreparePaymentParams) {
     return this.invoke(from, "preparePayment", params);
   }
 
-  prepareBond(from: string, params: PrepareBondParams) {
+  prepareBond(from: PaladinVerifier, params: PrepareBondParams) {
     return this.invoke(from, "prepareBond", params);
   }
 
-  async distribute(from: string) {
+  async distribute(from: PaladinVerifier) {
     return this.invoke(from, "distribute", {});
   }
 }

--- a/example/bond/src/helpers/bondtracker.ts
+++ b/example/bond/src/helpers/bondtracker.ts
@@ -1,7 +1,8 @@
 import PaladinClient, {
+  PaladinVerifier,
   PentePrivacyGroup,
   PentePrivateContract,
-} from "paladin-sdk";
+} from "@lfdecentralizedtrust-labs/paladin-sdk";
 import bondTracker from "../abis/BondTracker.json";
 import { InvestorList } from "./investorlist";
 
@@ -19,7 +20,7 @@ export interface BeginDistributionParams {
 
 export const newBondTracker = async (
   pente: PentePrivacyGroup,
-  from: string,
+  from: PaladinVerifier,
   params: BondTrackerConstructorParams
 ) => {
   const address = await pente.deploy(
@@ -43,11 +44,11 @@ export class BondTracker extends PentePrivateContract<BondTrackerConstructorPara
     return new BondTracker(this.evm.using(paladin), this.address);
   }
 
-  beginDistribution(from: string, params: BeginDistributionParams) {
+  beginDistribution(from: PaladinVerifier, params: BeginDistributionParams) {
     return this.invoke(from, "beginDistribution", params);
   }
 
-  async investorList(from: string) {
+  async investorList(from: PaladinVerifier) {
     const result = await this.call(from, "investorList", []);
     return new InvestorList(this.evm, result[0]);
   }

--- a/example/bond/src/helpers/investorlist.ts
+++ b/example/bond/src/helpers/investorlist.ts
@@ -1,7 +1,8 @@
 import PaladinClient, {
+  PaladinVerifier,
   PentePrivacyGroup,
   PentePrivateContract,
-} from "paladin-sdk";
+} from "@lfdecentralizedtrust-labs/paladin-sdk";
 import investorList from "../abis/InvestorList.json";
 
 export interface AddInvestorParams {
@@ -20,7 +21,7 @@ export class InvestorList extends PentePrivateContract<{}> {
     return new InvestorList(this.evm.using(paladin), this.address);
   }
 
-  addInvestor(from: string, params: AddInvestorParams) {
+  addInvestor(from: PaladinVerifier, params: AddInvestorParams) {
     return this.invoke(from, "addInvestor", params);
   }
 }

--- a/example/bond/src/index.ts
+++ b/example/bond/src/index.ts
@@ -7,12 +7,13 @@ import PaladinClient, {
   PenteFactory,
   TransactionType,
   Verifiers,
-} from "paladin-sdk";
+} from "@lfdecentralizedtrust-labs/paladin-sdk";
 import bondTrackerPublicJson from "./abis/BondTrackerPublic.json";
 import atomFactoryJson from "./abis/AtomFactory.json";
 import atomJson from "./abis/Atom.json";
 import { newBondSubscription } from "./helpers/bondsubscription";
 import { newBondTracker } from "./helpers/bondtracker";
+import { checkDeploy, checkReceipt } from "./util";
 
 const logger = console;
 
@@ -26,24 +27,13 @@ const paladin3 = new PaladinClient({
   url: "http://127.0.0.1:31748",
 });
 
-async function main() {
-  const cashIssuer = "bank1@node1";
-  const bondIssuerUnqualified = "bank1";
-  const bondIssuer = `${bondIssuerUnqualified}@node1`;
-  const bondCustodianUnqualified = "bank2";
-  const bondCustodian = `${bondCustodianUnqualified}@node2`;
-  const investor = "bank3@node3";
-
-  const bondCustodianAddress = await paladin2.resolveVerifier(
-    bondCustodian,
-    Algorithms.ECDSA_SECP256K1,
-    Verifiers.ETH_ADDRESS
+async function main(): Promise<boolean> {
+  const [cashIssuer, bondIssuer] = paladin1.getVerifiers(
+    "cashIssuer@node1",
+    "bondIssuer@node1"
   );
-  const investorAddress = await paladin1.resolveVerifier(
-    investor,
-    Algorithms.ECDSA_SECP256K1,
-    Verifiers.ETH_ADDRESS
-  );
+  const [bondCustodian] = paladin2.getVerifiers("bondCustodian@node2");
+  const [investor] = paladin3.getVerifiers("investor@node3");
 
   // Create a Noto token to represent cash
   logger.log("Deploying Noto cash token...");
@@ -52,11 +42,7 @@ async function main() {
     notary: cashIssuer,
     restrictMinting: true,
   });
-  if (notoCash === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log(`Success! address: ${notoCash.address}`);
+  if (!checkDeploy(notoCash)) return false;
 
   // Issue some cash
   logger.log("Issuing cash...");
@@ -65,11 +51,7 @@ async function main() {
     amount: 100000,
     data: "0x",
   });
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+  if (!checkReceipt(receipt)) return false;
 
   // Create a Pente privacy group between the bond issuer and bond custodian
   logger.log("Creating issuer+custodian privacy group...");
@@ -83,11 +65,7 @@ async function main() {
     endorsementType: "group_scoped_identities",
     externalCallsEnabled: true,
   });
-  if (issuerCustodianGroup === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log(`Success! address: ${issuerCustodianGroup.address}`);
+  if (!checkDeploy(issuerCustodianGroup)) return false;
 
   // Deploy the public bond tracker on the base ledger (controlled by the privacy group)
   logger.log("Creating public bond tracker...");
@@ -98,7 +76,7 @@ async function main() {
     abi: bondTrackerPublicJson.abi,
     bytecode: bondTrackerPublicJson.bytecode,
     function: "",
-    from: bondIssuerUnqualified,
+    from: bondIssuer.lookup,
     data: {
       owner: issuerCustodianGroup.address,
       issueDate_: issueDate,
@@ -110,7 +88,7 @@ async function main() {
   receipt = await paladin1.pollForReceipt(txID, 10000);
   if (receipt?.contractAddress === undefined) {
     logger.error("Failed!");
-    return;
+    return false;
   }
   logger.log(`Success! address: ${receipt.contractAddress}`);
   const bondTrackerPublicAddress = receipt.contractAddress;
@@ -120,14 +98,10 @@ async function main() {
   const bondTracker = await newBondTracker(issuerCustodianGroup, bondIssuer, {
     name: "BOND",
     symbol: "BOND",
-    custodian: bondCustodianAddress,
+    custodian: await bondCustodian.address(),
     publicTracker: bondTrackerPublicAddress,
   });
-  if (bondTracker === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log(`Success! address: ${bondTracker.address}`);
+  if (!checkDeploy(bondTracker)) return false;
 
   // Deploy Noto token to represent bond
   logger.log("Deploying Noto bond token...");
@@ -140,11 +114,7 @@ async function main() {
     },
     restrictMinting: false,
   });
-  if (notoBond === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log(`Success! address: ${notoBond.address}`);
+  if (!checkDeploy(notoBond)) return false;
 
   // Deploy the atom factory on the base ledger
   logger.log("Creating atom factory...");
@@ -153,13 +123,13 @@ async function main() {
     abi: atomFactoryJson.abi,
     bytecode: atomFactoryJson.bytecode,
     function: "",
-    from: bondIssuerUnqualified,
+    from: bondIssuer.lookup,
     data: {},
   });
   receipt = await paladin1.pollForReceipt(txID, 10000);
   if (receipt?.contractAddress === undefined) {
     logger.error("Failed!");
-    return;
+    return false;
   }
   logger.log(`Success! address: ${receipt.contractAddress}`);
   const atomFactoryAddress = receipt.contractAddress;
@@ -171,11 +141,7 @@ async function main() {
     amount: 1000,
     data: "0x",
   });
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+  if (!checkReceipt(receipt)) return false;
 
   // Begin bond distribution to investors
   logger.log("Beginning distribution...");
@@ -183,17 +149,13 @@ async function main() {
     discountPrice: 1,
     minimumDenomination: 1,
   });
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+  if (!checkReceipt(receipt)) return false;
 
   // Add allowed investors
   const investorList = await bondTracker.investorList(bondIssuer);
   await investorList
     .using(paladin2)
-    .addInvestor(bondCustodian, { addr: investorAddress });
+    .addInvestor(bondCustodian, { addr: await investor.address() });
 
   // Create a Pente privacy group between the bond investor and bond custodian
   logger.log("Creating investor+custodian privacy group...");
@@ -210,7 +172,7 @@ async function main() {
     });
   if (investorCustodianGroup === undefined) {
     logger.error("Failed!");
-    return;
+    return false;
   }
   logger.log(`Success! address: ${investorCustodianGroup.address}`);
 
@@ -222,15 +184,11 @@ async function main() {
     {
       bondAddress_: notoBond.address,
       units_: 100,
-      custodian_: bondCustodianAddress,
+      custodian_: await bondCustodian.address(),
       atomFactory_: atomFactoryAddress,
     }
   );
-  if (bondSubscription === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log(`Success! address: ${bondSubscription.address}`);
+  if (!checkDeploy(bondSubscription)) return false;
 
   // Prepare the payment transfer (investor -> custodian)
   logger.log("Preparing payment transfer...");
@@ -243,13 +201,13 @@ async function main() {
     });
   if (paymentTransfer === undefined) {
     logger.error("Failed!");
-    return;
+    return false;
   }
   logger.log("Success!");
 
   if (paymentTransfer.transaction.to === undefined) {
     logger.error("Prepared payment transfer had no 'to' address");
-    return;
+    return false;
   }
 
   // Prepare the bond transfer (custodian -> investor)
@@ -264,7 +222,7 @@ async function main() {
     });
   if (bondTransfer1 === undefined) {
     logger.error("Failed!");
-    return;
+    return false;
   }
   logger.log("Success!");
 
@@ -272,7 +230,7 @@ async function main() {
     logger.error(
       `Prepared bond transfer did not result in a private Pente transaction: ${bondTransfer1.transaction}`
     );
-    return;
+    return false;
   }
 
   logger.log("Preparing bond transfer (step 2/2)...");
@@ -280,19 +238,19 @@ async function main() {
   const bondTransfer2 = await paladin2.pollForPreparedTransaction(txID, 10000);
   if (bondTransfer2 === undefined) {
     logger.error("Failed!");
-    return;
+    return false;
   }
   logger.log("Success!");
 
   if (bondTransfer2.transaction.to === undefined) {
     logger.error("Prepared bond transfer had no 'to' address");
-    return;
+    return false;
   }
   if (!bondTransfer2.transaction.function.startsWith("transition(")) {
     logger.error(
       `Prepared bond transfer did not seem to be a Pente transition: ${bondTransfer2.transaction}`
     );
-    return;
+    return false;
   }
 
   // Pass the prepared payment transfer to the subscription contract
@@ -301,11 +259,7 @@ async function main() {
     to: paymentTransfer.transaction.to,
     encodedCall: paymentTransfer.metadata?.transferWithApproval?.encodedCall,
   });
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+  if (!checkReceipt(receipt)) return false;
 
   // Pass the prepared bond transfer to the subscription contract
   logger.log("Adding bond information to subscription request...");
@@ -313,26 +267,19 @@ async function main() {
     to: bondTransfer2.transaction.to,
     encodedCall: bondTransfer2.metadata.transitionWithApproval.encodedCall,
   });
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+  if (!checkReceipt(receipt)) return false;
 
   // Prepare bond distribution (initializes atomic swap of payment and bond units)
   logger.log("Generating atom for bond distribution...");
   receipt = await bondSubscription.using(paladin2).distribute(bondCustodian);
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
+  if (!checkReceipt(receipt)) return false;
 
   // TODO: use the AtomDeployed event instead of this lookup method
   const atomAddressResult = await paladin2.call({
     type: TransactionType.PUBLIC,
     abi: atomFactoryJson.abi,
     function: "lastDeploy",
-    from: bondIssuerUnqualified,
+    from: bondCustodian.lookup,
     to: atomFactoryAddress,
     data: {},
   });
@@ -347,28 +294,19 @@ async function main() {
     data: paymentTransfer.metadata.approvalParams.data,
     delegate: atomAddress,
   });
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+  if (!checkReceipt(receipt)) return false;
 
   // Approve the bond transfer
   logger.log("Approving bond transfer...");
-  receipt = await issuerCustodianGroup.approveTransition(
-    bondCustodianUnqualified,
-    {
+  receipt = await issuerCustodianGroup
+    .using(paladin2)
+    .approveTransition(bondCustodian, {
       txId: newTransactionId(),
       transitionHash: bondTransfer2.metadata.approvalParams.transitionHash,
       signatures: bondTransfer2.metadata.approvalParams.signatures,
       delegate: atomAddress,
-    }
-  );
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+    });
+  if (!checkReceipt(receipt)) return false;
 
   // Execute the atomic transfer
   logger.log("Distributing bond...");
@@ -376,22 +314,23 @@ async function main() {
     type: TransactionType.PUBLIC,
     abi: atomJson.abi,
     function: "execute",
-    from: bondCustodianUnqualified,
+    from: bondCustodian.lookup,
     to: atomAddress,
     data: {},
   });
-  receipt = await paladin2.pollForReceipt(txID, 10000);
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+  if (!checkReceipt(receipt)) return false;
+
+  return true;
 }
 
 if (require.main === module) {
-  main().catch((err) => {
-    console.error("Exiting with uncaught error");
-    console.error(err);
-    process.exit(1);
-  });
+  main()
+    .then((success: boolean) => {
+      process.exit(success ? 0 : 1);
+    })
+    .catch((err) => {
+      console.error("Exiting with uncaught error");
+      console.error(err);
+      process.exit(1);
+    });
 }

--- a/example/bond/src/util.ts
+++ b/example/bond/src/util.ts
@@ -1,0 +1,32 @@
+import { ITransactionReceipt } from "@lfdecentralizedtrust-labs/paladin-sdk";
+
+const logger = console;
+
+export interface DeployedContract {
+  address: string;
+}
+
+export function checkDeploy(
+  contract: DeployedContract | undefined
+): contract is DeployedContract {
+  if (contract === undefined) {
+    logger.error("Failed!");
+    return false;
+  }
+  logger.log(`Success! address: ${contract.address}`);
+  return true;
+}
+
+export function checkReceipt(
+  receipt: ITransactionReceipt | undefined
+): receipt is ITransactionReceipt {
+  if (receipt === undefined) {
+    logger.error("Failed!");
+    return false;
+  } else if (receipt.failureMessage !== undefined) {
+    logger.error(`Failed: ${receipt.failureMessage}`);
+    return false;
+  }
+  logger.log("Success!");
+  return true;
+}

--- a/example/zeto/build.gradle
+++ b/example/zeto/build.gradle
@@ -15,10 +15,6 @@
 
 configurations {
     // Resolvable configurations
-    contractCompile {
-        canBeConsumed = false
-        canBeResolved = true
-    }
     buildSDK {
         canBeConsumed = false
         canBeResolved = true
@@ -26,7 +22,7 @@ configurations {
 }
 
 dependencies {
-    buildSDK project(path: ":sdk:typescript", configuration: "buildSDK")
+    buildSDK project(path: ':sdk:typescript', configuration: 'buildSDK')
 }
 
 task install(type: Exec) {
@@ -34,9 +30,9 @@ task install(type: Exec) {
     args 'install'
 
     inputs.files(configurations.buildSDK)
-    inputs.files("package.json")
-    outputs.files("package-lock.json")
-    outputs.dir("node_modules")
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
 }
 
 task build(type: Exec, dependsOn: [install]) {
@@ -44,11 +40,19 @@ task build(type: Exec, dependsOn: [install]) {
     args 'run'
     args 'build'
 
-    inputs.dir("src")
-    outputs.dir("build")
+    inputs.dir('src')
+    outputs.dir('build')
+}
+
+task e2e(type: Exec, dependsOn: [build]) {
+    dependsOn ':operator:deploy'
+
+    executable 'npm'
+    args 'run'
+    args 'start'
 }
 
 task clean(type: Delete) {
-    delete "node_modules"
-    delete "build"
+    delete 'node_modules'
+    delete 'build'
 }

--- a/example/zeto/package-lock.json
+++ b/example/zeto/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../sdk/typescript": {
       "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.6-alpha.1",
+      "version": "0.0.6-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.7",

--- a/example/zeto/package-lock.json
+++ b/example/zeto/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "paladin-sdk": "file:../../sdk/typescript"
+        "@lfdecentralizedtrust-labs/paladin-sdk": "file:../../sdk/typescript"
       },
       "devDependencies": {
         "@types/node": "^22.8.7",
@@ -311,6 +311,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@lfdecentralizedtrust-labs/paladin-sdk": {
+      "resolved": "../../sdk/typescript",
+      "link": true
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "dev": true,
@@ -428,10 +432,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/paladin-sdk": {
-      "resolved": "../../sdk/typescript",
-      "link": true
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/example/zeto/package.json
+++ b/example/zeto/package.json
@@ -18,6 +18,6 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "paladin-sdk": "file:../../sdk/typescript"
+    "@lfdecentralizedtrust-labs/paladin-sdk": "file:../../sdk/typescript"
   }
 }

--- a/example/zeto/src/index.ts
+++ b/example/zeto/src/index.ts
@@ -1,10 +1,7 @@
 import PaladinClient, {
-  Algorithms,
-  newTransactionId,
   ZetoFactory,
-  TransactionType,
-  Verifiers,
-} from "paladin-sdk";
+} from "@lfdecentralizedtrust-labs/paladin-sdk";
+import { checkDeploy, checkReceipt } from "./util";
 
 const logger = console;
 
@@ -18,10 +15,10 @@ const paladin3 = new PaladinClient({
   url: "http://127.0.0.1:31748",
 });
 
-async function main() {
-  const cbdcIssuer = "centralbank@node3";
-  const bank1 = `bank1@node1`;
-  const bank2 = `bank2@node2`;
+async function main(): Promise<boolean> {
+  const [cbdcIssuer] = paladin1.getVerifiers("centralbank@node3");
+  const [bank1] = paladin2.getVerifiers("bank1@node1");
+  const [bank2] = paladin3.getVerifiers("bank2@node2");
 
   // Deploy a Zeto token to represent cash (CBDC)
   logger.log("Deploying Zeto CBDC token...");
@@ -29,11 +26,7 @@ async function main() {
   const zetoCBDC = await zetoFactory.newZeto(cbdcIssuer, {
     tokenName: "Zeto_AnonNullifier",
   });
-  if (zetoCBDC === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log(`Success! address: ${zetoCBDC.address}`);
+  if (!checkDeploy(zetoCBDC)) return false;
 
   // Issue some cash
   logger.log("Issuing CBDC to bank1 and bank2 ...");
@@ -47,35 +40,35 @@ async function main() {
         to: bank2,
         amount: 100000,
       },
-    ]
+    ],
   });
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+  if (!checkReceipt(receipt)) return false;
 
   // Transfer some cash from bank1 to bank2
-  logger.log("Bank1 transferring CBDC to bank2 to pay for some asset trades ...");
+  logger.log(
+    "Bank1 transferring CBDC to bank2 to pay for some asset trades ..."
+  );
   receipt = await zetoCBDC.using(paladin1).transfer(bank1, {
     transfers: [
       {
         to: bank2,
         amount: 1000,
       },
-    ]
+    ],
   });
-  if (receipt === undefined) {
-    logger.error("Failed!");
-    return;
-  }
-  logger.log("Success!");
+  if (!checkReceipt(receipt)) return false;
+
+  return true;
 }
 
 if (require.main === module) {
-  main().catch((err) => {
-    console.error("Exiting with uncaught error");
-    console.error(err);
-    process.exit(1);
-  });
+  main()
+    .then((success: boolean) => {
+      process.exit(success ? 0 : 1);
+    })
+    .catch((err) => {
+      console.error("Exiting with uncaught error");
+      console.error(err);
+      process.exit(1);
+    });
 }

--- a/example/zeto/src/util.ts
+++ b/example/zeto/src/util.ts
@@ -1,0 +1,32 @@
+import { ITransactionReceipt } from "@lfdecentralizedtrust-labs/paladin-sdk";
+
+const logger = console;
+
+export interface DeployedContract {
+  address: string;
+}
+
+export function checkDeploy(
+  contract: DeployedContract | undefined
+): contract is DeployedContract {
+  if (contract === undefined) {
+    logger.error("Failed!");
+    return false;
+  }
+  logger.log(`Success! address: ${contract.address}`);
+  return true;
+}
+
+export function checkReceipt(
+  receipt: ITransactionReceipt | undefined
+): receipt is ITransactionReceipt {
+  if (receipt === undefined) {
+    logger.error("Failed!");
+    return false;
+  } else if (receipt.failureMessage !== undefined) {
+    logger.error(`Failed: ${receipt.failureMessage}`);
+    return false;
+  }
+  logger.log("Success!");
+  return true;
+}

--- a/operator/build.gradle
+++ b/operator/build.gradle
@@ -266,10 +266,10 @@ task verifyPaladin(dependsOn: verifyBesu) {
     }
 }
 
-// The 'deplay' runs the whole flow
+// The 'deploy' runs the whole flow
 task deploy(dependsOn: [copySolidity, copyZetoSolidity, verifyPaladin]) {
     doLast {
-        println 'Deplopy setup completed. Operator is running in the paladin namespace.'
+        println 'Deploy setup completed. Operator is running in the paladin namespace.'
     }
 }
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-  "version": "0.0.6-alpha.1",
+  "version": "0.0.6-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.6-alpha.1",
+      "version": "0.0.6-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.7",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-  "version": "0.0.6-alpha.1",
+  "version": "0.0.6-alpha.2",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -3,6 +3,7 @@ export default PaladinClient;
 
 export * from "./interfaces/index";
 export * from "./utils";
+export * from "./verifier";
 export * from "./domains/noto";
 export * from "./domains/pente";
 export * from "./domains/zeto";

--- a/sdk/typescript/src/interfaces/domains/pente.ts
+++ b/sdk/typescript/src/interfaces/domains/pente.ts
@@ -7,5 +7,5 @@ export interface IGroupInfo {
 
 export interface IGroupInfoUnresolved {
   salt: string;
-  members: PaladinVerifier[];
+  members: (string | PaladinVerifier)[];
 }

--- a/sdk/typescript/src/interfaces/domains/pente.ts
+++ b/sdk/typescript/src/interfaces/domains/pente.ts
@@ -1,4 +1,11 @@
+import { PaladinVerifier } from "../../verifier";
+
 export interface IGroupInfo {
   salt: string;
   members: string[];
+}
+
+export interface IGroupInfoUnresolved {
+  salt: string;
+  members: PaladinVerifier[];
 }

--- a/sdk/typescript/src/interfaces/transaction.ts
+++ b/sdk/typescript/src/interfaces/transaction.ts
@@ -114,5 +114,5 @@ export interface IEventWithData {
   signature: string;
   soliditySignature: string;
   address: string;
-  data: string;
+  data: any;
 }

--- a/sdk/typescript/src/interfaces/transaction.ts
+++ b/sdk/typescript/src/interfaces/transaction.ts
@@ -105,3 +105,14 @@ export interface IDecodedEvent {
   data: any;
   summary: string; // errors only
 }
+
+export interface IEventWithData {
+  blockNumber: number;
+  transactionIndex: number;
+  logIndex: number;
+  transactionHash: string;
+  signature: string;
+  soliditySignature: string;
+  address: string;
+  data: string;
+}

--- a/sdk/typescript/src/interfaces/transaction.ts
+++ b/sdk/typescript/src/interfaces/transaction.ts
@@ -94,45 +94,6 @@ export interface ITransactionStates {
   };
 }
 
-export interface ITransactionDependencies {
-  dependsOn: string[];
-  prereqOf: string[];
-}
-
-export interface IPublicTxWithBinding {
-  to?: string;
-  data?: string;
-  from: string;
-  nonce: string;
-  created: string;
-  completedAt?: string;
-  transactionHash?: string;
-  success?: boolean;
-  revertData?: string;
-  submissions?: IPublicTxSubmissionData[];
-  activity?: ITransactionActivityRecord[];
-  gas?: string;
-  value?: string;
-  maxPriorityFeePerGas?: string;
-  maxFeePerGas?: string;
-  gasPrice?: string;
-  transaction: string;
-  transactionType: TransactionType;
-}
-
-export interface IPublicTxSubmissionData {
-  time: string;
-  transactionHash: string;
-  maxPriorityFeePerGas?: string;
-  maxFeePerGas?: string;
-  gasPrice?: string;
-}
-
-export interface ITransactionActivityRecord {
-  time: string;
-  message: string;
-}
-
 export enum TransactionType {
   Private = "private",
   Public = "public",

--- a/sdk/typescript/src/paladin.ts
+++ b/sdk/typescript/src/paladin.ts
@@ -227,6 +227,6 @@ export default class PaladinClient {
       "bidx_decodeTransactionEvents",
       [transactionHash, abi, resultFormat]
     );
-    return res.data;
+    return res.data.result;
   }
 }

--- a/sdk/typescript/src/paladin.ts
+++ b/sdk/typescript/src/paladin.ts
@@ -17,6 +17,7 @@ import {
 } from "./interfaces/transaction";
 import { Algorithms, Verifiers } from "./interfaces";
 import { ethers } from "ethers";
+import { PaladinVerifier } from "./verifier";
 
 const POLL_INTERVAL_MS = 100;
 
@@ -53,6 +54,10 @@ export default class PaladinClient {
       jsonrpc: "2.0",
       id: Date.now(),
     };
+  }
+
+  getVerifiers(...lookups: string[]) {
+    return lookups.map((lookup) => new PaladinVerifier(this, lookup));
   }
 
   parseAxiosErrorMessage(err: any) {

--- a/sdk/typescript/src/paladin.ts
+++ b/sdk/typescript/src/paladin.ts
@@ -14,9 +14,10 @@ import {
   ITransactionReceipt,
   ITransactionStates,
   IDecodedEvent,
+  IEventWithData,
 } from "./interfaces/transaction";
 import { Algorithms, Verifiers } from "./interfaces";
-import { ethers } from "ethers";
+import { ethers, InterfaceAbi } from "ethers";
 import { PaladinVerifier } from "./verifier";
 
 const POLL_INTERVAL_MS = 100;
@@ -215,5 +216,17 @@ export default class PaladinClient {
       }
       throw err;
     }
+  }
+
+  async decodeTransactionEvents(
+    transactionHash: string,
+    abi: InterfaceAbi,
+    resultFormat: string
+  ) {
+    const res = await this.post<JsonRpcResult<IEventWithData[]>>(
+      "bidx_decodeTransactionEvents",
+      [transactionHash, abi, resultFormat]
+    );
+    return res.data;
   }
 }

--- a/sdk/typescript/src/verifier.ts
+++ b/sdk/typescript/src/verifier.ts
@@ -1,0 +1,18 @@
+import { Algorithms, JsonRpcResult, Verifiers } from "./interfaces";
+import PaladinClient from "./paladin";
+
+export class PaladinVerifier {
+  constructor(private paladin: PaladinClient, public readonly lookup: string) {}
+
+  toString() {
+    return this.lookup;
+  }
+
+  resolve(algorithm: Algorithms, verifierType: Verifiers) {
+    return this.paladin.resolveVerifier(this.lookup, algorithm, verifierType);
+  }
+
+  address() {
+    return this.resolve(Algorithms.ECDSA_SECP256K1, Verifiers.ETH_ADDRESS);
+  }
+}

--- a/solidity/contracts/shared/Atom.sol
+++ b/solidity/contracts/shared/Atom.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.20;
 
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract Atom is Initializable {
@@ -63,26 +63,16 @@ contract Atom is Initializable {
 
 contract AtomFactory {
     address public immutable logic;
-    address public lastDeploy; // TODO: remove and listen to AtomDeployed
 
     event AtomDeployed(address addr);
-
-    // Must match the signature initialize(Atom.Operation[])
-    string private constant INIT_SIGNATURE = "initialize((address,bytes)[])";
 
     constructor() {
         logic = address(new Atom());
     }
 
     function create(Atom.Operation[] calldata operations) public {
-        bytes memory _initializationCalldata = abi.encodeWithSignature(
-            INIT_SIGNATURE,
-            operations
-        );
-        address addr = address(
-            new ERC1967Proxy(logic, _initializationCalldata)
-        );
-        lastDeploy = addr;
-        emit AtomDeployed(addr);
+        address instance = Clones.clone(logic);
+        Atom(instance).initialize(operations);
+        emit AtomDeployed(instance);
     }
 }


### PR DESCRIPTION
Add a `PaladinVerifier` type to the SDK for storing and resolving Paladin identities.

Update the examples to use this new type, and run all of the examples as part of `gradle e2e` (to help ensure the examples stay functional).