### PR TITLE
500: provide feedback for invalid ABI

### DIFF
--- a/ui/client/src/dialogs/ABIUpload.tsx
+++ b/ui/client/src/dialogs/ABIUpload.tsx
@@ -53,7 +53,7 @@ export const ABIUploadDialog: React.FC<Props> = ({
   const [abiText, setAbiText] = useState('');
   const [abiUploadCount, setAbiUploadCount] = useState(0);
 
-  const { mutate, data, reset } = useMutation({
+  const { mutate, data, reset, error } = useMutation({
     mutationFn: (value: Object) => uploadABI(value)
   });
 
@@ -63,8 +63,15 @@ export const ABIUploadDialog: React.FC<Props> = ({
       setRadioSelection('file');
       setFileSelected(null);
       setAbiText('');
+      setErrorMessage(undefined);
     }
   }, [dialogOpen]);
+
+  useEffect(() => {
+    if(error !== null) {
+      setErrorMessage(t('invalidABI'));
+    }
+  }, [error]);
 
   const handleSubmit = async () => {
     setErrorMessage(undefined);

--- a/ui/client/src/queries/storeABI.ts
+++ b/ui/client/src/queries/storeABI.ts
@@ -30,7 +30,7 @@ export const uploadABI = async (
 
   return <Promise<ABIUploadResponse>>(
     returnResponse(
-      () =>  fetch(RpcEndpoint, generatePostReq(JSON.stringify(payload))), "", [500]
+      () =>  fetch(RpcEndpoint, generatePostReq(JSON.stringify(payload))), "", []
     )
   );
 


### PR DESCRIPTION
Ensure feedback is provided when the ABI provided is invalid even though the JSON is (syntactically) valid.