### PR TITLE
Reduce testbed logging to stdout during build

### DIFF
--- a/.github/workflows/paladin-PR-build.yml
+++ b/.github/workflows/paladin-PR-build.yml
@@ -35,15 +35,21 @@ jobs:
       # This does not build any docker images, and does not run any dockerized tests.
       # It does run Go/Java/Solidity component and integration tests that use PostgreSQL and Besu
       - name: Build with Gradle
-        run: ./gradlew -PcomposeLogs=true -PverboseTests=true --no-daemon --parallel --max-workers=5 build
+        run: ./gradlew -PverboseTests=true --no-daemon --parallel --max-workers=5 build
 
-      - name: Upload logs
+      - name: Upload testbed logs
         uses: actions/upload-artifact@v4
-        if: always()      
+        if: always()
         with:
           name: testbed-logs
-          path: |
-            **/testbed.*.log
+          path: '**/testbed.*.log'
+
+      - name: Upload docker compose logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-compose-logs
+          path: '**/docker-compose.log'
 
   core-image-build:
     # run only on PRs

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ def transports = [
 def uiClient = [
     'ui/client/dist',
 ]
- 
+
 def assembleSubprojects = [
     ':core:go',
     ':core:java',
@@ -48,16 +48,14 @@ ext {
         },
 
         dumpLogsOnFailure: { task, dockerTaskPath ->
-            // If invoked with -PcomposeLogs=true and the given Exec task fails, look up the
-            // DockerCompose task specified, and ask it to dump logs.
+            // If the given Exec task fails, look up the DockerCompose task specified, and ask it to dump logs.
             task.ignoreExitValue(true)
             task.doLast {
                 def execResult = getExecutionResult().get()
-                def composeLogs = project.findProperty('composeLogs')
-                if (execResult.exitValue != 0 && composeLogs == "true") {
+                if (execResult.exitValue != 0) {
                     def docker = project.tasks.getByPath(dockerTaskPath)
                     println "\nTask '${task.path}' failed. Dumping Docker logs from '${dockerTaskPath}'."
-                    docker.dumpLogs()
+                    docker.dumpLogs(project.file('build/docker-compose.log'))
                 }
                 execResult.assertNormalExitValue()
             }

--- a/core/go/componenttest/utils_for_test.go
+++ b/core/go/componenttest/utils_for_test.go
@@ -188,7 +188,6 @@ func newInstanceForComponentTesting(t *testing.T, domainRegistryAddress *tktypes
 	}
 	i.ctx = log.WithLogField(context.Background(), "node-name", binding.name)
 
-	i.conf.Log.Level = confutil.P("info")
 	i.conf.BlockIndexer.FromBlock = json.RawMessage(`"latest"`)
 	i.conf.DomainManagerConfig.Domains = make(map[string]*pldconf.DomainConfig, 1)
 	if domainConfig == nil {
@@ -279,14 +278,6 @@ func newInstanceForComponentTesting(t *testing.T, domainRegistryAddress *tktypes
 	//i.conf.DB.SQLite.DSN = "./sql." + i.name + ".db"
 	//uncomment to use postgres - TODO once all tests are using postgres, we can parameterize this and run in both modes
 	//i.conf.DB.Type = "postgres"
-	i.conf.Log = pldconf.LogConfig{
-		Level:  confutil.P("debug"),
-		Output: confutil.P("file"),
-		File: pldconf.LogFileConfig{
-			Filename: confutil.P("build/testbed.component-test.log"),
-		},
-	}
-	log.InitConfig(&i.conf.Log)
 
 	if i.conf.DB.Type == "postgres" {
 		dns, cleanUp := initPostgres(t, context.Background())
@@ -394,6 +385,15 @@ func testConfig(t *testing.T) pldconf.PaladinConfig {
 		Encoding: "hex",
 		Inline:   tktypes.RandHex(32),
 	}
+
+	conf.Log = pldconf.LogConfig{
+		Level:  confutil.P("debug"),
+		Output: confutil.P("file"),
+		File: pldconf.LogFileConfig{
+			Filename: confutil.P("build/testbed.component-test.log"),
+		},
+	}
+	log.InitConfig(&conf.Log)
 
 	return *conf
 

--- a/core/go/pkg/testbed/testbed_test.go
+++ b/core/go/pkg/testbed/testbed_test.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/kaleido-io/paladin/config/pkg/confutil"
 	"github.com/kaleido-io/paladin/config/pkg/pldconf"
 
 	"github.com/stretchr/testify/assert"
@@ -36,6 +37,7 @@ func writeTestConfig(t *testing.T) (configFile string) {
 	var conf *pldconf.PaladinConfig
 	err := pldconf.ReadAndParseYAMLFile(ctx, "../../test/config/sqlite.memory.config.yaml", &conf)
 	require.NoError(t, err)
+
 	// For running in this unit test the dirs are different to the sample config
 	conf.DB.SQLite.MigrationsDir = "../../db/migrations/sqlite"
 	conf.DB.Postgres.MigrationsDir = "../../db/migrations/postgres"
@@ -47,6 +49,15 @@ func writeTestConfig(t *testing.T) (configFile string) {
 			Inline:   mnemonic,
 		},
 	}
+
+	conf.Log = pldconf.LogConfig{
+		Level:  confutil.P("debug"),
+		Output: confutil.P("file"),
+		File: pldconf.LogFileConfig{
+			Filename: confutil.P("build/testbed.component-test.log"),
+		},
+	}
+
 	configFile = path.Join(t.TempDir(), "test.config.yaml")
 	f, err := os.Create(configFile)
 	require.NoError(t, err)


### PR DESCRIPTION
This should greatly clean up CI build output to make test failures easier to find.

- Dump docker compose logs to a file instead of stdout, and collect file in GitHub build artifacts
- Set testbed logging to file earlier (previously the logger was initialized to stdout and then later redirected, but could still result in thousands of lines going to stdout)
- Fix testbed package tests to log to a file, just like other component tests that are built on top of the testbed