### PR TITLE
Publishing of Solidity Artifacts in GitHub Releases

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -157,7 +157,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         with:
-          mark_as_latest: false # the release is marked as latest in the next step
+          mark_as_latest: false # the release job is marked as latest
           charts_dir: "operator/charts"
           skip_existing: true
         env: 
@@ -165,15 +165,13 @@ jobs:
 
       - name: Prepare CRs artifacts
         run: ./gradlew prepareArtifacts -PartifactDir=${{ github.workspace }}/artifacts
-      - name: Release
-        uses: softprops/action-gh-release@v2
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ inputs.chart_tag }}
-          body: "Release ${{ inputs.chart_tag }}"
-          generate_release_notes: true
-          make_latest: ${{ inputs.latest }}
-          files: |
-            ${{ github.workspace }}/artifacts/basenet.yaml
-            ${{ github.workspace }}/artifacts/devnet.yaml
-            ${{ github.workspace }}/artifacts/artifacts.tar.gz
+          name: helm-artifacts
+          path: |
+              ${{ github.workspace }}/artifacts/basenet.yaml
+              ${{ github.workspace }}/artifacts/devnet.yaml
+              ${{ github.workspace }}/artifacts/artifacts.tar.gz
  

--- a/.github/workflows/release-solidity-contracts.yaml
+++ b/.github/workflows/release-solidity-contracts.yaml
@@ -1,0 +1,38 @@
+name: Publish Solidity Contracts
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Install pre-requisites
+      uses: ./.github/actions/setup
+
+    - name: Build
+      working-directory: solidity
+      run: ../gradlew build 
+
+    - name: Copy Solidity artifacts to contracts directory
+      run: |
+        mkdir -p contracts
+        find solidity/artifacts/contracts -type f -name "*.json" ! -name "*.dbg.json" -exec cp {} contracts/ \;
+
+    - name: Archive ABI directory
+      run: |
+        tar -czvf contracts.tar.gz -C contracts .
+
+    - name: Upload artifacts for inspection (optional)
+      uses: actions/upload-artifact@v4
+      with:
+        name: contracts
+        path: contracts.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
         description: 'Release tag (chart and images)'
-        
+
 jobs:
   set-variables:
     runs-on: ubuntu-latest
@@ -47,7 +47,6 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "latest=$LATEST" >> $GITHUB_OUTPUT
 
-
   release-images:
     needs: set-variables
     uses: ./.github/workflows/release-images.yaml
@@ -64,13 +63,50 @@ jobs:
     with:
       chart_tag: ${{ needs.set-variables.outputs.tag }}
       images_tag: ${{ needs.set-variables.outputs.tag }}
-      latest: '${{ fromJSON(needs.set-variables.outputs.latest) }}'
       registry: docker.io
     secrets:
       CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  release-solidity-contracts:
+    uses: ./.github/workflows/release-solidity-contracts.yaml
+
+  release:
+    needs: [set-variables, release-charts, release-solidity-contracts]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Helm artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: helm-artifacts
+          path: helm-artifacts/
+
+      - name: Download Solidity artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: contracts
+          path: contracts/
+
+      - name: List downloaded artifacts
+        run: |
+          ls -R
+
+      - name: Create release with all artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.set-variables.outputs.tag }}
+          body: "Release ${{ needs.set-variables.outputs.tag }}"
+          generate_release_notes: true
+          make_latest: '${{ fromJSON(needs.set-variables.outputs.latest) }}'
+          files: |
+            helm-artifacts/basenet.yaml
+            helm-artifacts/devnet.yaml
+            helm-artifacts/artifacts.tar.gz
+            contracts/contracts.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   release-typescript-sdk:
-    needs: [set-variables, release-charts]
+    needs: [set-variables, release]
     uses: ./.github/workflows/release-typescript-sdk.yaml
     with:
       sdk_version: ${{ needs.set-variables.outputs.tag }}


### PR DESCRIPTION
# Overview

As part of our effort to streamline the user experience with Paladin tutorials (#555 ), we want to publish Solidity artifacts as part of our GitHub release process. This PR implements the first step of our implementation plan:

## What this PR does

Automates the generation and publication of Solidity artifacts during the release process via GitHub Actions.
Ensures that every new release includes pre-compiled Solidity artifacts, making them readily available for users without the need for local compilation.

## Next Steps
Now, we need to update the tutorial documentation to reflect this change. 
We'll need to:
1. Instruct users to clone the latest stable tag rather than main.
2. Provide steps for downloading and using the Solidity artifacts from the release page.

# Release

Here are the released artifacts ([source](https://github.com/dwertent/paladin/releases/tag/v0.1.1)):
<img width="262" alt="image" src="https://github.com/user-attachments/assets/a1c3b528-3c47-4f30-9193-75644b583797" />

Here is the new flow ([source](https://github.com/dwertent/paladin/actions/runs/13396292675)):
<img width="1477" alt="image" src="https://github.com/user-attachments/assets/e8b590ca-36d6-4412-a886-a0f59d585b22" />

 