### PR TITLE
Fixing mysql/postgres units

### DIFF
--- a/config/pkg/pldconf/domainmgr.go
+++ b/config/pkg/pldconf/domainmgr.go
@@ -46,5 +46,5 @@ var ContractCacheDefaults = &CacheConfig{
 }
 
 type DomainInitConfig struct {
-	Retry RetryConfig `json:"retry"`
+	Retry RetryConfigWithMax `json:"retry"`
 }

--- a/config/pkg/pldconf/domainmgr.go
+++ b/config/pkg/pldconf/domainmgr.go
@@ -46,5 +46,5 @@ var ContractCacheDefaults = &CacheConfig{
 }
 
 type DomainInitConfig struct {
-	Retry RetryConfigWithMax `json:"retry"`
+	Retry RetryConfig `json:"retry"`
 }

--- a/core/go/internal/domainmgr/domain.go
+++ b/core/go/internal/domainmgr/domain.go
@@ -85,8 +85,8 @@ func (dm *domainManager) newDomain(name string, conf *pldconf.DomainConfig, toDo
 	d := &domain{
 		dm:              dm,
 		conf:            conf,
-		defaultGasLimit: pldconf.DefaultDefaultGasLimit, // can be set by config below
-		initRetry:       retry.NewRetryLimited(&conf.Init.Retry),
+		defaultGasLimit: pldconf.DefaultDefaultGasLimit,             // can be set by config below
+		initRetry:       retry.NewRetryIndefinite(&conf.Init.Retry), // indefinite retry
 		name:            name,
 		api:             toDomain,
 		initDone:        make(chan struct{}),

--- a/core/go/internal/domainmgr/domain.go
+++ b/core/go/internal/domainmgr/domain.go
@@ -86,7 +86,7 @@ func (dm *domainManager) newDomain(name string, conf *pldconf.DomainConfig, toDo
 		dm:              dm,
 		conf:            conf,
 		defaultGasLimit: pldconf.DefaultDefaultGasLimit, // can be set by config below
-		initRetry:       retry.NewRetryIndefinite(&conf.Init.Retry),
+		initRetry:       retry.NewRetryLimited(&conf.Init.Retry),
 		name:            name,
 		api:             toDomain,
 		initDone:        make(chan struct{}),

--- a/core/go/internal/domainmgr/domain_test.go
+++ b/core/go/internal/domainmgr/domain_test.go
@@ -193,6 +193,11 @@ func newTestDomain(t *testing.T, realDB bool, domainConfig *prototk.DomainConfig
 				Config:          map[string]any{"some": "conf"},
 				RegistryAddress: tktypes.RandHex(20),
 				DefaultGasLimit: confutil.P(uint64(100000)),
+				Init: pldconf.DomainInitConfig{
+					Retry: pldconf.RetryConfigWithMax{
+						MaxAttempts: confutil.P(1),
+					},
+				},
 			},
 		},
 	}, extraSetup...)
@@ -256,7 +261,6 @@ func registerTestDomain(t *testing.T, dm *domainManager, tp *testPlugin) {
 	da, err := dm.getDomainByName(context.Background(), "test1")
 	require.NoError(t, err)
 	tp.d = da
-	tp.d.initRetry.UTSetMaxAttempts(1)
 	<-tp.d.initDone
 }
 

--- a/core/go/internal/domainmgr/manager_test.go
+++ b/core/go/internal/domainmgr/manager_test.go
@@ -106,6 +106,7 @@ func newTestDomainManager(t *testing.T, realDB bool, conf *pldconf.DomainManager
 	}
 
 	dm := NewDomainManager(ctx, conf)
+
 	_, err = dm.PreInit(componentMocks)
 	require.NoError(t, err)
 	err = dm.PostInit(componentMocks)

--- a/toolkit/go/pkg/retry/retry.go
+++ b/toolkit/go/pkg/retry/retry.go
@@ -96,7 +96,9 @@ func (r *Retry) WaitDelay(ctx context.Context, failureCount int) error {
 	return nil
 }
 
