### PR TITLE
Ensure persisted zeto state and nullifiers are all 32 bytes

### DIFF
--- a/domains/integration-test/helpers/zeto_helper.go
+++ b/domains/integration-test/helpers/zeto_helper.go
@@ -26,9 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//go:embed abis/ZetoFactory.json
-var ZetoFactoryJSON []byte
-
 type ZetoHelper struct {
 	t       *testing.T
 	rpc     rpcbackend.Backend

--- a/domains/zeto/integration-test/contracts.go
+++ b/domains/zeto/integration-test/contracts.go
@@ -24,12 +24,14 @@ import (
 	"github.com/hyperledger/firefly-signer/pkg/abi"
 	"github.com/hyperledger/firefly-signer/pkg/rpcbackend"
 	"github.com/kaleido-io/paladin/core/pkg/testbed"
-	"github.com/kaleido-io/paladin/domains/integration-test/helpers"
 	"github.com/kaleido-io/paladin/toolkit/pkg/log"
 	"github.com/kaleido-io/paladin/toolkit/pkg/pldapi"
 	"github.com/kaleido-io/paladin/toolkit/pkg/solutils"
 	"github.com/kaleido-io/paladin/toolkit/pkg/tktypes"
 )
+
+//go:embed abis/ZetoFactory.json
+var zetoFactoryJSON []byte
 
 type ZetoDomainContracts struct {
 	FactoryAddress       *tktypes.EthAddress
@@ -51,7 +53,7 @@ type cloneableContract struct {
 }
 
 func newZetoDomainContracts() *ZetoDomainContracts {
-	factory := solutils.MustLoadBuild(helpers.ZetoFactoryJSON)
+	factory := solutils.MustLoadBuild(zetoFactoryJSON)
 
 	return &ZetoDomainContracts{
 		factoryAbi: factory.ABI,
@@ -235,5 +237,6 @@ func registerImpl(ctx context.Context, name string, domainContracts *ZetoDomainC
 		},
 		ABI: abi.ABI{abiFunc},
 	})
+	log.L(ctx).Infof("Registered implementation %s", name)
 	return err
 }

--- a/domains/zeto/integration-test/e2e_test.go
+++ b/domains/zeto/integration-test/e2e_test.go
@@ -222,9 +222,9 @@ func (s *zetoDomainTestSuite) testZetoFungible(t *testing.T, tokenName string, u
 	require.Len(t, coins, expectedCoins)
 
 	if useBatch {
-		assert.Equal(t, int64(10), coins[0].Data.Amount.Int().Int64()) // state for recipient1
+		assert.Equal(t, int64(15), coins[0].Data.Amount.Int().Int64()) // state for recipient1
 		assert.Equal(t, int64(40), coins[1].Data.Amount.Int().Int64()) // state for recipient2
-		assert.Equal(t, int64(10), coins[2].Data.Amount.Int().Int64()) // change for controller
+		assert.Equal(t, int64(5), coins[2].Data.Amount.Int().Int64())  // change for controller
 		assert.Equal(t, controllerAddr.String(), coins[2].Data.Owner.String())
 	} else {
 		assert.Equal(t, int64(25), coins[0].Data.Amount.Int().Int64()) // state for recipient1

--- a/domains/zeto/integration-test/e2e_test.go
+++ b/domains/zeto/integration-test/e2e_test.go
@@ -186,8 +186,8 @@ func (s *zetoDomainTestSuite) testZetoFungible(t *testing.T, tokenName string, u
 	assert.Regexp(t, "PD012216: Transaction reverted OwnableUnauthorizedAccount.*", err)
 
 	if useBatch {
-		// for testing the batch circuits, we transfer 50 which would require 3 UTXOs (>2)
-		amount1 := 10
+		// for testing the batch circuits, we transfer 55 which would require 3 UTXOs (>2)
+		amount1 := 15
 		amount2 := 40
 		log.L(ctx).Info("*************************************")
 		log.L(ctx).Infof("Transfer %d from controller to recipient1 (%d) and recipient2 (%d)", amount1+amount2, amount1, amount2)
@@ -209,6 +209,9 @@ func (s *zetoDomainTestSuite) testZetoFungible(t *testing.T, tokenName string, u
 	// one for the recipient (value=25)
 	expectedCoins := 2
 	if useBatch {
+		// one for the controller from the successful transaction as change (value=5)
+		// one for the recipient1 (value=15)
+		// one for the recipient2 (value=40)
 		expectedCoins = 3
 	}
 	if len(coins) != expectedCoins {

--- a/domains/zeto/integration-test/testbed.config.yaml
+++ b/domains/zeto/integration-test/testbed.config.yaml
@@ -5,7 +5,7 @@ db:
     dsn: ':memory:'
     autoMigrate: true
     migrationsDir: '../../../core/go/db/migrations/sqlite'
-    debugQueries: false
+    debugQueries: true
   # type: postgres
   # postgres:
   #   dsn: 'postgres://postgres:my-secret@localhost:5432/postgres?sslmode=disable'

--- a/domains/zeto/integration-test/testbed.config.yaml
+++ b/domains/zeto/integration-test/testbed.config.yaml
@@ -5,7 +5,7 @@ db:
     dsn: ':memory:'
     autoMigrate: true
     migrationsDir: '../../../core/go/db/migrations/sqlite'
-    debugQueries: true
+    debugQueries: false
   # type: postgres
   # postgres:
   #   dsn: 'postgres://postgres:my-secret@localhost:5432/postgres?sslmode=disable'

--- a/domains/zeto/internal/zeto/handler_events.go
+++ b/domains/zeto/internal/zeto/handler_events.go
@@ -2,7 +2,6 @@ package zeto
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -172,9 +171,8 @@ func (z *Zeto) addOutputToMerkleTree(ctx context.Context, tree core.SparseMerkle
 func parseStatesFromEvent(txID tktypes.HexBytes, states []tktypes.HexUint256) []*prototk.StateUpdate {
 	refs := make([]*prototk.StateUpdate, len(states))
 	for i, state := range states {
-		paddedBytes := intTo32ByteSlice(state.Int())
 		refs[i] = &prototk.StateUpdate{
-			Id:            hex.EncodeToString(paddedBytes),
+			Id:            hexUint256To32ByteHexString(&state),
 			TransactionId: txID.String(),
 		}
 	}

--- a/domains/zeto/internal/zeto/handler_events.go
+++ b/domains/zeto/internal/zeto/handler_events.go
@@ -2,6 +2,7 @@ package zeto
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -171,8 +172,9 @@ func (z *Zeto) addOutputToMerkleTree(ctx context.Context, tree core.SparseMerkle
 func parseStatesFromEvent(txID tktypes.HexBytes, states []tktypes.HexUint256) []*prototk.StateUpdate {
 	refs := make([]*prototk.StateUpdate, len(states))
 	for i, state := range states {
+		paddedBytes := intTo32ByteSlice(state.Int())
 		refs[i] = &prototk.StateUpdate{
-			Id:            state.String(),
+			Id:            hex.EncodeToString(paddedBytes),
 			TransactionId: txID.String(),
 		}
 	}

--- a/domains/zeto/internal/zeto/handler_events_test.go
+++ b/domains/zeto/internal/zeto/handler_events_test.go
@@ -198,3 +198,11 @@ func TestHandleWithdrawEvent(t *testing.T) {
 	err = z.handleWithdrawEvent(ctx, merkleTree, storage, ev, "Zeto_AnonNullifier", res)
 	assert.ErrorContains(t, err, "PD210061: Failed to update merkle tree for the UTXOWithdraw event. PD210056: Failed to create new node index from hash. 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 }
+
+func TestParseStatesFromEvent(t *testing.T) {
+	txID := tktypes.MustParseHexBytes("0x1234")
+	states := parseStatesFromEvent(txID, []tktypes.HexUint256{*tktypes.MustParseHexUint256("0x1234"), *tktypes.MustParseHexUint256("0x0")})
+	assert.Len(t, states, 2)
+	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000001234", states[0].Id)
+	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000000000", states[1].Id)
+}

--- a/domains/zeto/internal/zeto/states.go
+++ b/domains/zeto/internal/zeto/states.go
@@ -75,7 +75,7 @@ func (z *Zeto) makeNewState(ctx context.Context, useNullifiers bool, coin *types
 	if err != nil {
 		return nil, err
 	}
-	hashStr := hash.String()
+	hashStr := hexUint256To32ByteHexString(hash)
 	newState := &pb.NewState{
 		Id:               &hashStr,
 		SchemaId:         z.coinSchema.Id,


### PR DESCRIPTION
fixes #410 

The problem was that when the nullifiers were generated and persisted in `state_nullifiers`, they were padded to 32 bytes (because they are big numbers, they can be less than 32 bytes), but in the processing of the events for spent states, the nullifiers were NOT padded. This is not a problem when most of the time the big number from the Poseidon hash ends up being 32 bytes, but is a problem when the hash is less than 32 bytes, as it causes the mismatch when comparing the nullifier ID vs. the spend ID.

The fix is to always pad the state IDs, for both states and nullifiers when processing events