### PR TITLE
Remove package-lock.json file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Untitled",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
This file appears to have been created by mistake. It should be removed. Thank you @awrichar for catching this issue.