### PR TITLE
noto: remove "restrictUnlock" option

### DIFF
--- a/doc-site/docs/architecture/noto.md
+++ b/doc-site/docs/architecture/noto.md
@@ -31,7 +31,6 @@ Creates a new Noto token, with a new address on the base ledger.
                 {"name": "restrictMint", "type": "boolean"},
                 {"name": "allowBurn", "type": "boolean"},
                 {"name": "allowLock", "type": "boolean"},
-                {"name": "restrictUnlock", "type": "boolean"},
             ]},
             {"name": "hooks", "type": "tuple", "components": [
                 {"name": "privateGroup", "type": "tuple", "components": [
@@ -512,7 +511,10 @@ When a Noto contract is constructed with notary mode `basic`, the following nota
 | restrictMint   | true    | _True:_ only the notary may mint<br>_False:_ any party may mint |
 | allowBurn      | true    | _True:_ token owners may burn their tokens<br>_False:_ tokens cannot be burned |
 | allowLock      | true    | _True:_ token owners may lock tokens (for purposes such as preparing or delegating transfers)<br>_False:_ tokens cannot be locked (not recommended, as it restricts the ability to incorporate tokens into swaps and other workflows) |
-| restrictUnlock | true    | _True:_ only the creator of a lock may unlock it<br>_False:_ any party may unlock (not recommended, as it allows anyone to claim locked tokens)
+
+In addition, the following restrictions will always be enforced, and cannot be disabled in `basic` mode:
+
+- **Unlock:** Only the creator of a lock may unlock it.
 
 ### Notary mode: hooks
 
@@ -539,7 +541,7 @@ receive a `sender` parameter representing the resolved and verified party that s
 !!! important
     Note that none of the `basic` notary constraints described in the previous section will be active when hooks are
     configured. It is the responsibility of the hooks to enforce policies, such as which senders are allowed to mint,
-    burn, etc.
+    burn, lock, unlock, etc.
 
 ## Transaction walkthrough
 
@@ -574,5 +576,3 @@ No information is leaked to Party C, that allows them to infer that Party A and 
     - a) Receives the private data for `#7` to allow it to store `S7` in its wallet
     - b) Receives the confirmation from the blockchain that `TX2` created `#7`
     - Now `Party C` has `S7` confirmed in its wallet and ready to spend
-
-> TODO: Fill in significantly more detail on how Noto operates (Lead: Andrew Richardson)

--- a/domains/noto/internal/noto/handler_unlock.go
+++ b/domains/noto/internal/noto/handler_unlock.go
@@ -63,9 +63,6 @@ func (h *unlockCommon) checkAllowed(ctx context.Context, tx *types.ParsedTransac
 	if tx.DomainConfig.NotaryMode != types.NotaryModeBasic.Enum() {
 		return nil
 	}
-	if !*tx.DomainConfig.Options.Basic.RestrictUnlock {
-		return nil
-	}
 
 	localNodeName, _ := h.noto.Callbacks.LocalNodeName(ctx, &prototk.LocalNodeNameRequest{})
 	fromQualified, err := tktypes.PrivateIdentityLocator(from).FullyQualified(ctx, localNodeName.Name)

--- a/domains/noto/internal/noto/noto.go
+++ b/domains/noto/internal/noto/noto.go
@@ -367,7 +367,6 @@ func (n *Noto) PrepareDeploy(ctx context.Context, req *prototk.PrepareDeployRequ
 		deployData.RestrictMint = true
 		deployData.AllowBurn = true
 		deployData.AllowLock = true
-		deployData.RestrictUnlock = true
 		if params.Options.Basic != nil {
 			if params.Options.Basic.RestrictMint != nil {
 				deployData.RestrictMint = *params.Options.Basic.RestrictMint
@@ -377,9 +376,6 @@ func (n *Noto) PrepareDeploy(ctx context.Context, req *prototk.PrepareDeployRequ
 			}
 			if params.Options.Basic.AllowLock != nil {
 				deployData.AllowLock = *params.Options.Basic.AllowLock
-			}
-			if params.Options.Basic.RestrictUnlock != nil {
-				deployData.RestrictUnlock = *params.Options.Basic.RestrictUnlock
 			}
 		}
 	case types.NotaryModeHooks:
@@ -453,10 +449,9 @@ func (n *Noto) InitContract(ctx context.Context, req *prototk.InitContractReques
 		}
 	} else {
 		parsedConfig.Options.Basic = &types.NotoBasicOptions{
-			RestrictMint:   &decodedData.RestrictMint,
-			AllowBurn:      &decodedData.AllowBurn,
-			AllowLock:      &decodedData.AllowLock,
-			RestrictUnlock: &decodedData.RestrictUnlock,
+			RestrictMint: &decodedData.RestrictMint,
+			AllowBurn:    &decodedData.AllowBurn,
+			AllowLock:    &decodedData.AllowLock,
 		}
 	}
 

--- a/domains/noto/internal/noto/noto_test.go
+++ b/domains/noto/internal/noto/noto_test.go
@@ -142,8 +142,7 @@ func TestNotoDomainDeployDefaults(t *testing.T) {
 		"privateGroup": null,
 		"restrictMint": true,
 		"allowBurn": true,
-		"allowLock": true,
-		"restrictUnlock": true
+		"allowLock": true
 	}`, string(deployData))
 
 	initContractRes, err := n.InitContract(ctx, &prototk.InitContractRequest{
@@ -167,8 +166,7 @@ func TestNotoDomainDeployBasicConfig(t *testing.T) {
 				"basic": {
 					"restrictMint": false,
 					"allowBurn": false,
-					"allowLock": false,
-					"restrictUnlock": false
+					"allowLock": false
 				}
 			}
 		}`,
@@ -207,8 +205,7 @@ func TestNotoDomainDeployBasicConfig(t *testing.T) {
 		"privateGroup": null,
 		"restrictMint": false,
 		"allowBurn": false,
-		"allowLock": false,
-		"restrictUnlock": false
+		"allowLock": false
 	}`, string(deployData))
 
 	initContractRes, err := n.InitContract(ctx, &prototk.InitContractRequest{
@@ -278,8 +275,7 @@ func TestNotoDomainDeployHooksConfig(t *testing.T) {
 		},
 		"restrictMint": false,
 		"allowBurn": false,
-		"allowLock": false,
-		"restrictUnlock": false
+		"allowLock": false
 	}`, groupSalt), string(deployData))
 
 	initContractRes, err := n.InitContract(ctx, &prototk.InitContractRequest{

--- a/domains/noto/pkg/types/config.go
+++ b/domains/noto/pkg/types/config.go
@@ -43,7 +43,6 @@ type NotoConfigData_V0 struct {
 	RestrictMint   bool                `json:"restrictMint"`
 	AllowBurn      bool                `json:"allowBurn"`
 	AllowLock      bool                `json:"allowLock"`
-	RestrictUnlock bool                `json:"restrictUnlock"`
 }
 
 // This is the structure we parse the config into in InitConfig and gets passed back to us on every call
@@ -61,10 +60,9 @@ type NotoOptions struct {
 }
 
 type NotoBasicOptions struct {
-	RestrictMint   *bool `json:"restrictMint"`   // Only allow notary to mint (default: true)
-	AllowBurn      *bool `json:"allowBurn"`      // Allow token holders to burn their tokens (default: true)
-	AllowLock      *bool `json:"allowLock"`      // Allow token holders to lock their tokens (default: true)
-	RestrictUnlock *bool `json:"restrictUnlock"` // Only allow lock creator to unlock tokens (default: true)
+	RestrictMint *bool `json:"restrictMint"` // Only allow notary to mint (default: true)
+	AllowBurn    *bool `json:"allowBurn"`    // Allow token holders to burn their tokens (default: true)
+	AllowLock    *bool `json:"allowLock"`    // Allow token holders to lock their tokens (default: true)
 }
 
 type NotoHooksOptions struct {

--- a/sdk/typescript/src/domains/noto.ts
+++ b/sdk/typescript/src/domains/noto.ts
@@ -47,7 +47,6 @@ export const notoConstructorABI = (
                   { name: "restrictMint", type: "bool" },
                   { name: "allowBurn", type: "bool" },
                   { name: "allowLock", type: "bool" },
-                  { name: "restrictUnlock", type: "bool" },
                 ],
               },
             ]),
@@ -64,7 +63,6 @@ export interface NotoConstructorParams {
       restrictMint: boolean;
       allowBurn: boolean;
       allowLock: boolean;
-      restrictUnlock: boolean;
     };
     hooks?: {
       publicAddress: string;
@@ -163,7 +161,6 @@ export class NotoFactory {
             restrictMint: true,
             allowBurn: true,
             allowLock: true,
-            restrictUnlock: true,
             ...data.options?.basic,
           },
           ...data.options,


### PR DESCRIPTION
There is really no need to make this configurable. It should always be enforced in "basic" notary mode.