### PR TITLE
noto: remove lockId from Solidity contract

### DIFF
--- a/domains/integration-test/noto_test.go
+++ b/domains/integration-test/noto_test.go
@@ -439,7 +439,7 @@ func (s *notoTestSuite) TestNotoLock() {
 	}, true)
 	require.NoError(t, rpcerr)
 
-	_, _, unlockParams, encodedUnlock, err := buildUnlock(ctx, notoDomain, noto.ABI, &invokeResult)
+	_, _, unlockParams, _, err := buildUnlock(ctx, notoDomain, noto.ABI, &invokeResult)
 	require.NoError(t, err)
 
 	log.L(ctx).Infof("Delegate lock to recipient2")
@@ -450,7 +450,7 @@ func (s *notoTestSuite) TestNotoLock() {
 			Function: "delegateLock",
 			Data: toJSON(t, &types.DelegateLockParams{
 				LockID:   lockInfo.LockID,
-				Unlock:   encodedUnlock,
+				Unlock:   unlockParams,
 				Delegate: tktypes.MustEthAddress(recipient2Key.Verifier.Verifier),
 			}),
 		},

--- a/domains/integration-test/noto_test.go
+++ b/domains/integration-test/noto_test.go
@@ -381,9 +381,10 @@ func (s *notoTestSuite) TestNotoLock() {
 	}, true)
 	require.NoError(t, rpcerr)
 
-	lockID, err := extractLockID(notoDomain, &invokeResult)
+	lockInfo, err := extractLockInfo(notoDomain, &invokeResult)
 	require.NoError(t, err)
-	require.NotEmpty(t, lockID)
+	require.NotNil(t, lockInfo)
+	require.NotEmpty(t, lockInfo.LockID)
 
 	lockedCoins := findAvailableCoins[types.NotoLockedCoinState](t, ctx, rpc, notoDomain.Name(), notoDomain.LockedCoinSchemaID(), noto.Address, nil)
 	require.Len(t, lockedCoins, 1)
