### PR TITLE
Make RPCSubscriptionNotification an interface

### DIFF
--- a/core/go/pkg/blockindexer/block_listener_test.go
+++ b/core/go/pkg/blockindexer/block_listener_test.go
@@ -256,10 +256,7 @@ func TestBlockListenerWSShoulderTap(t *testing.T) {
 							for !complete {
 								time.Sleep(100 * time.Microsecond)
 								if bl.newHeadsSub != nil {
-									bl.newHeadsSub.Notifications() <- &rpcclient.RPCSubscriptionNotification{
-										CurrentSubID: bl.newHeadsSub.LocalID().String(),
-										Result:       tktypes.JSONString("anything"),
-									}
+									bl.newHeadsSub.Notifications() <- rpcclientmocks.NewRPCSubscriptionNotification(t)
 								}
 							}
 						}()

--- a/operator/test/e2e/e2e_noto_pente_test.go
+++ b/operator/test/e2e/e2e_noto_pente_test.go
@@ -733,10 +733,10 @@ var _ = Describe("noto/pente - simple", Ordered, func() {
 			mintMatched := false
 			for !mintMatched {
 				var receiptBatch pldapi.TransactionReceiptBatch
-				var notification *rpcclient.RPCSubscriptionNotification
+				var notification rpcclient.RPCSubscriptionNotification
 				select {
 				case notification = <-receiptsSub.Notifications():
-					err := json.Unmarshal(notification.Result, &receiptBatch)
+					err := json.Unmarshal(notification.GetResult(), &receiptBatch)
 					Expect(err).To(BeNil())
 				case <-time.After(5 * time.Second):
 					Fail("Timed out waiting for ereceipt")

--- a/perf/internal/perf/perf.go
+++ b/perf/internal/perf/perf.go
@@ -417,10 +417,10 @@ func (pr *perfRunner) batchEventLoop(sub rpcclient.Subscription) (err error) {
 
 			// Handle websocket event
 			var batch pldapi.TransactionReceiptBatch
-			json.Unmarshal(subNotification.Result, &batch)
+			json.Unmarshal(subNotification.GetResult(), &batch)
 
 			if pr.cfg.LogEvents {
-				log.Info("Batch: ", string(subNotification.Result))
+				log.Info("Batch: ", string(subNotification.GetResult()))
 			}
 
 			g, _ := errgroup.WithContext(pr.ctx)

--- a/toolkit/go/pkg/rpcclient/wsclient_test.go
+++ b/toolkit/go/pkg/rpcclient/wsclient_test.go
@@ -123,11 +123,11 @@ func TestWSRPCSubscribe(t *testing.T) {
 	newHead := <-s.Notifications()
 	assert.NotNil(t, newHead)
 
-	blockNumber, err := tktypes.ParseHexUint256(ctx, newHead.Result.ToMap()["number"].(string))
+	blockNumber, err := tktypes.ParseHexUint256(ctx, newHead.GetResult().ToMap()["number"].(string))
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(1263817), blockNumber.Int())
 
-	hash := newHead.Result.ToMap()["hash"]
+	hash := newHead.GetResult().ToMap()["hash"]
 	assert.Equal(t, "0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378", hash)
 
 	go func() {
@@ -221,11 +221,11 @@ func TestWSRPCUnsubscribeError(t *testing.T) {
 	newHead := <-s.Notifications()
 	assert.NotNil(t, newHead)
 
-	blockNumber, err := tktypes.ParseHexUint256(ctx, newHead.Result.ToMap()["number"].(string))
+	blockNumber, err := tktypes.ParseHexUint256(ctx, newHead.GetResult().ToMap()["number"].(string))
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(1263817), blockNumber.Int())
 
-	hash := newHead.Result.ToMap()["hash"]
+	hash := newHead.GetResult().ToMap()["hash"]
 	assert.Equal(t, "0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378", hash)
 
 	done()
@@ -481,13 +481,13 @@ func TestHandleAckNack(t *testing.T) {
 	require.NoError(t, err)
 
 	n1 := <-s.Notifications()
-	assert.Equal(t, "0x9ce59a13059e417087c02d3236a0b1cc", n1.CurrentSubID)
-	assert.Equal(t, "11111", n1.Result.StringValue())
+	assert.Equal(t, "0x9ce59a13059e417087c02d3236a0b1cc", n1.GetCurrentSubID())
+	assert.Equal(t, "11111", n1.GetResult().StringValue())
 	err = n1.Nack(ctx)
 	assert.NoError(t, err)
 	n2 := <-s.Notifications()
-	assert.Equal(t, "0x9ce59a13059e417087c02d3236a0b1cc", n2.CurrentSubID)
-	assert.Equal(t, "22222", n2.Result.StringValue())
+	assert.Equal(t, "0x9ce59a13059e417087c02d3236a0b1cc", n2.GetCurrentSubID())
+	assert.Equal(t, "22222", n2.GetResult().StringValue())
 	err = n1.Ack(ctx)
 	assert.NoError(t, err)
 

--- a/toolkit/go/pkg/rpcserver/websockets_ethsub_test.go
+++ b/toolkit/go/pkg/rpcserver/websockets_ethsub_test.go
@@ -199,7 +199,7 @@ func TestWebSocketEthSubscribeUnsubscribe(t *testing.T) {
 
 	notification := <-sub1.Notifications()
 	assert.NotNil(t, notification)
-	assert.JSONEq(t, `{"some": "thing"}`, notification.Result.String())
+	assert.JSONEq(t, `{"some": "thing"}`, notification.GetResult().String())
 
 	rpcErr = sub1.Unsubscribe(context.Background())
 	assert.Nil(t, rpcErr)


### PR DESCRIPTION
Otherwise consumers cannot easily mock `Ack` and `Nack` functions