### PR TITLE
Add wait for subID to be set in RPC event listener tests

### DIFF
--- a/core/go/internal/txmgr/rpc_eventstreams_test.go
+++ b/core/go/internal/txmgr/rpc_eventstreams_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/hyperledger/firefly-common/pkg/wsclient"
@@ -112,6 +113,9 @@ func TestRPCEventListenerE2E(t *testing.T) {
 					receipts <- r
 				}
 
+				for subID.Load() == nil { // wait for subID to be set
+					time.Sleep(10 * time.Millisecond)
+				}
 				_, req := rpcTestRequest("ptx_ack", *subID.Load())
 				err = wsc.Send(ctx, req)
 				require.NoError(t, err)
@@ -211,6 +215,9 @@ func TestRPCEventListenerE2ENack(t *testing.T) {
 				switch rpcID {
 				case subReqID: // Subscribe reply
 					subIDChan <- rpcPayload.Result.StringValue()
+					for subID.Load() == nil { // wait for subID to be set
+						time.Sleep(10 * time.Millisecond)
+					}
 				case unSubReqID.Load(): // Unsubscribe reply
 					unSubChan <- true
 				}


### PR DESCRIPTION
This test: [paladin-test](https://productionresultssa5.blob.core.windows.net/actions-results/545eda5b-1a6f-452d-8725-03a1cf44b19b/workflow-job-run-ca395085-040a-526b-2ce8-bdc85f692774/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-02-18T15%3A02%3A56Z&sig=irfWG9kadJBDrP3T8lCYPi%2F2Cr6As%2F9RmuPmg5klNOA%3D&ske=2025-02-19T00%3A43%3A44Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-02-18T12%3A43%3A44Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-02-18T14%3A52%3A51Z&sv=2025-01-05)
We get the following panic:
```
2025-02-18T14:48:06.3624691Z [2025-02-18T14:48:03.320Z]  INFO Delivering receipt batch 1 to subscription 26d276bb-774c-4f17-9270-db22348038cf over JSON/RPC receipt-listener=listener1
2025-02-18T14:48:06.3624902Z panic: runtime error: invalid memory address or nil pointer dereference
2025-02-18T14:48:06.3625112Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf20eae]
2025-02-18T14:48:06.3625123Z 
2025-02-18T14:48:06.3625225Z goroutine 1209 [running]:
2025-02-18T14:48:06.3625514Z github.com/kaleido-io/paladin/core/internal/txmgr.TestRPCEventListenerE2ENack.func1()
2025-02-18T14:48:06.3625871Z 	/home/runner/work/paladin/paladin/core/go/internal/txmgr/rpc_eventstreams_test.go:226 +0x3ce
2025-02-18T14:48:06.3626371Z created by github.com/kaleido-io/paladin/core/internal/txmgr.TestRPCEventListenerE2ENack in goroutine 1088
2025-02-18T14:48:06.3626846Z 	/home/runner/work/paladin/paladin/core/go/internal/txmgr/rpc_eventstreams_test.go:196 +0x44b
2025-02-18T14:48:06.3627041Z FAIL	github.com/kaleido-io/paladin/core/internal/txmgr	0.677s
2025-02-18T14:48:06.3627120Z FAIL
```

There is a race condition between two goroutines: one stores to the `subID`, and the other loads from it. However, the test doesn’t ensure that the `subID` is set before attempting to load it. This PR modifies the test to wait for the `subID` to be stored before performing the load.