### PR TITLE
downgrade nanoid to v3

### DIFF
--- a/example/event-listener/package-lock.json
+++ b/example/event-listener/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@lfdecentralizedtrust-labs/paladin-sdk": "file:../../sdk/typescript",
-        "nanoid": "^5.1.3"
+        "nanoid": "^3.3.9"
       },
       "devDependencies": {
         "@types/node": "^22.8.7",
@@ -201,9 +201,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.3.tgz",
-      "integrity": "sha512-zAbEOEr7u2CbxwoMRlz/pNSpRP0FdAU4pRaYunCdEezWohXFs+a0Xw7RfkKaezMsmSM1vttcLthJtwRnVtOfHQ==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.9.tgz",
+      "integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==",
       "funding": [
         {
           "type": "github",
@@ -212,10 +212,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/p-event": {

--- a/example/event-listener/package.json
+++ b/example/event-listener/package.json
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "@lfdecentralizedtrust-labs/paladin-sdk": "file:../../sdk/typescript",
-    "nanoid": "^5.1.3"
+    "nanoid": "^3.3.9"
   }
 }


### PR DESCRIPTION
All builds are failing on the `chart-build / operator-build` job.

```
> Task :example:event-listener:e2e FAILED
/home/runner/work/paladin/paladin/example/event-listener/node_modules/ts-node/dist/index.js:851

> paladin-example-event-listener@0.0.1 start
> ts-node ./src/index.ts


> Task :operator:e2e
            return old(m, filename);
                   ^
Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/paladin/paladin/example/event-listener/node_modules/nanoid/index.js from /home/runner/work/paladin/paladin/example/event-listener/src/index.ts not supported.
Instead change the require of index.js in /home/runner/work/paladin/paladin/example/event-listener/src/index.ts to a dynamic import() which is available in all CommonJS modules.
    at require.extensions.<computed> [as .js] (/home/runner/work/paladin/paladin/example/event-listener/node_modules/ts-node/dist/index.js:851:20)
    at Object.<anonymous> (/home/runner/work/paladin/paladin/example/event-listener/src/index.ts:42:18)
    at m._compile (/home/runner/work/paladin/paladin/example/event-listener/node_modules/ts-node/dist/index.js:857:29) {
  code: 'ERR_REQUIRE_ESM'
}
```

https://github.com/ai/nanoid/?tab=readme-ov-file#commonjs - downgrading to v3 which is still supported was the most straight forward fix.

https://github.com/LF-Decentralized-Trust-labs/paladin/pull/598 which added this also failed which looks like there might be a problem with auto merge not requiring all green status checks to merge.