### PR TITLE
Stop pulling all blocks to catch up with into memory

### DIFF
--- a/core/go/internal/publictxmgr/transaction_orchestrator.go
+++ b/core/go/internal/publictxmgr/transaction_orchestrator.go
@@ -278,13 +278,13 @@ func (oc *orchestrator) initNextNonceFromDB(ctx context.Context) error {
 	}
 	nextNonce := *txns[0].Nonce + 1
 	oc.nextNonce = &nextNonce
-	log.L(ctx).Infof("Next nonce initialized from DB fro %s: %d", oc.signingAddress, nextNonce)
+	log.L(ctx).Infof("Next nonce initialized from DB from %s: %d", oc.signingAddress, nextNonce)
 	return nil
 }
 
 func (oc *orchestrator) allocateNonces(ctx context.Context, txns []*DBPublicTxn) error {
 
-	// Of the the transactions might have nonces already
+	// Some of the the transactions might have nonces already
 	toAlloc := make([]*DBPublicTxn, 0, len(txns))
 	for _, tx := range txns {
 		if tx.Nonce == nil {


### PR DESCRIPTION
The block indexer dispatcher loop is reading all blocks into an unbounded array in memory until it has caught up with the head of the chain. Pulling more blocks into memory at a time doesn't speed anything up as the enrichment is only being triggered for one block each iteration of the loop, and that process is only starting after all the blocks have been read into memory.

This PR changes it so that one block is read per loop iteration, and the enrichment started immediately for each block. Batches can be written as soon as max batch size is reached.

I've also included some trace logs that I added while debugging so they are there in future.