### PR TITLE
config sets max size for the array rather than enabled/disabled

### DIFF
--- a/config/pkg/pldconf/publictxmgr.go
+++ b/config/pkg/pldconf/publictxmgr.go
@@ -172,5 +172,5 @@ type PublicTxManagerOrchestratorConfig struct {
 	PersistenceRetryTime      *string            `json:"persistenceRetryTime"`
 	UnavailableBalanceHandler *string            `json:"unavailableBalanceHandler"`
 	SubmissionRetry           RetryConfigWithMax `json:"submissionRetry"`
-	TimeLineLoggingEnabled    bool               `json:"timelineLoggingEnabled"`
+	TimeLineLoggingMaxEntries int                `json:"timelineMaxEntries"`
 }

--- a/core/go/internal/publictxmgr/transaction_manager_test.go
+++ b/core/go/internal/publictxmgr/transaction_manager_test.go
@@ -98,7 +98,7 @@ func newTestPublicTxManager(t *testing.T, realDBAndSigner bool, extraSetup ...fu
 			SubmissionRetry: pldconf.RetryConfigWithMax{
 				MaxAttempts: confutil.P(1),
 			},
-			TimeLineLoggingEnabled: true,
+			TimeLineLoggingMaxEntries: 10,
 		},
 		GasPrice: pldconf.GasPriceConfig{
 			FixedGasPrice: 0,

--- a/core/go/internal/publictxmgr/transaction_orchestrator.go
+++ b/core/go/internal/publictxmgr/transaction_orchestrator.go
@@ -148,7 +148,7 @@ type orchestrator struct {
 	updates   []*transactionUpdate
 	updateMux sync.Mutex
 
-	timeLineLoggingEnabled bool
+	timeLineLoggingMaxEntries int
 }
 
 const veryShortMinimum = 50 * time.Millisecond
@@ -184,7 +184,7 @@ func NewOrchestrator(
 		stopProcess:                make(chan bool, 1),
 		ethClient:                  ptm.ethClient,
 		bIndexer:                   ptm.bIndexer,
-		timeLineLoggingEnabled:     conf.Orchestrator.TimeLineLoggingEnabled,
+		timeLineLoggingMaxEntries:  conf.Orchestrator.TimeLineLoggingMaxEntries,
 	}
 
 	log.L(ctx).Debugf("NewOrchestrator for signing address %s created: %+v", newOrchestrator.signingAddress, newOrchestrator)


### PR DESCRIPTION
Control timeline logging by defining the maximum array size for timeline entries so that the array is always bounded. Default is 0 which is equivalent to timeline logging disabled.