### PR TITLE
Do not continue to delegate after finalize initiation

### DIFF
--- a/core/go/internal/privatetxnmgr/transaction_flow_actions.go
+++ b/core/go/internal/privatetxnmgr/transaction_flow_actions.go
@@ -74,6 +74,8 @@ func (tf *transactionFlow) Action(ctx context.Context) {
 		//we know we need to finalize but we are not currently waiting for a finalize to complete
 		// most likely a previous attempt to finalize has failed
 		tf.finalize(ctx)
+		tf.logActionInfo(ctx, "finalize initiated")
+		return
 	}
 
 	if tf.dispatched {
@@ -284,6 +286,8 @@ func (tf *transactionFlow) finalize(ctx context.Context) {
 			go tf.publisher.PublishTransactionFinalizeError(ctx, tf.transaction.ID.String(), tf.finalizeRevertReason, rollbackErr)
 		},
 	)
+
+	tf.finalizePending = true
 }
 
 func (tf *transactionFlow) delegateIfRequired(ctx context.Context) (doContinue bool) {


### PR DESCRIPTION
Fixes #518 

Inspecting this code, it seems like the intent of `finalize()` (linked below) is to:
1. Initiate a background finalization
2. Fire an event on success/failure of the finalization

However, it did not seem to be setting the `finalizePending` flag, or exiting the state reconcile loop.

https://github.com/LF-Decentralized-Trust-labs/paladin/blob/bf09215d333d8701cfc77d03c69ee1fde7f3211f/core/go/internal/privatetxnmgr/transaction_flow_actions.go#L250-L287