### PR TITLE
add gas estimate factor for public transactions

### DIFF
--- a/config/pkg/pldconf/publictxmgr.go
+++ b/config/pkg/pldconf/publictxmgr.go
@@ -24,6 +24,7 @@ type PublicTxManagerConfig struct {
 	Orchestrator   PublicTxManagerOrchestratorConfig `json:"orchestrator"`
 	GasPrice       GasPriceConfig                    `json:"gasPrice"`
 	BalanceManager BalanceManagerConfig              `json:"balanceManager"`
+	GasLimit       GasLimitConfig                    `json:"gasLimit"`
 }
 
 var PublicTxManagerDefaults = &PublicTxManagerConfig{
@@ -100,6 +101,9 @@ var PublicTxManagerDefaults = &PublicTxManagerConfig{
 			MinThreshold:                     nil,
 		},
 	},
+	GasLimit: GasLimitConfig{
+		GasEstimateFactor: confutil.P(1.0),
+	},
 }
 
 type PublicTxManagerManagerConfig struct {
@@ -148,6 +152,10 @@ type GasPriceConfig struct {
 	FixedGasPrice      any                `json:"fixedGasPrice"` // number or object
 	GasOracleAPI       GasOracleAPIConfig `json:"gasOracleAPI"`
 	Cache              CacheConfig        `json:"cache"`
+}
+
+type GasLimitConfig struct {
+	GasEstimateFactor *float64 `json:"gasEstimateFactor"`
 }
 
 type GasOracleAPIConfig struct {


### PR DESCRIPTION
Adds the ability to set a gas estimation factor in paladin public transaction manager to accommodate known inaccuracies in `eth_estimateGas` (e.g. branching, setting same vs different values in a storage slot).