-// SetMaxAttempts is useful for unit tests
+// UTSetMaxAttempts is a UNIT TEST ONLY function to switch an unlimited retry, into a limited retry.
+// This is helpful to provoke code to return an error condition, rather than just spinning indefinitely
+// retrying against that error condition. For unit tests that are testing individual error conditions.
 func (r *Retry) UTSetMaxAttempts(maxAttempts int) {
 	r.maxAttempts = maxAttempts
 }

--- a/toolkit/go/pkg/retry/retry.go
+++ b/toolkit/go/pkg/retry/retry.go
@@ -65,15 +65,11 @@ func (r *Retry) Do(ctx context.Context, do func(attempt int) (retryable bool, er
 		attempt++
 		retry, err := do(attempt)
 		if err != nil {
-			log.L(ctx).Errorf("%s (attempt=%d, maxAttempts=%d)", err, attempt, r.maxAttempts)
+			log.L(ctx).Errorf("%s (attempt=%d)", err, attempt)
 		}
 		if !retry || err == nil || (r.maxAttempts > 0 && attempt >= r.maxAttempts) {
-			if err != nil {
-				log.L(ctx).Errorf("failed after %d attempts (maxAttempts=%d)", attempt, r.maxAttempts)
-			}
 			return err
 		}
-		log.L(ctx).Infof("retrying. (attempt=%d, maxAttempts=%d)", attempt, r.maxAttempts)
 		if err := r.WaitDelay(ctx, attempt); err != nil {
 			return err
 		}

--- a/toolkit/go/pkg/retry/retry.go
+++ b/toolkit/go/pkg/retry/retry.go
@@ -65,11 +65,15 @@ func (r *Retry) Do(ctx context.Context, do func(attempt int) (retryable bool, er
 		attempt++
 		retry, err := do(attempt)
 		if err != nil {
-			log.L(ctx).Errorf("%s (attempt=%d)", err, attempt)
+			log.L(ctx).Errorf("%s (attempt=%d, maxAttempts=%d)", err, attempt, r.maxAttempts)
 		}
 		if !retry || err == nil || (r.maxAttempts > 0 && attempt >= r.maxAttempts) {
+			if err != nil {
+				log.L(ctx).Errorf("failed after %d attempts (maxAttempts=%d)", attempt, r.maxAttempts)
+			}
 			return err
 		}
+		log.L(ctx).Infof("retrying. (attempt=%d, maxAttempts=%d)", attempt, r.maxAttempts)
 		if err := r.WaitDelay(ctx, attempt); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Fix Race Condition in Unit Tests  

This PR resolves a race condition that occurred during unit testing.  

#### Issue  
The race condition caused inconsistent behavior in test assertions. As shown in the [logs](https://productionresultssa15.blob.core.windows.net/actions-results/8275b8c6-0280-4918-959b-d33aea76e79e/workflow-job-run-ca395085-040a-526b-2ce8-bdc85f692774/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-02-13T21%3A20%3A34Z&sig=qBxE9ojenB%2FxHfLe6sNjZ%2BZ60kp8IRXE1d3kbd3hJjY%3D&ske=2025-02-14T07%3A07%3A02Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-02-13T19%3A07%3A02Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-02-13T21%3A10%3A29Z&sv=2025-01-05), the first error had `maxAttempts=0`, while the second had `maxAttempts=1`:  

```
[2025-02-13T21:07:48.791Z] ERROR PD011642: Events ABI is invalid: invalid character '!' looking for beginning of value (attempt=1, maxAttempts=0) domain=test1  
[2025-02-13T21:07:49.041Z] ERROR all expectations were already fulfilled, call to database transaction Begin was not expected (attempt=2, maxAttempts=1) domain=test1  
```  

This discrepancy occurred because the `Do` function ran in a separate goroutine from the test setting `UTSetMaxAttempts`. As a result, the test encountered an unexpected error message, leading to test failures.  

#### Fix  
The solution is to initialize the retry logic with `maxRetries` at the start, rather than modifying it later. This ensures consistent behavior across test runs and eliminates the race condition.  
