### PR TITLE
Address fields in filters for tx

### DIFF
--- a/core/go/internal/txmgr/transaction_query.go
+++ b/core/go/internal/txmgr/transaction_query.go
@@ -37,9 +37,9 @@ var transactionFilters = filters.FieldMap{
 	"created":        filters.TimestampField("created"),
 	"abiReference":   filters.TimestampField("abi_ref"),
 	"functionName":   filters.StringField("fn_name"),
-	"domain":         filters.StringField("domain"),
-	"from":           filters.StringField("from"),
-	"to":             filters.HexBytesField("to"),
+	"domain":         filters.StringField(`transactions.domain`),
+	"from":           filters.StringField(`"from"`),
+	"to":             filters.HexBytesField(`"to"`),
 }
 
 func (tm *txManager) mapPersistedTXBase(pt *persistedTransaction) *pldapi.Transaction {

--- a/core/go/internal/txmgr/transaction_query.go
+++ b/core/go/internal/txmgr/transaction_query.go
@@ -37,7 +37,7 @@ var transactionFilters = filters.FieldMap{
 	"created":        filters.TimestampField("created"),
 	"abiReference":   filters.TimestampField("abi_ref"),
 	"functionName":   filters.StringField("fn_name"),
-	"domain":         filters.StringField(`transactions.domain`),
+	"domain":         filters.StringField(`"transactions"."domain"`),
 	"from":           filters.StringField(`"from"`),
 	"to":             filters.HexBytesField(`"to"`),
 	"type":           filters.StringField(`"type"`),

--- a/core/go/internal/txmgr/transaction_query.go
+++ b/core/go/internal/txmgr/transaction_query.go
@@ -40,6 +40,7 @@ var transactionFilters = filters.FieldMap{
 	"domain":         filters.StringField(`transactions.domain`),
 	"from":           filters.StringField(`"from"`),
 	"to":             filters.HexBytesField(`"to"`),
+	"type":           filters.StringField(`"type"`),
 }
 
 func (tm *txManager) mapPersistedTXBase(pt *persistedTransaction) *pldapi.Transaction {


### PR DESCRIPTION
It was observed that using JSON Query for transactions would result in either unexpected errors (unknown columns or invalid SQL statements). After examining the code it could be verified that the issue was simply due to the way the FieldMap was defined for the filters. Specifically reserved SQL words ("from", "to") need to be escaped. In addition, "domain" needs to be changed to "transactions.domain" to remove ambiguity. 
With the changes in place, the JSON queries run against transactions correctly return the expected results.