@@ -425,7 +426,7 @@ func (s *notoTestSuite) TestNotoLock() {
 			To:       noto.Address,
 			Function: "prepareUnlock",
 			Data: toJSON(t, &types.UnlockParams{
-				LockID: lockID,
+				LockID: lockInfo.LockID,
 				From:   recipient1Name,
 				Recipients: []*types.UnlockRecipient{{
 					To:     recipient2Name,
@@ -437,7 +438,9 @@ func (s *notoTestSuite) TestNotoLock() {
 		ABI: types.NotoABI,
 	}, true)
 	require.NoError(t, rpcerr)
-	_, _, unlockParams, _, _ := buildUnlock(ctx, notoDomain, noto.ABI, lockID, &invokeResult)
+
+	_, _, unlockParams, encodedUnlock, err := buildUnlock(ctx, notoDomain, noto.ABI, &invokeResult)
+	require.NoError(t, err)
 
 	log.L(ctx).Infof("Delegate lock to recipient2")
 	rpcerr = rpc.CallRPC(ctx, &invokeResult, "testbed_invoke", &pldapi.TransactionInput{
@@ -446,7 +449,8 @@ func (s *notoTestSuite) TestNotoLock() {
 			To:       noto.Address,
 			Function: "delegateLock",
 			Data: toJSON(t, &types.DelegateLockParams{
-				LockID:   lockID,
+				LockID:   lockInfo.LockID,
+				Unlock:   encodedUnlock,
 				Delegate: tktypes.MustEthAddress(recipient2Key.Verifier.Verifier),
 			}),
 		},

--- a/domains/integration-test/pvp_test.go
+++ b/domains/integration-test/pvp_test.go
@@ -97,22 +97,26 @@ func decodeTransactionResult(t *testing.T, resultInput map[string]any) *testbed.
 	return &result
 }
 
-func extractLockID(noto noto.Noto, invokeResult *testbed.TransactionResult) (tktypes.Bytes32, error) {
+// TODO: this should be retrieved from the domain receipt (not currently available in testbed)
+func extractLockInfo(noto noto.Noto, invokeResult *testbed.TransactionResult) (*nototypes.ReceiptLockInfo, error) {
 	for _, state := range invokeResult.InfoStates {
 		if state.Schema.String() == noto.LockInfoSchemaID() {
 			var lockInfo map[string]any
 			err := json.Unmarshal(state.Data, &lockInfo)
 			if err != nil {
-				return tktypes.Bytes32{}, err
+				return nil, err
 			}
-			return tktypes.MustParseBytes32(lockInfo["lockId"].(string)), nil
+			receiptInfo := &nototypes.ReceiptLockInfo{
+				LockID: tktypes.MustParseBytes32(lockInfo["lockId"].(string)),
+			}
+			return receiptInfo, nil
 		}
 	}
-	return tktypes.Bytes32{}, nil
+	return nil, nil
 }
 
-// TODO: make this easier to extract
-func buildUnlock(ctx context.Context, notoDomain noto.Noto, abi abi.ABI, lockID tktypes.Bytes32, prepareUnlockResult *testbed.TransactionResult) ([]*pldapi.StateEncoded, []*pldapi.StateEncoded, map[string]any, []byte, error) {
+// TODO: this should be retrieved from the domain receipt (not currently available in testbed)
+func buildUnlock(ctx context.Context, notoDomain noto.Noto, abi abi.ABI, prepareUnlockResult *testbed.TransactionResult) ([]*pldapi.StateEncoded, []*pldapi.StateEncoded, map[string]any, []byte, error) {
 	notoInputStates := make([]*pldapi.StateEncoded, 0, len(prepareUnlockResult.ReadStates))
 	notoOutputStates := make([]*pldapi.StateEncoded, 0, len(prepareUnlockResult.InfoStates))
 	lockedInputs := make([]tktypes.HexBytes, 0)
@@ -134,7 +138,6 @@ func buildUnlock(ctx context.Context, notoDomain noto.Noto, abi abi.ABI, lockID 
 	}
 
 	unlockParams := map[string]any{
-		"lockId":        lockID,
 		"lockedInputs":  lockedInputs,
 		"lockedOutputs": lockedOutputs,
 		"outputs":       unlockedOutputs,
@@ -404,13 +407,14 @@ func (s *pvpTestSuite) TestNotoForZeto() {
 	}).SignAndSend(alice).Wait()
 	notoLockResult := decodeTransactionResult(t, notoLock)
 
-	lockID, err := extractLockID(notoDomain, notoLockResult)
+	lockInfo, err := extractLockInfo(notoDomain, notoLockResult)
 	require.NoError(t, err)
-	require.NotEmpty(t, lockID)
+	require.NotNil(t, lockInfo)
+	require.NotEmpty(t, lockInfo.LockID)
 
 	time.Sleep(1 * time.Second) // TODO: remove
 	notoPrepareUnlock := noto.PrepareUnlock(ctx, &nototypes.UnlockParams{
-		LockID: lockID,
+		LockID: lockInfo.LockID,
 		From:   alice,
 		Recipients: []*nototypes.UnlockRecipient{{
 			To:     bob,
@@ -420,7 +424,7 @@ func (s *pvpTestSuite) TestNotoForZeto() {
 	require.NotNil(t, notoPrepareUnlock)
 	prepareUnlockResult := decodeTransactionResult(t, notoPrepareUnlock)
 
-	notoInputStates, notoOutputStates, _, transferNoto, err := buildUnlock(ctx, notoDomain, noto.ABI, lockID, prepareUnlockResult)
+	notoInputStates, notoOutputStates, _, transferNoto, err := buildUnlock(ctx, notoDomain, noto.ABI, prepareUnlockResult)
 	require.NoError(t, err)
 
 	log.L(ctx).Infof("Prepare the Zeto transfer")
@@ -480,7 +484,8 @@ func (s *pvpTestSuite) TestNotoForZeto() {
 
 	log.L(ctx).Infof("Approve both transfers")
 	noto.DelegateLock(ctx, &nototypes.DelegateLockParams{
-		LockID:   lockID,
+		LockID:   lockInfo.LockID,
+		Unlock:   transferNoto,
 		Delegate: transferAtom.Address,
 	}).SignAndSend(alice).Wait()
 	zeto.Lock(ctx, transferAtom.Address, transferZeto.EncodedCall).SignAndSend(bob).Wait()

--- a/domains/noto/build.gradle
+++ b/domains/noto/build.gradle
@@ -18,7 +18,7 @@ ext {
         include 'internal/**/*.go'
         include 'pkg/**/*.go'
     }
-    targetCoverage = 62.0
+    targetCoverage = 61.0
     maxCoverageBarGap = 1
 }
 

--- a/domains/noto/internal/noto/events_test.go
+++ b/domains/noto/internal/noto/events_test.go
@@ -128,7 +128,6 @@ func TestHandleEventBatch_NotoLock(t *testing.T) {
 	output := tktypes.RandBytes32()
 	lockedOutput := tktypes.RandBytes32()
 	event := &NotoLock_Event{
-		LockID:        tktypes.RandBytes32(),
 		Inputs:        []tktypes.Bytes32{input},
 		Outputs:       []tktypes.Bytes32{output},
 		LockedOutputs: []tktypes.Bytes32{lockedOutput},
@@ -221,7 +220,6 @@ func TestHandleEventBatch_NotoUnlock(t *testing.T) {
 	output := tktypes.RandBytes32()
 	lockedOutput := tktypes.RandBytes32()
 	event := &NotoUnlock_Event{
-		LockID:        tktypes.RandBytes32(),
 		LockedInputs:  []tktypes.Bytes32{lockedInput},
 		LockedOutputs: []tktypes.Bytes32{lockedOutput},
 		Outputs:       []tktypes.Bytes32{output},

--- a/domains/noto/internal/noto/handler_delegate_lock.go
+++ b/domains/noto/internal/noto/handler_delegate_lock.go
@@ -44,6 +44,9 @@ func (h *delegateLockHandler) ValidateParams(ctx context.Context, config *types.
 	if delegateParams.LockID.IsZero() {
 		return nil, i18n.NewError(ctx, msgs.MsgParameterRequired, "lockId")
 	}
+	if delegateParams.Unlock == nil {
+		return nil, i18n.NewError(ctx, msgs.MsgParameterRequired, "unlock")
+	}
 	if delegateParams.Delegate.IsZero() {
 		return nil, i18n.NewError(ctx, msgs.MsgInvalidDelegate, delegateParams.Delegate)
 	}
@@ -178,15 +181,20 @@ func (h *delegateLockHandler) baseLedgerInvoke(ctx context.Context, tx *types.Pa
 		return nil, i18n.NewError(ctx, msgs.MsgAttestationNotFound, "sender")
 	}
 
+	unlockHash, err := h.noto.unlockHashFromEncodedCall(ctx, tx.ContractAddress, inParams.Unlock, inParams.Data)
+	if err != nil {
+		return nil, err
+	}
+
 	data, err := h.noto.encodeTransactionData(ctx, req.Transaction, req.InfoStates)
 	if err != nil {
 		return nil, err
 	}
 	params := &NotoDelegateLockParams{
-		LockID:    inParams.LockID,
-		Delegate:  inParams.Delegate,
-		Signature: sender.Payload,
-		Data:      data,
+		UnlockHash: tktypes.Bytes32(unlockHash),
+		Delegate:   inParams.Delegate,
+		Signature:  sender.Payload,
+		Data:       data,
 	}
 	paramsJSON, err := json.Marshal(params)
 	if err != nil {

--- a/domains/noto/internal/noto/handler_delegate_lock.go
+++ b/domains/noto/internal/noto/handler_delegate_lock.go
@@ -181,7 +181,7 @@ func (h *delegateLockHandler) baseLedgerInvoke(ctx context.Context, tx *types.Pa
 		return nil, i18n.NewError(ctx, msgs.MsgAttestationNotFound, "sender")
 	}
 
-	unlockHash, err := h.noto.unlockHashFromEncodedCall(ctx, tx.ContractAddress, inParams.Unlock, inParams.Data)
+	unlockHash, err := h.noto.unlockHashFromIDs(ctx, tx.ContractAddress, inParams.Unlock.LockedInputs, inParams.Unlock.LockedOutputs, inParams.Unlock.Outputs, inParams.Unlock.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/domains/noto/internal/noto/handler_lock.go
+++ b/domains/noto/internal/noto/handler_lock.go
@@ -198,7 +198,7 @@ func (h *lockHandler) Endorse(ctx context.Context, tx *types.ParsedTransaction, 
 	}, nil
 }
 
-func (h *lockHandler) baseLedgerInvoke(ctx context.Context, lockID tktypes.Bytes32, req *prototk.PrepareTransactionRequest) (*TransactionWrapper, error) {
+func (h *lockHandler) baseLedgerInvoke(ctx context.Context, req *prototk.PrepareTransactionRequest) (*TransactionWrapper, error) {
 	inputs := req.InputStates
 	outputs, lockedOutputs := h.noto.splitStates(req.OutputStates)
 
@@ -214,7 +214,6 @@ func (h *lockHandler) baseLedgerInvoke(ctx context.Context, lockID tktypes.Bytes
 		return nil, err
 	}
 	params := &NotoLockParams{
-		LockID:        lockID,
 		Inputs:        endorsableStateIDs(inputs),
 		Outputs:       endorsableStateIDs(outputs),
 		LockedOutputs: endorsableStateIDs(lockedOutputs),
@@ -295,7 +294,7 @@ func (h *lockHandler) Prepare(ctx context.Context, tx *types.ParsedTransaction, 
 		return nil, i18n.NewError(ctx, msgs.MsgAttestationNotFound, "notary")
 	}
 
-	baseTransaction, err := h.baseLedgerInvoke(ctx, lockID, req)
+	baseTransaction, err := h.baseLedgerInvoke(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/domains/noto/internal/noto/handler_lock_test.go
+++ b/domains/noto/internal/noto/handler_lock_test.go
@@ -208,13 +208,12 @@ func TestLock(t *testing.T) {
 	assert.JSONEq(t, expectedFunction, prepareRes.Transaction.FunctionAbiJson)
 	assert.Nil(t, prepareRes.Transaction.ContractAddress)
 	assert.JSONEq(t, fmt.Sprintf(`{
-		"lockId": "%s",
 		"inputs": ["%s"],
 		"outputs": [],
 		"lockedOutputs": ["0x26b394af655bdc794a6d7cd7f8004eec20bffb374e4ddd24cdaefe554878d945"],
 		"signature": "%s",
 		"data": "0x00010000015e1881f2ba769c22d05c841f06949ec6e1bd573f5e1e0328885494212f077d000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000024cc7840e186de23c4127b4853c878708d2642f1942959692885e098f1944547d69101a0740ec8096b83653600fa7553d676fc92bcc6e203c3572d2cac4f1db2f"
-	}`, lockInfo.LockID, inputCoin.ID, signatureBytes), prepareRes.Transaction.ParamsJson)
+	}`, inputCoin.ID, signatureBytes), prepareRes.Transaction.ParamsJson)
 
 	var invokeFn abi.Entry
 	err = json.Unmarshal([]byte(prepareRes.Transaction.FunctionAbiJson), &invokeFn)

--- a/domains/noto/internal/noto/handler_prepare_unlock.go
+++ b/domains/noto/internal/noto/handler_prepare_unlock.go
@@ -133,7 +133,6 @@ func (h *prepareUnlockHandler) baseLedgerInvoke(ctx context.Context, tx *types.P
 		return nil, err
 	}
 	params := &NotoPrepareUnlockParams{
-		LockID:       inParams.LockID,
 		LockedInputs: endorsableStateIDs(lockedInputs),
 		UnlockHash:   tktypes.Bytes32(unlockHash),
 		Signature:    sender.Payload,

--- a/domains/noto/internal/noto/handler_prepare_unlock.go
+++ b/domains/noto/internal/noto/handler_prepare_unlock.go
@@ -116,7 +116,7 @@ func (h *prepareUnlockHandler) baseLedgerInvoke(ctx context.Context, tx *types.P
 
 	lockedInputs := req.ReadStates
 	outputs, lockedOutputs := h.noto.splitStates(req.InfoStates)
-	unlockHash, err := h.noto.encodeUnlockMasked(ctx, tx.ContractAddress, lockedInputs, lockedOutputs, outputs, inParams.Data)
+	unlockHash, err := h.noto.unlockHashFromStates(ctx, tx.ContractAddress, lockedInputs, lockedOutputs, outputs, inParams.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/domains/noto/internal/noto/handler_prepare_unlock_test.go
+++ b/domains/noto/internal/noto/handler_prepare_unlock_test.go
@@ -222,12 +222,11 @@ func TestPrepareUnlock(t *testing.T) {
 	assert.JSONEq(t, expectedFunction, prepareRes.Transaction.FunctionAbiJson)
 	assert.Nil(t, prepareRes.Transaction.ContractAddress)
 	assert.JSONEq(t, fmt.Sprintf(`{
-		"lockId": "%s",
 		"lockedInputs": ["%s"],
 		"unlockHash": "%s",
 		"signature": "%s",
 		"data": "0x00010000015e1881f2ba769c22d05c841f06949ec6e1bd573f5e1e0328885494212f077d000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000034cc7840e186de23c4127b4853c878708d2642f1942959692885e098f1944547d69101a0740ec8096b83653600fa7553d676fc92bcc6e203c3572d2cac4f1db2f26b394af655bdc794a6d7cd7f8004eec20bffb374e4ddd24cdaefe554878d945"
-	}`, lockID, inputCoin.ID, unlockHash, signatureBytes), prepareRes.Transaction.ParamsJson)
+	}`, inputCoin.ID, unlockHash, signatureBytes), prepareRes.Transaction.ParamsJson)
 
 	var invokeFn abi.Entry
 	err = json.Unmarshal([]byte(prepareRes.Transaction.FunctionAbiJson), &invokeFn)

--- a/domains/noto/internal/noto/handler_prepare_unlock_test.go
+++ b/domains/noto/internal/noto/handler_prepare_unlock_test.go
@@ -196,7 +196,7 @@ func TestPrepareUnlock(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, prototk.EndorseTransactionResponse_ENDORSER_SUBMIT, endorseRes.EndorsementResult)
 
-	unlockHash, err := n.encodeUnlockMasked(ctx, ethtypes.MustNewAddress(contractAddress), readStates, nil, n.filterSchema(infoStates, []string{"coin"}), tktypes.MustParseHexBytes("0x1234"))
+	unlockHash, err := n.unlockHashFromStates(ctx, ethtypes.MustNewAddress(contractAddress), readStates, nil, n.filterSchema(infoStates, []string{"coin"}), tktypes.MustParseHexBytes("0x1234"))
 	require.NoError(t, err)
 
 	// Prepare once to test base invoke

--- a/domains/noto/internal/noto/handler_unlock.go
+++ b/domains/noto/internal/noto/handler_unlock.go
@@ -301,7 +301,7 @@ func (h *unlockHandler) baseLedgerInvoke(ctx context.Context, req *prototk.Prepa
 	if err != nil {
 		return nil, err
 	}
-	params := &NotoUnlockParams{
+	params := &types.UnlockPublicParams{
 		LockedInputs:  endorsableStateIDs(lockedInputs),
 		LockedOutputs: endorsableStateIDs(lockedOutputs),
 		Outputs:       endorsableStateIDs(outputs),

--- a/domains/noto/internal/noto/handler_unlock.go
+++ b/domains/noto/internal/noto/handler_unlock.go
@@ -286,8 +286,7 @@ func (h *unlockHandler) Endorse(ctx context.Context, tx *types.ParsedTransaction
 	return h.endorse(ctx, tx, params, req, inputs, outputs)
 }
 
-func (h *unlockHandler) baseLedgerInvoke(ctx context.Context, tx *types.ParsedTransaction, req *prototk.PrepareTransactionRequest) (*TransactionWrapper, error) {
-	inParams := tx.Params.(*types.UnlockParams)
+func (h *unlockHandler) baseLedgerInvoke(ctx context.Context, req *prototk.PrepareTransactionRequest) (*TransactionWrapper, error) {
 	lockedInputs := req.InputStates
 	outputs, lockedOutputs := h.noto.splitStates(req.OutputStates)
 
@@ -303,7 +302,6 @@ func (h *unlockHandler) baseLedgerInvoke(ctx context.Context, tx *types.ParsedTr
 		return nil, err
 	}
 	params := &NotoUnlockParams{
-		LockID:        inParams.LockID,
 		LockedInputs:  endorsableStateIDs(lockedInputs),
 		LockedOutputs: endorsableStateIDs(lockedOutputs),
 		Outputs:       endorsableStateIDs(outputs),
@@ -374,7 +372,7 @@ func (h *unlockHandler) Prepare(ctx context.Context, tx *types.ParsedTransaction
 		return nil, i18n.NewError(ctx, msgs.MsgAttestationNotFound, "notary")
 	}
 
-	baseTransaction, err := h.baseLedgerInvoke(ctx, tx, req)
+	baseTransaction, err := h.baseLedgerInvoke(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/domains/noto/internal/noto/handler_unlock_test.go
+++ b/domains/noto/internal/noto/handler_unlock_test.go
@@ -223,13 +223,12 @@ func TestUnlock(t *testing.T) {
 	assert.JSONEq(t, expectedFunction, prepareRes.Transaction.FunctionAbiJson)
 	assert.Nil(t, prepareRes.Transaction.ContractAddress)
 	assert.JSONEq(t, fmt.Sprintf(`{
-		"lockId": "%s",
 		"lockedInputs": ["%s"],
 		"lockedOutputs": [],
 		"outputs": ["0x26b394af655bdc794a6d7cd7f8004eec20bffb374e4ddd24cdaefe554878d945"],
 		"signature": "%s",
 		"data": "0x00010000015e1881f2ba769c22d05c841f06949ec6e1bd573f5e1e0328885494212f077d000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000024cc7840e186de23c4127b4853c878708d2642f1942959692885e098f1944547d69101a0740ec8096b83653600fa7553d676fc92bcc6e203c3572d2cac4f1db2f"
-	}`, lockID, inputCoin.ID, signatureBytes), prepareRes.Transaction.ParamsJson)
+	}`, inputCoin.ID, signatureBytes), prepareRes.Transaction.ParamsJson)
 
 	var invokeFn abi.Entry
 	err = json.Unmarshal([]byte(prepareRes.Transaction.FunctionAbiJson), &invokeFn)

--- a/domains/noto/internal/noto/noto.go
+++ b/domains/noto/internal/noto/noto.go
@@ -134,7 +134,6 @@ type NotoApproveTransferParams struct {
 }
 
 type NotoLockParams struct {
-	LockID        tktypes.Bytes32  `json:"lockId"`
 	Inputs        []string         `json:"inputs"`
 	Outputs       []string         `json:"outputs"`
 	LockedOutputs []string         `json:"lockedOutputs"`
@@ -143,7 +142,6 @@ type NotoLockParams struct {
 }
 
 type NotoUnlockParams struct {
-	LockID        tktypes.Bytes32  `json:"lockId"`
 	LockedInputs  []string         `json:"lockedInputs"`
 	LockedOutputs []string         `json:"lockedOutputs"`
 	Outputs       []string         `json:"outputs"`
@@ -152,7 +150,6 @@ type NotoUnlockParams struct {
 }
 
 type NotoPrepareUnlockParams struct {
-	LockID       tktypes.Bytes32  `json:"lockId"`
 	LockedInputs []string         `json:"lockedInputs"`
 	UnlockHash   tktypes.Bytes32  `json:"unlockHash"`
 	Signature    tktypes.HexBytes `json:"signature"`
@@ -160,10 +157,10 @@ type NotoPrepareUnlockParams struct {
 }
 
 type NotoDelegateLockParams struct {
-	LockID    tktypes.Bytes32     `json:"lockId"`
-	Delegate  *tktypes.EthAddress `json:"delegate"`
-	Signature tktypes.HexBytes    `json:"signature"`
-	Data      tktypes.HexBytes    `json:"data"`
+	UnlockHash tktypes.Bytes32     `json:"unlockHash"`
+	Delegate   *tktypes.EthAddress `json:"delegate"`
+	Signature  tktypes.HexBytes    `json:"signature"`
+	Data       tktypes.HexBytes    `json:"data"`
 }
 
 type NotoTransfer_Event struct {
@@ -181,7 +178,6 @@ type NotoApproved_Event struct {
 }
 
 type NotoLock_Event struct {
-	LockID        tktypes.Bytes32   `json:"lockId"`
 	Inputs        []tktypes.Bytes32 `json:"inputs"`
 	Outputs       []tktypes.Bytes32 `json:"outputs"`
 	LockedOutputs []tktypes.Bytes32 `json:"lockedOutputs"`
@@ -190,7 +186,6 @@ type NotoLock_Event struct {
 }
 
 type NotoUnlock_Event struct {
-	LockID        tktypes.Bytes32     `json:"lockId"`
 	Sender        *tktypes.EthAddress `json:"sender"`
 	LockedInputs  []tktypes.Bytes32   `json:"lockedInputs"`
 	LockedOutputs []tktypes.Bytes32   `json:"lockedOutputs"`
@@ -200,7 +195,6 @@ type NotoUnlock_Event struct {
 }
 
 type NotoUnlockPrepared_Event struct {
-	LockID       tktypes.Bytes32   `json:"lockId"`
 	LockedInputs []tktypes.Bytes32 `json:"lockedInputs"`
 	UnlockHash   tktypes.Bytes32   `json:"unlockHash"`
 	Signature    tktypes.HexBytes  `json:"signature"`
@@ -208,10 +202,10 @@ type NotoUnlockPrepared_Event struct {
 }
 
 type NotoLockDelegated_Event struct {
-	LockID    tktypes.Bytes32     `json:"lockId"`
-	Delegate  *tktypes.EthAddress `json:"delegate"`
-	Signature tktypes.HexBytes    `json:"signature"`
-	Data      tktypes.HexBytes    `json:"data"`
+	UnlockHash tktypes.Bytes32     `json:"unlockHash"`
+	Delegate   *tktypes.EthAddress `json:"delegate"`
+	Signature  tktypes.HexBytes    `json:"signature"`
+	Data       tktypes.HexBytes    `json:"data"`
 }
 
 type parsedCoins struct {

--- a/domains/noto/internal/noto/noto.go
+++ b/domains/noto/internal/noto/noto.go
@@ -141,14 +141,6 @@ type NotoLockParams struct {
 	Data          tktypes.HexBytes `json:"data"`
 }
 
-type NotoUnlockParams struct {
-	LockedInputs  []string         `json:"lockedInputs"`
-	LockedOutputs []string         `json:"lockedOutputs"`
-	Outputs       []string         `json:"outputs"`
-	Signature     tktypes.HexBytes `json:"signature"`
-	Data          tktypes.HexBytes `json:"data"`
-}
-
 type NotoPrepareUnlockParams struct {
 	LockedInputs []string         `json:"lockedInputs"`
 	UnlockHash   tktypes.Bytes32  `json:"unlockHash"`

--- a/domains/noto/internal/noto/receipts.go
+++ b/domains/noto/internal/noto/receipts.go
@@ -37,9 +37,9 @@ func (n *Noto) BuildReceipt(ctx context.Context, req *prototk.BuildReceiptReques
 		receipt.Data = info.Data
 	}
 
-	lockStates := n.filterSchema(req.InfoStates, []string{n.lockInfoSchema.Id})
-	if len(lockStates) == 1 {
-		lock, err := n.unmarshalLock(lockStates[0].StateDataJson)
+	lockInfoStates := n.filterSchema(req.InfoStates, []string{n.lockInfoSchema.Id})
+	if len(lockInfoStates) == 1 {
+		lock, err := n.unmarshalLock(lockInfoStates[0].StateDataJson)
 		if err != nil {
 			return nil, err
 		}
@@ -79,7 +79,6 @@ func (n *Noto) BuildReceipt(ctx context.Context, req *prototk.BuildReceiptReques
 		// For prepareUnlock transactions, include the encoded "unlock" call that can be used to unlock the coins
 		unlock := interfaceBuild.ABI.Functions()["unlock"]
 		params := &NotoUnlockParams{
-			LockID:        receipt.LockInfo.LockID,
 			LockedInputs:  endorsableStateIDs(n.filterSchema(req.ReadStates, []string{n.lockedCoinSchema.Id})),
 			LockedOutputs: endorsableStateIDs(n.filterSchema(req.InfoStates, []string{n.lockedCoinSchema.Id})),
 			Outputs:       endorsableStateIDs(n.filterSchema(req.InfoStates, []string{n.coinSchema.Id})),

--- a/domains/noto/internal/noto/receipts.go
+++ b/domains/noto/internal/noto/receipts.go
@@ -78,12 +78,14 @@ func (n *Noto) BuildReceipt(ctx context.Context, req *prototk.BuildReceiptReques
 	if receipt.LockInfo != nil && len(receipt.States.ReadLockedInputs) > 0 && len(receipt.States.PreparedOutputs) > 0 {
 		// For prepareUnlock transactions, include the encoded "unlock" call that can be used to unlock the coins
 		unlock := interfaceBuild.ABI.Functions()["unlock"]
-		params := &NotoUnlockParams{
+		receipt.LockInfo.UnlockParams = &types.UnlockPublicParams{
 			LockedInputs:  endorsableStateIDs(n.filterSchema(req.ReadStates, []string{n.lockedCoinSchema.Id})),
 			LockedOutputs: endorsableStateIDs(n.filterSchema(req.InfoStates, []string{n.lockedCoinSchema.Id})),
 			Outputs:       endorsableStateIDs(n.filterSchema(req.InfoStates, []string{n.coinSchema.Id})),
+			Signature:     tktypes.HexBytes{},
+			Data:          tktypes.HexBytes{},
 		}
-		paramsJSON, err := json.Marshal(params)
+		paramsJSON, err := json.Marshal(receipt.LockInfo.UnlockParams)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +93,7 @@ func (n *Noto) BuildReceipt(ctx context.Context, req *prototk.BuildReceiptReques
 		if err != nil {
 			return nil, err
 		}
-		receipt.LockInfo.Unlock = encodedCall
+		receipt.LockInfo.UnlockCall = encodedCall
 	}
 
 	receipt.Transfers, err = n.receiptTransfers(ctx, req)

--- a/domains/noto/internal/noto/states.go
+++ b/domains/noto/internal/noto/states.go
@@ -508,41 +508,19 @@ func (n *Noto) encodeUnlock(ctx context.Context, contract *ethtypes.Address0xHex
 	})
 }
 
-func (n *Noto) encodeUnlockMasked(ctx context.Context, contract *ethtypes.Address0xHex, lockedInputs, lockedOutputs, outputs []*prototk.EndorsableState, data tktypes.HexBytes) (ethtypes.HexBytes0xPrefix, error) {
-	return eip712.EncodeTypedDataV4(ctx, &eip712.TypedData{
-		Types:       NotoUnlockMaskedTypeSet,
-		PrimaryType: "Unlock",
-		Domain:      n.eip712Domain(contract),
-		Message: map[string]any{
-			"lockedInputs":  stringToAny(endorsableStateIDs(lockedInputs)),
-			"lockedOutputs": stringToAny(endorsableStateIDs(lockedOutputs)),
-			"outputs":       stringToAny(endorsableStateIDs(outputs)),
-			"data":          data,
-		},
-	})
+func (n *Noto) unlockHashFromStates(ctx context.Context, contract *ethtypes.Address0xHex, lockedInputs, lockedOutputs, outputs []*prototk.EndorsableState, data tktypes.HexBytes) (ethtypes.HexBytes0xPrefix, error) {
+	return n.unlockHashFromIDs(ctx, contract, endorsableStateIDs(lockedInputs), endorsableStateIDs(lockedOutputs), endorsableStateIDs(outputs), data)
 }
 
-func (n *Noto) unlockHashFromEncodedCall(ctx context.Context, contract *ethtypes.Address0xHex, encodedUnlock tktypes.HexBytes, data tktypes.HexBytes) (ethtypes.HexBytes0xPrefix, error) {
-	decodedUnlock, err := interfaceBuild.ABI.Functions()["unlock"].DecodeCallDataCtx(ctx, encodedUnlock)
-	if err != nil {
-		return nil, err
-	}
-	unlockJSON, err := tktypes.StandardABISerializer().SerializeJSON(decodedUnlock)
-	if err != nil {
-		return nil, err
-	}
-	var unlockParams NotoUnlockParams
-	if err := json.Unmarshal(unlockJSON, &unlockParams); err != nil {
-		return nil, err
-	}
+func (n *Noto) unlockHashFromIDs(ctx context.Context, contract *ethtypes.Address0xHex, lockedInputs, lockedOutputs, outputs []string, data tktypes.HexBytes) (ethtypes.HexBytes0xPrefix, error) {
 	return eip712.EncodeTypedDataV4(ctx, &eip712.TypedData{
 		Types:       NotoUnlockMaskedTypeSet,
 		PrimaryType: "Unlock",
 		Domain:      n.eip712Domain(contract),
 		Message: map[string]any{
-			"lockedInputs":  stringToAny(unlockParams.LockedInputs),
-			"lockedOutputs": stringToAny(unlockParams.LockedOutputs),
-			"outputs":       stringToAny(unlockParams.Outputs),
+			"lockedInputs":  stringToAny(lockedInputs),
+			"lockedOutputs": stringToAny(lockedOutputs),
+			"outputs":       stringToAny(outputs),
 			"data":          data,
 		},
 	})

--- a/domains/noto/pkg/types/abi.go
+++ b/domains/noto/pkg/types/abi.go
@@ -92,6 +92,7 @@ type UnlockParams struct {
 
 type DelegateLockParams struct {
 	LockID   tktypes.Bytes32     `json:"lockId"`
+	Unlock   tktypes.HexBytes    `json:"unlock"`
 	Delegate *tktypes.EthAddress `json:"delegate"`
 	Data     tktypes.HexBytes    `json:"data"`
 }

--- a/domains/noto/pkg/types/abi.go
+++ b/domains/noto/pkg/types/abi.go
@@ -92,7 +92,7 @@ type UnlockParams struct {
 
 type DelegateLockParams struct {
 	LockID   tktypes.Bytes32     `json:"lockId"`
-	Unlock   tktypes.HexBytes    `json:"unlock"`
+	Unlock   *UnlockPublicParams `json:"unlock"`
 	Delegate *tktypes.EthAddress `json:"delegate"`
 	Data     tktypes.HexBytes    `json:"data"`
 }
@@ -100,6 +100,14 @@ type DelegateLockParams struct {
 type UnlockRecipient struct {
 	To     string              `json:"to"`
 	Amount *tktypes.HexUint256 `json:"amount"`
+}
+
+type UnlockPublicParams struct {
+	LockedInputs  []string         `json:"lockedInputs"`
+	LockedOutputs []string         `json:"lockedOutputs"`
+	Outputs       []string         `json:"outputs"`
+	Signature     tktypes.HexBytes `json:"signature"`
+	Data          tktypes.HexBytes `json:"data"`
 }
 
 type ApproveExtraParams struct {

--- a/domains/noto/pkg/types/states.go
+++ b/domains/noto/pkg/types/states.go
@@ -39,9 +39,10 @@ type ReceiptStates struct {
 }
 
 type ReceiptLockInfo struct {
-	LockID   tktypes.Bytes32     `json:"lockId"`
-	Delegate *tktypes.EthAddress `json:"delegate,omitempty"` // only set for delegateLock
-	Unlock   tktypes.HexBytes    `json:"unlock,omitempty"`   // only set for prepareUnlock
+	LockID     tktypes.Bytes32     `json:"lockId"`
+	Delegate   *tktypes.EthAddress `json:"delegate,omitempty"`   // only set for delegateLock
+	UnlockHash tktypes.Bytes32     `json:"unlockHash,omitempty"` // only set for prepareUnlock/delegateLock
+	Unlock     tktypes.HexBytes    `json:"unlock,omitempty"`     // only set for prepareUnlock
 }
 
 type ReceiptState struct {

--- a/domains/noto/pkg/types/states.go
+++ b/domains/noto/pkg/types/states.go
@@ -39,10 +39,10 @@ type ReceiptStates struct {
 }
 
 type ReceiptLockInfo struct {
-	LockID     tktypes.Bytes32     `json:"lockId"`
-	Delegate   *tktypes.EthAddress `json:"delegate,omitempty"`   // only set for delegateLock
-	UnlockHash tktypes.Bytes32     `json:"unlockHash,omitempty"` // only set for prepareUnlock/delegateLock
-	Unlock     tktypes.HexBytes    `json:"unlock,omitempty"`     // only set for prepareUnlock
+	LockID       tktypes.Bytes32     `json:"lockId"`
+	Delegate     *tktypes.EthAddress `json:"delegate,omitempty"`     // only set for delegateLock
+	UnlockParams *UnlockPublicParams `json:"unlockParams,omitempty"` // only set for prepareUnlock
+	UnlockCall   tktypes.HexBytes    `json:"unlockCall,omitempty"`   // only set for prepareUnlock
 }
 
 type ReceiptState struct {

--- a/example/swap/src/index.ts
+++ b/example/swap/src/index.ts
@@ -196,6 +196,7 @@ async function main(): Promise<boolean> {
   logger.log("Approving asset leg...");
   receipt = await notoAsset.using(paladin2).delegateLock(investor1, {
     lockId,
+    unlock: encodedAssetTransfer,
     delegate: atom.address,
     data: "0x",
   });

--- a/example/swap/src/index.ts
+++ b/example/swap/src/index.ts
@@ -147,8 +147,9 @@ async function main(): Promise<boolean> {
   receipt = await paladin2.getTransactionReceipt(receipt.id, true);
 
   domainReceipt = receipt?.domainReceipt as INotoDomainReceipt | undefined;
-  const encodedAssetTransfer = domainReceipt?.lockInfo?.unlock;
-  if (encodedAssetTransfer === undefined) {
+  const assetUnlockParams = domainReceipt?.lockInfo?.unlockParams;
+  const assetUnlockCall = domainReceipt?.lockInfo?.unlockCall;
+  if (assetUnlockParams === undefined || assetUnlockCall === undefined) {
     logger.error("No unlock data found in domain receipt");
     return false;
   }
@@ -183,7 +184,7 @@ async function main(): Promise<boolean> {
   const atom = await atomFactory.create(cashIssuer, [
     {
       contractAddress: notoAsset.address,
-      callData: encodedAssetTransfer,
+      callData: assetUnlockCall,
     },
     {
       contractAddress: zetoCash.address,
@@ -196,7 +197,7 @@ async function main(): Promise<boolean> {
   logger.log("Approving asset leg...");
   receipt = await notoAsset.using(paladin2).delegateLock(investor1, {
     lockId,
-    unlock: encodedAssetTransfer,
+    unlock: assetUnlockParams,
     delegate: atom.address,
     data: "0x",
   });

--- a/sdk/typescript/src/domains/noto.ts
+++ b/sdk/typescript/src/domains/noto.ts
@@ -117,12 +117,12 @@ export interface UnlockRecipient {
 
 export interface NotoDelegateLockParams {
   lockId: string;
+  unlock: string;
   delegate: string;
   data: string;
 }
 
 export interface NotoUnlockPublicParams {
-  lockId: string;
   lockedInputs: string[];
   lockedOutputs: string[];
   outputs: string[];
@@ -345,7 +345,6 @@ export class NotoInstance {
 
   encodeUnlock(data: NotoUnlockPublicParams) {
     return new ethers.Interface(notoJSON.abi).encodeFunctionData("unlock", [
-      data.lockId,
       data.lockedInputs,
       data.lockedOutputs,
       data.outputs,

--- a/sdk/typescript/src/domains/noto.ts
+++ b/sdk/typescript/src/domains/noto.ts
@@ -117,7 +117,7 @@ export interface UnlockRecipient {
 
 export interface NotoDelegateLockParams {
   lockId: string;
-  unlock: string;
+  unlock: NotoUnlockPublicParams;
   delegate: string;
   data: string;
 }

--- a/sdk/typescript/src/interfaces/transaction.ts
+++ b/sdk/typescript/src/interfaces/transaction.ts
@@ -101,6 +101,7 @@ export interface INotoDomainReceipt {
   lockInfo?: {
     lockId: string;
     delegate?: string;
+    unlockHash?: string;
     unlock?: string;
   };
   data?: string;

--- a/sdk/typescript/src/interfaces/transaction.ts
+++ b/sdk/typescript/src/interfaces/transaction.ts
@@ -1,3 +1,4 @@
+import { NotoUnlockPublicParams } from "../domains/noto";
 import { IStateBase } from "./states";
 import { ethers } from "ethers";
 
@@ -101,8 +102,8 @@ export interface INotoDomainReceipt {
   lockInfo?: {
     lockId: string;
     delegate?: string;
-    unlockHash?: string;
-    unlock?: string;
+    unlockParams?: NotoUnlockPublicParams;
+    unlockCall?: string;
   };
   data?: string;
 }

--- a/solidity/contracts/domains/interfaces/INoto.sol
+++ b/solidity/contracts/domains/interfaces/INoto.sol
@@ -21,7 +21,6 @@ interface INoto {
     );
 
     event NotoLock(
-        bytes32 lockId,
         bytes32[] inputs,
         bytes32[] outputs,
         bytes32[] lockedOutputs,
@@ -30,7 +29,6 @@ interface INoto {
     );
 
     event NotoUnlock(
-        bytes32 lockId,
         address sender,
         bytes32[] lockedInputs,
         bytes32[] lockedOutputs,
@@ -40,7 +38,6 @@ interface INoto {
     );
 
     event NotoUnlockPrepared(
-        bytes32 lockId,
         bytes32[] lockedInputs,
         bytes32 unlockHash,
         bytes signature,
@@ -48,7 +45,7 @@ interface INoto {
     );
 
     event NotoLockDelegated(
-        bytes32 lockId,
+        bytes32 unlockHash,
         address delegate,
         bytes signature,
         bytes data
@@ -87,7 +84,6 @@ interface INoto {
     ) external;
 
     function lock(
-        bytes32 lockId,
         bytes32[] calldata inputs,
         bytes32[] calldata outputs,
         bytes32[] calldata lockedOutputs,
@@ -96,7 +92,6 @@ interface INoto {
     ) external;
 
     function unlock(
-        bytes32 lockId,
         bytes32[] calldata lockedInputs,
         bytes32[] calldata lockedOutputs,
         bytes32[] calldata outputs,
@@ -105,7 +100,6 @@ interface INoto {
     ) external;
 
     function prepareUnlock(
-        bytes32 lockId,
         bytes32[] calldata lockedInputs,
         bytes32 unlockHash,
         bytes calldata signature,
@@ -113,7 +107,7 @@ interface INoto {
     ) external;
 
     function delegateLock(
-        bytes32 lockId,
+        bytes32 unlockHash,
         address delegate,
         bytes calldata signature,
         bytes calldata data

--- a/solidity/contracts/domains/interfaces/INotoErrors.sol
+++ b/solidity/contracts/domains/interfaces/INotoErrors.sol
@@ -14,19 +14,7 @@ interface INotoErrors {
 
     error NotoInvalidDelegate(bytes32 txhash, address delegate, address sender);
 
-    error NotoLockNotFound(bytes32 lockId);
+    error NotoInvalidUnlockHash(bytes32 expected, bytes32 actual);
 
-    error NotoInvalidLockState(bytes32 lockId);
-
-    error NotoInvalidLockDelegate(
-        bytes32 lockId,
-        address delegate,
-        address sender
-    );
-
-    error NotoInvalidUnlockHash(
-        bytes32 lockId,
-        bytes32 expected,
-        bytes32 actual
-    );
+    error NotoAlreadyPrepared(bytes32 unlockHash);
 }

--- a/solidity/contracts/domains/interfaces/INotoPrivate.sol
+++ b/solidity/contracts/domains/interfaces/INotoPrivate.sol
@@ -49,6 +49,7 @@ interface INotoPrivate {
 
     function delegateLock(
         bytes32 lockId,
+        bytes calldata unlock,
         address delegate,
         bytes calldata data
     ) external;

--- a/solidity/contracts/domains/interfaces/INotoPrivate.sol
+++ b/solidity/contracts/domains/interfaces/INotoPrivate.sol
@@ -28,10 +28,7 @@ interface INotoPrivate {
         address delegate
     ) external;
 
-    function lock(
-        uint256 amount,
-        bytes calldata data
-    ) external;
+    function lock(uint256 amount, bytes calldata data) external;
 
     function unlock(
         bytes32 lockId,
@@ -49,7 +46,7 @@ interface INotoPrivate {
 
     function delegateLock(
         bytes32 lockId,
-        bytes calldata unlock,
+        UnlockPublicParams calldata unlock,
         address delegate,
         bytes calldata data
     ) external;
@@ -65,5 +62,13 @@ interface INotoPrivate {
     struct UnlockRecipient {
         string to;
         uint256 amount;
+    }
+
+    struct UnlockPublicParams {
+        bytes32[] lockedInputs;
+        bytes32[] lockedOutputs;
+        bytes32[] outputs;
+        bytes signature;
+        bytes data;
     }
 }

--- a/solidity/contracts/domains/noto/Noto.sol
+++ b/solidity/contracts/domains/noto/Noto.sol
@@ -28,14 +28,10 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
     address _notary;
     mapping(bytes32 => bool) private _unspent;
     mapping(bytes32 => address) private _approvals;
-    mapping(bytes32 => LockDetail) private _locks;
 
-    struct LockDetail {
-        uint256 stateCount;
-        mapping(bytes32 => bool) states;
-        bytes32 unlockHash;
-        address delegate;
-    }
+    mapping(bytes32 => bool) private _locked;
+    mapping(bytes32 => bytes32) private _unlockHashes; // state ID => unlock hash
+    mapping(bytes32 => address) private _unlockDelegates; // unlock hash => delegate
 
     // Config follows the convention of a 4 byte type selector, followed by ABI encoded bytes
     bytes4 public constant NotoConfigID_V0 = 0x00010000;
@@ -66,11 +62,14 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
         _;
     }
 
-    function requireLockDelegate(bytes32 lockId, address addr) internal view {
-        if (addr != _locks[lockId].delegate) {
-            revert NotoInvalidLockDelegate(
-                lockId,
-                _locks[lockId].delegate,
+    function requireLockDelegate(
+        bytes32 unlockHash,
+        address addr
+    ) internal view {
+        if (addr != _unlockDelegates[unlockHash]) {
+            revert NotoInvalidDelegate(
+                unlockHash,
+                _unlockDelegates[unlockHash],
                 addr
             );
         }
@@ -122,15 +121,11 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
 
     /**
      * @dev query whether a TXO is currently locked
-     * @param lockId the lock identifier
      * @param id the UTXO identifier
      * @return locked true or false depending on whether the identifier is locked
      */
-    function isLocked(
-        bytes32 lockId,
-        bytes32 id
-    ) public view returns (bool locked) {
-        return _locks[lockId].states[id];
+    function isLocked(bytes32 id) public view returns (bool locked) {
+        return _locked[id];
     }
 
     /**
@@ -207,7 +202,7 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
      */
     function _processOutputs(bytes32[] memory outputs) internal {
         for (uint256 i = 0; i < outputs.length; ++i) {
-            if (_unspent[outputs[i]]) {
+            if (_unspent[outputs[i]] || _locked[outputs[i]]) {
                 revert NotoInvalidOutput(outputs[i]);
             }
             _unspent[outputs[i]] = true;
@@ -304,7 +299,6 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
     /**
      * @dev Lock some value so it cannot be spent until it is unlocked.
      *
-     * @param lockId the unique identifier for this lock
      * @param inputs array of zero or more outputs of a previous function call against this
      *      contract that have not yet been spent, and the signer is authorized to spend
      * @param outputs array of zero or more new outputs to generate, for future transactions to spend
@@ -315,7 +309,6 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
      * Emits a {NotoLock} event.
      */
     function lock(
-        bytes32 lockId,
         bytes32[] calldata inputs,
         bytes32[] calldata outputs,
         bytes32[] calldata lockedOutputs,
@@ -324,8 +317,8 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
     ) public virtual override onlyNotary {
         _processInputs(inputs);
         _processOutputs(outputs);
-        _processLockedOutputs(lockId, lockedOutputs);
-        emit NotoLock(lockId, inputs, outputs, lockedOutputs, signature, data);
+        _processLockedOutputs(lockedOutputs);
+        emit NotoLock(inputs, outputs, lockedOutputs, signature, data);
     }
 
     /**
@@ -333,7 +326,6 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
      *      May be triggered by the notary (if lock is undelegated) or by the current lock delegate.
      *      If triggered by the lock delegate, only a prepared unlock operation may be triggered.
      *
-     * @param lockId the unique identifier for the lock
      * @param lockedInputs array of zero or more locked outputs of a previous function call
      * @param lockedOutputs array of zero or more locked outputs to generate, which will be tied to the lock ID
      * @param outputs array of zero or more new unlocked outputs to generate, for future transactions to spend
@@ -343,49 +335,49 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
      * Emits a {NotoUnlock} event.
      */
     function unlock(
-        bytes32 lockId,
         bytes32[] calldata lockedInputs,
         bytes32[] calldata lockedOutputs,
         bytes32[] calldata outputs,
         bytes calldata signature,
         bytes calldata data
     ) external virtual override {
-        LockDetail storage lock_ = _locks[lockId];
-        if (lock_.stateCount == 0) {
-            revert NotoLockNotFound(lockId);
+        bytes32 expectedHash;
+        if (lockedInputs.length > 0) {
+            expectedHash = _unlockHashes[lockedInputs[0]];
+            delete _unlockHashes[lockedInputs[0]];
+        }
+        for (uint256 i = 1; i < lockedInputs.length; ++i) {
+            if (_unlockHashes[lockedInputs[i]] != expectedHash) {
+                revert NotoInvalidInput(lockedInputs[i]);
+            }
+            delete _unlockHashes[lockedInputs[i]];
         }
 
-        if (lock_.delegate == address(0)) {
+        address delegate = _unlockDelegates[expectedHash];
+        if (delegate == address(0)) {
             requireNotary(msg.sender);
         } else {
-            requireLockDelegate(lockId, msg.sender);
+            requireLockDelegate(expectedHash, msg.sender);
+            delete _unlockDelegates[expectedHash];
 
-            if (lock_.unlockHash != 0) {
-                bytes32 unlockHash = _buildUnlockHash(
+            if (expectedHash != 0) {
+                bytes32 actualHash = _buildUnlockHash(
                     lockedInputs,
                     lockedOutputs,
                     outputs,
                     data
                 );
-                if (lock_.unlockHash != unlockHash) {
-                    revert NotoInvalidUnlockHash(
-                        lockId,
-                        lock_.unlockHash,
-                        unlockHash
-                    );
+                if (actualHash != expectedHash) {
+                    revert NotoInvalidUnlockHash(expectedHash, actualHash);
                 }
             }
         }
 
-        delete lock_.delegate;
-        delete lock_.unlockHash;
-
-        _processLockedInputs(lockId, lockedInputs);
-        _processLockedOutputs(lockId, lockedOutputs);
+        _processLockedInputs(lockedInputs);
+        _processLockedOutputs(lockedOutputs);
         _processOutputs(outputs);
 
         emit NotoUnlock(
-            lockId,
             msg.sender,
             lockedInputs,
             lockedOutputs,
@@ -399,7 +391,6 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
      * @dev Prepare an unlock operation that can be triggered later.
      *      May only be triggered by the notary, and only if the lock is not delegated.
      *
-     * @param lockId the unique identifier for the lock
      * @param lockedInputs array of zero or more locked outputs of a previous function call
      * @param unlockHash pre-calculated EIP-712 hash of the prepared unlock transaction
      * @param signature a signature over the original request to the notary (opaque to the blockchain)
@@ -408,30 +399,19 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
      * Emits a {NotoUnlockPrepared} event.
      */
     function prepareUnlock(
-        bytes32 lockId,
         bytes32[] calldata lockedInputs,
         bytes32 unlockHash,
         bytes calldata signature,
         bytes calldata data
     ) external virtual override onlyNotary {
-        LockDetail storage lock_ = _locks[lockId];
-        if (lock_.stateCount == 0) {
-            revert NotoLockNotFound(lockId);
+        if (_unlockDelegates[unlockHash] != address(0)) {
+            revert NotoAlreadyPrepared(unlockHash);
         }
-        if (lock_.delegate != address(0)) {
-            revert NotoInvalidLockState(lockId);
+        _checkLockedInputs(lockedInputs);
+        for (uint256 i = 0; i < lockedInputs.length; ++i) {
+            _unlockHashes[lockedInputs[i]] = unlockHash;
         }
-
-        _checkLockedInputs(lockId, lockedInputs);
-        lock_.unlockHash = unlockHash;
-
-        emit NotoUnlockPrepared(
-            lockId,
-            lockedInputs,
-            unlockHash,
-            signature,
-            data
-        );
+        emit NotoUnlockPrepared(lockedInputs, unlockHash, signature, data);
     }
 
     /**
@@ -439,7 +419,6 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
      *      May be triggered by the notary (if lock is undelegated) or by the current lock delegate.
      *      May only be triggered after an unlock operation has been prepared.
      *
-     * @param lockId the unique identifier for the lock
      * @param delegate the address that is authorized to perform the unlock
      * @param signature a signature over the original request to the notary (opaque to the blockchain)
      * @param data any additional transaction data (opaque to the blockchain)
@@ -447,40 +426,27 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
      * Emits a {NotoLockDelegated} event.
      */
     function delegateLock(
-        bytes32 lockId,
+        bytes32 unlockHash,
         address delegate,
         bytes calldata signature,
         bytes calldata data
     ) external virtual {
-        LockDetail storage lock_ = _locks[lockId];
-        if (lock_.stateCount == 0) {
-            revert NotoLockNotFound(lockId);
-        }
-        if (lock_.unlockHash == 0) {
-            revert NotoInvalidLockState(lockId);
-        }
-
-        if (lock_.delegate == address(0)) {
+        address currentDelegate = _unlockDelegates[unlockHash];
+        if (currentDelegate == address(0)) {
             requireNotary(msg.sender);
         } else {
-            requireLockDelegate(lockId, msg.sender);
+            requireLockDelegate(unlockHash, msg.sender);
         }
-
-        lock_.delegate = delegate;
-
-        emit NotoLockDelegated(lockId, delegate, signature, data);
+        _unlockDelegates[unlockHash] = delegate;
+        emit NotoLockDelegated(unlockHash, delegate, signature, data);
     }
 
     /**
      * @dev Check the inputs are all locked
      */
-    function _checkLockedInputs(
-        bytes32 id,
-        bytes32[] calldata inputs
-    ) internal view {
-        LockDetail storage lock_ = _locks[id];
+    function _checkLockedInputs(bytes32[] calldata inputs) internal view {
         for (uint256 i = 0; i < inputs.length; ++i) {
-            if (lock_.states[inputs[i]] == false) {
+            if (!_locked[inputs[i]]) {
                 revert NotoInvalidInput(inputs[i]);
             }
         }
@@ -489,34 +455,24 @@ contract Noto is EIP712Upgradeable, UUPSUpgradeable, INoto, INotoErrors {
     /**
      * @dev Check the inputs are all locked, and remove them
      */
-    function _processLockedInputs(
-        bytes32 id,
-        bytes32[] calldata inputs
-    ) internal {
-        LockDetail storage lock_ = _locks[id];
+    function _processLockedInputs(bytes32[] calldata inputs) internal {
         for (uint256 i = 0; i < inputs.length; ++i) {
-            if (!lock_.states[inputs[i]]) {
+            if (!_locked[inputs[i]]) {
                 revert NotoInvalidInput(inputs[i]);
             }
-            delete lock_.states[inputs[i]];
-            lock_.stateCount--;
+            delete _locked[inputs[i]];
         }
     }
 
     /**
      * @dev Check the outputs are all new, and mark them as locked
      */
-    function _processLockedOutputs(
-        bytes32 id,
-        bytes32[] calldata outputs
-    ) internal {
-        LockDetail storage lock_ = _locks[id];
+    function _processLockedOutputs(bytes32[] calldata outputs) internal {
         for (uint256 i = 0; i < outputs.length; ++i) {
-            if (lock_.states[outputs[i]]) {
+            if (_locked[outputs[i]] || _unspent[outputs[i]]) {
                 revert NotoInvalidOutput(outputs[i]);
             }
-            lock_.states[outputs[i]] = true;
-            lock_.stateCount++;
+            _locked[outputs[i]] = true;
         }
     }
 }

--- a/solidity/test/domains/noto/util.ts
+++ b/solidity/test/domains/noto/util.ts
@@ -105,7 +105,6 @@ export async function doTransfer(
 export async function doLock(
   notary: Signer,
   noto: Noto,
-  lockId: string,
   inputs: string[],
   outputs: string[],
   lockedOutputs: string[],
@@ -113,7 +112,7 @@ export async function doLock(
 ) {
   const tx = await noto
     .connect(notary)
-    .lock(lockId, inputs, outputs, lockedOutputs, "0x", data);
+    .lock(inputs, outputs, lockedOutputs, "0x", data);
   const results = await tx.wait();
   expect(results).to.exist;
 
@@ -133,7 +132,7 @@ export async function doLock(
     expect(await noto.isUnspent(output)).to.equal(true);
   }
   for (const output of lockedOutputs) {
-    expect(await noto.isLocked(lockId, output)).to.equal(true);
+    expect(await noto.isLocked(output)).to.equal(true);
     expect(await noto.isUnspent(output)).to.equal(false);
   }
 }
@@ -141,7 +140,6 @@ export async function doLock(
 export async function doUnlock(
   sender: Signer,
   noto: Noto,
-  lockId: string,
   lockedInputs: string[],
   lockedOutputs: string[],
   outputs: string[],
@@ -149,7 +147,7 @@ export async function doUnlock(
 ) {
   const tx = await noto
     .connect(sender)
-    .unlock(lockId, lockedInputs, lockedOutputs, outputs, "0x", data);
+    .unlock(lockedInputs, lockedOutputs, outputs, "0x", data);
   const results = await tx.wait();
   expect(results).to.exist;
 
@@ -163,11 +161,11 @@ export async function doUnlock(
     expect(event?.args.data).to.deep.equal(data);
   }
   for (const input of lockedInputs) {
-    expect(await noto.isLocked(lockId, input)).to.equal(false);
+    expect(await noto.isLocked(input)).to.equal(false);
     expect(await noto.isUnspent(input)).to.equal(false);
   }
   for (const output of lockedOutputs) {
-    expect(await noto.isLocked(lockId, output)).to.equal(true);
+    expect(await noto.isLocked(output)).to.equal(true);
     expect(await noto.isUnspent(output)).to.equal(false);
   }
   for (const output of outputs) {
@@ -178,14 +176,13 @@ export async function doUnlock(
 export async function doPrepareUnlock(
   notary: Signer,
   noto: Noto,
-  lockId: string,
   lockedInputs: string[],
   unlockHash: string,
   data: string
 ) {
   const tx = await noto
     .connect(notary)
-    .prepareUnlock(lockId, lockedInputs, unlockHash, "0x", data);
+    .prepareUnlock(lockedInputs, unlockHash, "0x", data);
   const results = await tx.wait();
   expect(results).to.exist;
 
@@ -198,20 +195,20 @@ export async function doPrepareUnlock(
     expect(event?.args.data).to.deep.equal(data);
   }
   for (const input of lockedInputs) {
-    expect(await noto.isLocked(lockId, input)).to.equal(true);
+    expect(await noto.isLocked(input)).to.equal(true);
   }
 }
 
 export async function doDelegateLock(
   notary: Signer,
   noto: Noto,
-  lockId: string,
+  unlockHash: string,
   delegate: string,
   data: string
 ) {
   const tx = await noto
     .connect(notary)
-    .delegateLock(lockId, delegate, "0x", data);
+    .delegateLock(unlockHash, delegate, "0x", data);
   const results = await tx.wait();
   expect(results).to.exist;
 


### PR DESCRIPTION
This alters the functionality introduced in https://github.com/LF-Decentralized-Trust-labs/paladin/pull/483, to remove the "lockId" parameter at the Solidity contract level.

In a chain with https://github.com/LF-Decentralized-Trust-labs/paladin/pull/522