### PR TITLE
Rename Go Packages to be under LF-Decentralized-Trust-labs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,7 +11,7 @@ body:
         _The more information you share, the faster we can help you._
         Prior to opening the issue, please make sure that you:
         - Use English (EN/US) to communicate.
-        - Search the [open issues](https://github.com/kaleido-io/paladin/issues) to avoid duplicating the issue.
+        - Search the [open issues](https://github.com/LF-Decentralized-Trust-labs/paladin/issues) to avoid duplicating the issue.
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -10,7 +10,7 @@ body:
         _The more information you share, the faster we can help you._
         Prior to opening the issue, please make sure that you:
         - Use English (EN/US) to communicate.
-        - Search the [open issues](https://github.com/kaleido-io/paladin/issues) to avoid duplicating the issue.
+        - Search the [open issues](https://github.com/LF-Decentralized-Trust-labs/paladin/issues) to avoid duplicating the issue.
 
   - type: textarea
     id: enhancement

--- a/.github/ISSUE_TEMPLATE/improve_docs.yml
+++ b/.github/ISSUE_TEMPLATE/improve_docs.yml
@@ -11,7 +11,7 @@ body:
         _The more information you share, the faster we can help you._
         Prior to opening the issue, please make sure that you:
         - Use English (EN/US) to communicate.
-        - Search the [open issues](https://github.com/kaleido-io/paladin/issues) to avoid duplicating the issue.
+        - Search the [open issues](https://github.com/LF-Decentralized-Trust-labs/paladin/issues) to avoid duplicating the issue.
 
   - type: textarea
     id: current-state

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,4 +1,4 @@
-module github.com/kaleido-io/paladin/config
+module github.com/LF-Decentralized-Trust-labs/paladin/config
 
 go 1.22.5
 

--- a/core/go/build.gradle
+++ b/core/go/build.gradle
@@ -34,12 +34,12 @@ ext {
     targetCoverage = 94.4
     maxCoverageBarGap = 1
     coverageExcludedPackages = [
-        'github.com/kaleido-io/paladin/core/internal/privatetxnmgr/ptmgrtypes/mock_transaction_flow.go',
-        'github.com/kaleido-io/paladin/core/pkg/proto',
-        'github.com/kaleido-io/paladin/core/pkg/proto/transaction',
-        'github.com/kaleido-io/paladin/toolkit/prototk',
-        'github.com/kaleido-io/paladin/core/internal/plugins/loader',
-        'github.com/kaleido-io/paladin/core/pkg/testbed',
+        'github.com/LF-Decentralized-Trust-labs/paladin/core/internal/privatetxnmgr/ptmgrtypes/mock_transaction_flow.go',
+        'github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/proto',
+        'github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/proto/transaction',
+        'github.com/LF-Decentralized-Trust-labs/paladin/toolkit/prototk',
+        'github.com/LF-Decentralized-Trust-labs/paladin/core/internal/plugins/loader',
+        'github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/testbed',
     ]
 }
 
@@ -165,7 +165,7 @@ task goGet(type:Exec, dependsOn:[protoc, copyContracts, ":toolkit:go:goGet"]) {
 task makeMocks(type: Mockery, dependsOn: [":installMockery", protoc, goGet]) {
     args '--case', 'underscore'
     mock {
-        inputDir "go list -f {{.Dir}} github.com/kaleido-io/paladin/toolkit/pkg/rpcclient".execute().text.trim()
+        inputDir "go list -f {{.Dir}} github.com/LF-Decentralized-Trust-labs/paladin/toolkit/pkg/rpcclient".execute().text.trim()
         includeAll true
         outputPackage 'rpcclientmocks'
         outputDir 'mocks/rpcclientmocks'
@@ -213,13 +213,13 @@ task makeMocks(type: Mockery, dependsOn: [":installMockery", protoc, goGet]) {
         outputDir 'mocks/componentmocks'
     }
     mock {
-        inputDir "go list -f {{.Dir}} github.com/kaleido-io/paladin/toolkit/pkg/rpcserver".execute().text.trim()
+        inputDir "go list -f {{.Dir}} github.com/LF-Decentralized-Trust-labs/paladin/toolkit/pkg/rpcserver".execute().text.trim()
         includeAll true
         outputPackage 'componentmocks'
         outputDir 'mocks/componentmocks'
     }
     mock {
-        inputDir "go list -f {{.Dir}} github.com/kaleido-io/paladin/toolkit/pkg/signer".execute().text.trim()
+        inputDir "go list -f {{.Dir}} github.com/LF-Decentralized-Trust-labs/paladin/toolkit/pkg/signer".execute().text.trim()
         name 'SigningModule'
         outputPackage 'signermocks'
         outputDir 'mocks/signermocks'
@@ -354,7 +354,7 @@ abstract class ComponentTest extends Exec {
         args 'test'
         args './componenttest', './pkg/testbed'
         args '-cover'
-        args "-coverpkg=github.com/kaleido-io/paladin/core/..." // toolkit handled seperately
+        args "-coverpkg=github.com/LF-Decentralized-Trust-labs/paladin/core/..." // toolkit handled seperately
         args '-covermode=atomic'
         args '-timeout=120s'
         if (project.findProperty('verboseTests') == 'true') {

--- a/core/go/go.mod
+++ b/core/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/kaleido-io/paladin/core
+module github.com/LF-Decentralized-Trust-labs/paladin/core
 
 go 1.22.5
 
@@ -9,10 +9,10 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hyperledger/firefly-common v1.4.14
 	github.com/hyperledger/firefly-signer v1.1.19
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/registries/static v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/transports/grpc v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/registries/static v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/toolkit v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/transports/grpc v0.0.0-00010101000000-000000000000
 	github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
@@ -110,10 +110,10 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/kaleido-io/paladin/toolkit => ../../toolkit/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/toolkit => ../../toolkit/go
 
-replace github.com/kaleido-io/paladin/config => ../../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../../config
 
-replace github.com/kaleido-io/paladin/registries/static => ../../registries/static
+replace github.com/LF-Decentralized-Trust-labs/paladin/registries/static => ../../registries/static
 
-replace github.com/kaleido-io/paladin/transports/grpc => ../../transports/grpc
+replace github.com/LF-Decentralized-Trust-labs/paladin/transports/grpc => ../../transports/grpc

--- a/core/java/src/main/java/io/kaleido/paladin/Main.java
+++ b/core/java/src/main/java/io/kaleido/paladin/Main.java
@@ -64,7 +64,7 @@ public class Main {
     }
 
     static {
-        // see https://github.com/kaleido-io/paladin/issues/239
+        // see https://github.com/LF-Decentralized-Trust-labs/paladin/issues/239
         LoadBalancerRegistry.getDefaultRegistry().register(new PickFirstLoadBalancerProvider());
     }
 

--- a/doc-site/docs/architecture/programming_model.md
+++ b/doc-site/docs/architecture/programming_model.md
@@ -96,7 +96,7 @@ The UTXO model works extremely well for **tokens** - both fungible value, and no
 
 ![Confidential UTXO models](../images/confidential_utxo_model.png)
 
-> Note that projects do exist (such as [Anonymous Zether](https://github.com/LF-Decentralized-Trust-labs/anonymous-zether-client)) that implement tokens with an account model using advanced cryptography to protect global state. The Paladin architecture supports such models, although at time of writing no project has been onboarded.
+> Note that projects do exist (such as [Anonymous Zether](https://github.com/kaleido-io/anonymous-zether-client)) that implement tokens with an account model using advanced cryptography to protect global state. The Paladin architecture supports such models, although at time of writing no project has been onboarded.
 
 ### Programming interfaces for Layer B
 

--- a/doc-site/docs/architecture/programming_model.md
+++ b/doc-site/docs/architecture/programming_model.md
@@ -96,7 +96,7 @@ The UTXO model works extremely well for **tokens** - both fungible value, and no
 
 ![Confidential UTXO models](../images/confidential_utxo_model.png)
 
-> Note that projects do exist (such as [Anonymous Zether](https://github.com/kaleido-io/anonymous-zether-client)) that implement tokens with an account model using advanced cryptography to protect global state. The Paladin architecture supports such models, although at time of writing no project has been onboarded.
+> Note that projects do exist (such as [Anonymous Zether](https://github.com/LF-Decentralized-Trust-labs/anonymous-zether-client)) that implement tokens with an account model using advanced cryptography to protect global state. The Paladin architecture supports such models, although at time of writing no project has been onboarded.
 
 ### Programming interfaces for Layer B
 

--- a/doc-site/docs/architecture/zeto.md
+++ b/doc-site/docs/architecture/zeto.md
@@ -3,7 +3,7 @@
 Zeto is a UTXO based privacy-preserving token toolkit for EVM, using Zero Knowledge Proofs, implemented via Circom.
 
 The architecture documentations for Zeto is being managed in a separate Github repository here:
-https://github.com/kaleido-io/zeto
+https://github.com/LF-Decentralized-Trust-labs/zeto
 
 Zeto is a growing collection of token implementations that enforce a wide variety of token transaction policies including, but not limited to, mass conservation (for fungible tokens), preservation of asset properties during ownership transfer (for non-fungible tokens), KYC with privacy, and non-repudiation compliance. Each policy is expressed in zeto knowledge proof circuits using [Circom](https://iden3.io/circom). The list of policies and their corresponding token implementations will continue to grow to meet the needs of enterprise use cases.
 

--- a/doc-site/docs/contributing/reporting-a-bug.md
+++ b/doc-site/docs/contributing/reporting-a-bug.md
@@ -11,4 +11,4 @@ When reporting an issue, please provide as much detail as possible about how to 
 * Actual results
 * Expected results
 
-  [issue tracker]: https://github.com/kaleido-io/paladin/issues
+  [issue tracker]: https://github.com/LF-Decentralized-Trust-labs/paladin/issues

--- a/doc-site/docs/contributing/requesting-a-change.md
+++ b/doc-site/docs/contributing/requesting-a-change.md
@@ -12,7 +12,7 @@ This guide is our best effort to explain the criteria and reasoning behind our
 decisions when evaluating change requests and considering them for
 implementation. 
 
-  [issue tracker]: https://github.com/kaleido-io/paladin/issues
+  [issue tracker]: https://github.com/LF-Decentralized-Trust-labs/paladin/issues
 
 ## Before creating an issue
 

--- a/doc-site/docs/reference/types/transactionreceiptfilters.md
+++ b/doc-site/docs/reference/types/transactionreceiptfilters.md
@@ -14,6 +14,6 @@ title: TransactionReceiptFilters
 | Field Name | Description | Type |
 |------------|-------------|------|
 | `sequenceAbove` | Only deliver receipts above a certain sequence (rather than from the beginning of indexing of the chain) | `uint64` |
-| `type` | Only deliver receipts for one transaction type (public/private) | `Enum[github.com/kaleido-io/paladin/toolkit/pkg/pldapi.TransactionType]` |
+| `type` | Only deliver receipts for one transaction type (public/private) | `Enum[github.com/LF-Decentralized-Trust-labs/paladin/toolkit/pkg/pldapi.TransactionType]` |
 | `domain` | Only deliver receipts for an individual domain (only valid with type=private) | `string` |
 

--- a/domains/integration-test/go.mod
+++ b/domains/integration-test/go.mod
@@ -1,15 +1,15 @@
-module github.com/kaleido-io/paladin/domains/integration-test
+module github.com/LF-Decentralized-Trust-labs/paladin/domains/integration-test
 
 go 1.22.5
 
 require (
 	github.com/go-resty/resty/v2 v2.14.0
 	github.com/hyperledger/firefly-signer v1.1.19
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/core v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/domains/noto v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/domains/zeto v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/core v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/domains/noto v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/domains/zeto v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/toolkit v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 )
 
@@ -113,12 +113,12 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/kaleido-io/paladin/core => ../../core/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/core => ../../core/go
 
-replace github.com/kaleido-io/paladin/toolkit => ../../toolkit/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/toolkit => ../../toolkit/go
 
-replace github.com/kaleido-io/paladin/domains/noto => ../noto
+replace github.com/LF-Decentralized-Trust-labs/paladin/domains/noto => ../noto
 
-replace github.com/kaleido-io/paladin/domains/zeto => ../zeto
+replace github.com/LF-Decentralized-Trust-labs/paladin/domains/zeto => ../zeto
 
-replace github.com/kaleido-io/paladin/config => ../../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../../config

--- a/domains/noto/go.mod
+++ b/domains/noto/go.mod
@@ -1,11 +1,11 @@
-module github.com/kaleido-io/paladin/domains/noto
+module github.com/LF-Decentralized-Trust-labs/paladin/domains/noto
 
 go 1.22.5
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/hyperledger/firefly-signer v1.1.19
-	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/toolkit v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/text v0.21.0
 )
@@ -17,7 +17,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/hyperledger/firefly-common v1.4.14 // indirect
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000 // indirect
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -39,8 +39,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/kaleido-io/paladin/core => ../../core/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/core => ../../core/go
 
-replace github.com/kaleido-io/paladin/toolkit => ../../toolkit/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/toolkit => ../../toolkit/go
 
-replace github.com/kaleido-io/paladin/config => ../../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../../config

--- a/domains/zeto/build.gradle
+++ b/domains/zeto/build.gradle
@@ -27,9 +27,9 @@ ext {
     targetCoverage = 92.0
     maxCoverageBarGap = 1
     coveragePackages = [
-        "github.com/kaleido-io/paladin/domains/zeto/internal/...",
-        "github.com/kaleido-io/paladin/domains/zeto/pkg/types",
-        "github.com/kaleido-io/paladin/domains/zeto/pkg/zetosigner",
+        "github.com/LF-Decentralized-Trust-labs/paladin/domains/zeto/internal/...",
+        "github.com/LF-Decentralized-Trust-labs/paladin/domains/zeto/pkg/types",
+        "github.com/LF-Decentralized-Trust-labs/paladin/domains/zeto/pkg/zetosigner",
     ]
 
     zetoVersion = "v0.0.11"

--- a/domains/zeto/go.mod
+++ b/domains/zeto/go.mod
@@ -1,4 +1,4 @@
-module github.com/kaleido-io/paladin/domains/zeto
+module github.com/LF-Decentralized-Trust-labs/paladin/domains/zeto
 
 go 1.22.5
 
@@ -11,9 +11,9 @@ require (
 	github.com/iden3/go-rapidsnark/types v0.0.3
 	github.com/iden3/go-rapidsnark/witness/v2 v2.0.0
 	github.com/iden3/go-rapidsnark/witness/wasmer v0.0.0-20240914111027-9588ce2d7e1b
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/core v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/core v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/toolkit v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/text v0.21.0
 	google.golang.org/protobuf v1.35.1
@@ -112,10 +112,10 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/kaleido-io/paladin/core => ../../core/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/core => ../../core/go
 
-replace github.com/kaleido-io/paladin/toolkit => ../../toolkit/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/toolkit => ../../toolkit/go
 
-replace github.com/kaleido-io/paladin/config => ../../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../../config
 
-replace github.com/kaleido-io/paladin/domains/noto => ../noto
+replace github.com/LF-Decentralized-Trust-labs/paladin/domains/noto => ../noto

--- a/operator/PROJECT
+++ b/operator/PROJECT
@@ -9,7 +9,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: operator-go
-repo: github.com/kaleido-io/paladin/operator
+repo: github.com/LF-Decentralized-Trust-labs/paladin/operator
 resources:
 - api:
     crdVersion: v1
@@ -18,7 +18,7 @@ resources:
   domain: paladin.io
   group: core
   kind: Paladin
-  path: github.com/kaleido-io/paladin/operator/api/v1alpha1
+  path: github.com/LF-Decentralized-Trust-labs/paladin/operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -27,7 +27,7 @@ resources:
   domain: paladin.io
   group: core
   kind: SmartContractDeployment
-  path: github.com/kaleido-io/paladin/operator/api/v1alpha1
+  path: github.com/LF-Decentralized-Trust-labs/paladin/operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -36,7 +36,7 @@ resources:
   domain: paladin.io
   group: core
   kind: Besu
-  path: github.com/kaleido-io/paladin/operator/api/v1alpha1
+  path: github.com/LF-Decentralized-Trust-labs/paladin/operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -45,7 +45,7 @@ resources:
   domain: paladin.io
   group: core
   kind: BesuGenesis
-  path: github.com/kaleido-io/paladin/operator/api/v1alpha1
+  path: github.com/LF-Decentralized-Trust-labs/paladin/operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -54,7 +54,7 @@ resources:
   domain: paladin.io
   group: core
   kind: PaladinRegistry
-  path: github.com/kaleido-io/paladin/operator/api/v1alpha1
+  path: github.com/LF-Decentralized-Trust-labs/paladin/operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -63,7 +63,7 @@ resources:
   domain: paladin.io
   group: core
   kind: PaladinDomain
-  path: github.com/kaleido-io/paladin/operator/api/v1alpha1
+  path: github.com/LF-Decentralized-Trust-labs/paladin/operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -72,7 +72,7 @@ resources:
   domain: paladin.io
   group: core
   kind: PaladinRegistration
-  path: github.com/kaleido-io/paladin/operator/api/v1alpha1
+  path: github.com/LF-Decentralized-Trust-labs/paladin/operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -81,6 +81,6 @@ resources:
   domain: paladin.io
   group: core
   kind: TransactionInvoke
-  path: github.com/kaleido-io/paladin/operator/api/v1alpha1
+  path: github.com/LF-Decentralized-Trust-labs/paladin/operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,4 +1,4 @@
-module github.com/kaleido-io/paladin/operator
+module github.com/LF-Decentralized-Trust-labs/paladin/operator
 
 go 1.22.5
 
@@ -8,9 +8,9 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/google/uuid v1.6.0
 	github.com/hyperledger/firefly-signer v1.1.19
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/testinfra v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/testinfra v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/toolkit v0.0.0-00010101000000-000000000000
 	github.com/onsi/ginkgo/v2 v2.17.2
 	github.com/onsi/gomega v1.33.1
 	github.com/pelletier/go-toml/v2 v2.2.3
@@ -126,8 +126,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-replace github.com/kaleido-io/paladin/config => ../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../config
 
-replace github.com/kaleido-io/paladin/toolkit => ../toolkit/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/toolkit => ../toolkit/go
 
-replace github.com/kaleido-io/paladin/testinfra => ../testinfra
+replace github.com/LF-Decentralized-Trust-labs/paladin/testinfra => ../testinfra

--- a/perf/Makefile
+++ b/perf/Makefile
@@ -23,9 +23,9 @@ LINT := $(GOBIN)/golangci-lint
 
 all: build
 build: ## Builds all go code
-		cd pldperf && go build -ldflags="-X 'github.com/kaleido-io/paladin/perf/internal/version.Version=$(VERSION)' -X 'github.com/kaleido-io/paladin/perf/internal/version.Date=$(DATE)' -X 'github.com/kaleido-io/paladin/perf/internal/version.Commit=$(GITREF)'"
+		cd pldperf && go build -ldflags="-X 'github.com/LF-Decentralized-Trust-labs/paladin/perf/internal/version.Version=$(VERSION)' -X 'github.com/LF-Decentralized-Trust-labs/paladin/perf/internal/version.Date=$(DATE)' -X 'github.com/LF-Decentralized-Trust-labs/paladin/perf/internal/version.Commit=$(GITREF)'"
 install: ## Installs the package
-		cd pldperf && go install -ldflags="-X 'github.com/kaleido-io/paladin/perf/internal/version.Version=$(VERSION)' -X 'github.com/kaleido-io/paladin/perf/internal/version.Date=$(DATE)' -X 'github.com/kaleido-io/paladin/perf/internal/version.Commit=$(GITREF)'"
+		cd pldperf && go install -ldflags="-X 'github.com/LF-Decentralized-Trust-labs/paladin/perf/internal/version.Version=$(VERSION)' -X 'github.com/LF-Decentralized-Trust-labs/paladin/perf/internal/version.Date=$(DATE)' -X 'github.com/LF-Decentralized-Trust-labs/paladin/perf/internal/version.Commit=$(GITREF)'"
 # TODO: what should the tag be
 docker:
 	docker build --platform linux/amd64 --build-arg BUILD_VERSION=$(VERSION) . -t ghcr.io/lf-decentralized-trust-labs/paladin-perf-cli

--- a/perf/README.md
+++ b/perf/README.md
@@ -16,7 +16,7 @@ Run `gradle build` in the `perf` directory to build and install the `pldperf` co
 
 ### Public contract
 
-This test submits transactions which call the `set` method on a [`simplestorage`](https://github.com/kaleido-io/kaleido-js/blob/master/deploy-transact/contracts/simplestorage.sol) contract.
+This test submits transactions which call the `set` method on a [`simplestorage`](https://github.com/LF-Decentralized-Trust-labs/kaleido-js/blob/master/deploy-transact/contracts/simplestorage.sol) contract.
 
 1. Create a configuration file for your test. See [`example-quick-start.yaml`](./config/example-quick-start.yaml) for an example and [`conf.go`](./internal/conf/conf.go) for all configuration options.
 1. Deploy the `simplestorage` smart contract. Replace <key> in the following command with the the name of the key you wish to use, e.g. `key@node1`.

--- a/perf/README.md
+++ b/perf/README.md
@@ -16,7 +16,7 @@ Run `gradle build` in the `perf` directory to build and install the `pldperf` co
 
 ### Public contract
 
-This test submits transactions which call the `set` method on a [`simplestorage`](https://github.com/LF-Decentralized-Trust-labs/kaleido-js/blob/master/deploy-transact/contracts/simplestorage.sol) contract.
+This test submits transactions which call the `set` method on a [`simplestorage`](https://github.com/kaleido-io/kaleido-js/blob/master/deploy-transact/contracts/simplestorage.sol) contract.
 
 1. Create a configuration file for your test. See [`example-quick-start.yaml`](./config/example-quick-start.yaml) for an example and [`conf.go`](./internal/conf/conf.go) for all configuration options.
 1. Deploy the `simplestorage` smart contract. Replace <key> in the following command with the the name of the key you wish to use, e.g. `key@node1`.

--- a/perf/go.mod
+++ b/perf/go.mod
@@ -1,12 +1,12 @@
-module github.com/kaleido-io/paladin/perf
+module github.com/LF-Decentralized-Trust-labs/paladin/perf
 
 go 1.22.5
 
 require (
 	github.com/go-resty/resty/v2 v2.14.0
 	github.com/hyperledger/firefly-common v1.4.14
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/toolkit v0.0.0-00010101000000-000000000000
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/client_model v0.6.1
@@ -80,6 +80,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/kaleido-io/paladin/toolkit => ../toolkit/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/toolkit => ../toolkit/go
 
-replace github.com/kaleido-io/paladin/config => ../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../config

--- a/registries/evm/go.mod
+++ b/registries/evm/go.mod
@@ -1,11 +1,11 @@
-module github.com/kaleido-io/paladin/registries/evm
+module github.com/LF-Decentralized-Trust-labs/paladin/registries/evm
 
 go 1.22.5
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/hyperledger/firefly-signer v1.1.19
-	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/toolkit v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/text v0.21.0
 )
@@ -15,7 +15,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/hyperledger/firefly-common v1.4.14 // indirect
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000 // indirect
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -37,6 +37,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/kaleido-io/paladin/toolkit => ../../toolkit/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/toolkit => ../../toolkit/go
 
-replace github.com/kaleido-io/paladin/config => ../../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../../config

--- a/registries/static/go.mod
+++ b/registries/static/go.mod
@@ -1,9 +1,9 @@
-module github.com/kaleido-io/paladin/registries/static
+module github.com/LF-Decentralized-Trust-labs/paladin/registries/static
 
 go 1.22.5
 
 require (
-	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/toolkit v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.31.0
 	golang.org/x/text v0.21.0
@@ -16,7 +16,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hyperledger/firefly-common v1.4.14 // indirect
 	github.com/hyperledger/firefly-signer v1.1.19 // indirect
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000 // indirect
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -37,6 +37,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/kaleido-io/paladin/toolkit => ../../toolkit/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/toolkit => ../../toolkit/go
 
-replace github.com/kaleido-io/paladin/config => ../../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../../config

--- a/solidity/contracts/domains/interfaces/IPaladinContractRegistry.sol
+++ b/solidity/contracts/domains/interfaces/IPaladinContractRegistry.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 /// A contract registry is a trusted smart contract that announces the existence of
 /// new smart contracts instances of that are part of a single domain.
-/// @author https://github.com/kaleido-io/paladin
+/// @author https://github.com/LF-Decentralized-Trust-labs/paladin
 /// @title Paladin contract registry
 interface IPaladinContractRegistry_V0 {
 

--- a/solidity/contracts/private/NotoTrackerERC20.sol
+++ b/solidity/contracts/private/NotoTrackerERC20.sol
@@ -138,7 +138,7 @@ contract NotoTrackerERC20 is INotoHooks, ERC20 {
         bytes calldata data,
         PreparedTransaction calldata prepared
     ) external virtual override {
-        approvals++; // must store something on each call (see https://github.com/kaleido-io/paladin/issues/252)
+        approvals++; // must store something on each call (see https://github.com/LF-Decentralized-Trust-labs/paladin/issues/252)
         emit PenteExternalCall(prepared.contractAddress, prepared.encodedCall);
     }
 

--- a/testinfra/go.mod
+++ b/testinfra/go.mod
@@ -1,4 +1,4 @@
-module github.com/kaleido-io/paladin/testinfra
+module github.com/LF-Decentralized-Trust-labs/paladin/testinfra
 
 go 1.22.5
 

--- a/toolkit/go/build.gradle
+++ b/toolkit/go/build.gradle
@@ -24,8 +24,8 @@ ext {
     targetCoverage = 100
     maxCoverageBarGap = 1
     coverageExcludedPackages = [
-        'github.com/kaleido-io/paladin/toolkit/pkg/prototk',
-        'github.com/kaleido-io/paladin/toolkit/pkg/reference',
+        'github.com/LF-Decentralized-Trust-labs/paladin/toolkit/pkg/prototk',
+        'github.com/LF-Decentralized-Trust-labs/paladin/toolkit/pkg/reference',
     ]
 }
 

--- a/toolkit/go/go.mod
+++ b/toolkit/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/kaleido-io/paladin/toolkit
+module github.com/LF-Decentralized-Trust-labs/paladin/toolkit
 
 go 1.22.5
 
@@ -13,7 +13,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hyperledger/firefly-common v1.4.14
 	github.com/hyperledger/firefly-signer v1.1.19
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.11.0
 	github.com/sirupsen/logrus v1.9.3
@@ -87,4 +87,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/kaleido-io/paladin/config => ../../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../../config

--- a/transports/grpc/go.mod
+++ b/transports/grpc/go.mod
@@ -1,10 +1,10 @@
-module github.com/kaleido-io/paladin/transports/grpc
+module github.com/LF-Decentralized-Trust-labs/paladin/transports/grpc
 
 go 1.22.5
 
 require (
-	github.com/kaleido-io/paladin/config v0.0.0-00010101000000-000000000000
-	github.com/kaleido-io/paladin/toolkit v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/config v0.0.0-00010101000000-000000000000
+	github.com/LF-Decentralized-Trust-labs/paladin/toolkit v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/text v0.21.0
 	google.golang.org/grpc v1.67.1
@@ -37,6 +37,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/kaleido-io/paladin/toolkit => ../../toolkit/go
+replace github.com/LF-Decentralized-Trust-labs/paladin/toolkit => ../../toolkit/go
 
-replace github.com/kaleido-io/paladin/config => ../../config
+replace github.com/LF-Decentralized-Trust-labs/paladin/config => ../../config


### PR DESCRIPTION
The Golang Packages are incorrectly scoped from when the repository was moved over to the LFDT Labs organization.  This makes it challenging for external users to import these packages as the GitHub URL is different from the package name and the only way to solve it is to do a local replace. 

