### PR TITLE
fix: extended protocol limited to 65535 parameters 

### DIFF
--- a/config/pkg/pldconf/blockindexer.go
+++ b/config/pkg/pldconf/blockindexer.go
@@ -25,6 +25,7 @@ import (
 type BlockIndexerConfig struct {
 	FromBlock             json.RawMessage    `json:"fromBlock,omitempty"` // TODO: this should be a pldtypes.RawJSON but that's not possible right now because of a ciruclar dependency
 	CommitBatchSize       *int               `json:"commitBatchSize"`
+	InsertDBBatchSize     *int               `json:"insertDBBatchSize"` // Amount of tx and events to insert in a single DB transaction
 	CommitBatchTimeout    *string            `json:"commitBatchTimeout"`
 	RequiredConfirmations *int               `json:"requiredConfirmations"`
 	ChainHeadCacheLen     *int               `json:"chainHeadCacheLen"`
@@ -46,6 +47,7 @@ var EventStreamDefaults = &EventStreamsConfig{
 var BlockIndexerDefaults = &BlockIndexerConfig{
 	FromBlock:             json.RawMessage(`0`),
 	CommitBatchSize:       confutil.P(50),
+	InsertDBBatchSize:     confutil.P(5000),
 	CommitBatchTimeout:    confutil.P("100ms"),
 	RequiredConfirmations: confutil.P(0),
 	ChainHeadCacheLen:     confutil.P(50),

--- a/core/go/pkg/blockindexer/block_indexer.go
+++ b/core/go/pkg/blockindexer/block_indexer.go
@@ -96,6 +96,7 @@ type blockIndexer struct {
 	requiredConfirmations      int
 	retry                      *retry.Retry
 	batchSize                  int
+	insertDBBatchSize          int
 	batchTimeout               time.Duration
 	txWaiters                  *inflight.InflightManager[pldtypes.Bytes32, *pldapi.IndexedTransaction]
 	preCommitHandlers          []PreCommitHandler
@@ -130,6 +131,7 @@ func newBlockIndexer(ctx context.Context, conf *pldconf.BlockIndexerConfig, pers
 		requiredConfirmations:      confutil.IntMin(conf.RequiredConfirmations, 0, *pldconf.BlockIndexerDefaults.RequiredConfirmations),
 		retry:                      blockListener.retry,
 		batchSize:                  confutil.IntMin(conf.CommitBatchSize, 1, *pldconf.BlockIndexerDefaults.CommitBatchSize),
+		insertDBBatchSize:          confutil.IntMin(conf.InsertDBBatchSize, 1, *pldconf.BlockIndexerDefaults.InsertDBBatchSize),
 		batchTimeout:               confutil.DurationMin(conf.CommitBatchTimeout, 0, *pldconf.BlockIndexerDefaults.CommitBatchTimeout),
 		txWaiters:                  inflight.NewInflightManager[pldtypes.Bytes32, *pldapi.IndexedTransaction](pldtypes.ParseBytes32),
 		eventStreams:               make(map[uuid.UUID]*eventStream),
@@ -612,7 +614,7 @@ func (bi *blockIndexer) writeBatch(ctx context.Context, batch *blockWriterBatch)
 				err = dbTX.DB().
 					WithContext(ctx).
 					Table("indexed_transactions").
-					CreateInBatches(transactions, 1000).
+					CreateInBatches(transactions, bi.insertDBBatchSize).
 					Error
 			}
 			if err == nil && len(events) > 0 {
@@ -621,7 +623,7 @@ func (bi *blockIndexer) writeBatch(ctx context.Context, batch *blockWriterBatch)
 					Table("indexed_events").
 					Omit("Transaction").
 					Omit("Event").
-					CreateInBatches(events, 1000).
+					CreateInBatches(events, bi.insertDBBatchSize).
 					Error
 			}
 			return err

--- a/core/go/pkg/blockindexer/block_indexer.go
+++ b/core/go/pkg/blockindexer/block_indexer.go
@@ -596,7 +596,6 @@ func (bi *blockIndexer) writeBatch(ctx context.Context, batch *blockWriterBatch)
 
 	err := bi.retry.Do(ctx, func(attempt int) (retryable bool, err error) {
 		err = bi.persistence.Transaction(ctx, func(ctx context.Context, dbTX persistence.DBTX) (err error) {
-			// We need to handle the case where the limit of 65000 is reached
 			for _, preCommitHandler := range bi.preCommitHandlers {
 				if err == nil {
 					err = preCommitHandler(ctx, dbTX, blocks, notifyTransactions)

--- a/core/go/pkg/blockindexer/block_indexer_test.go
+++ b/core/go/pkg/blockindexer/block_indexer_test.go
@@ -233,7 +233,6 @@ func testBlockArray(t *testing.T, l int, knownAddress ...ethtypes.Address0xHex) 
 			},
 		})
 		require.NoError(t, err)
-		// Default TX receipt for most tests
 		receipts[blocks[i].Hash.String()] = []*TXReceiptJSONRPC{
 			{
 				TransactionHash: txHash,
@@ -1282,6 +1281,7 @@ func TestBlockIndexerManyEventsWaitForTransactionSuccess(t *testing.T) {
 	ctx, bi, mRPC, blDone := newTestBlockIndexer(t)
 	defer blDone()
 
+	// 20000 events in a single tx
 	blocks, receipts := testBlockWithManyTXAndEvents(t, 1, 20000)
 	mockBlocksRPCCalls(mRPC, blocks, receipts)
 

--- a/core/go/pkg/blockindexer/block_indexer_test.go
+++ b/core/go/pkg/blockindexer/block_indexer_test.go
@@ -1234,6 +1234,49 @@ func TestGetFromBlock(t *testing.T) {
 	assert.Equal(t, ethtypes.HexUint64(0), *v)
 }
 
+func TestBlockIndexerManyTXsWaitForTransactionSuccess(t *testing.T) {
+	ctx, bi, mRPC, blDone := newTestBlockIndexer(t)
+	defer blDone()
+
+	// 20000 transactions in a block
+	blocks, receipts := testBlockWithManyTXAndEvents(t, 20000, 0)
+	mockBlocksRPCCalls(mRPC, blocks, receipts)
+
+	txHash := pldtypes.Bytes32(receipts[blocks[0].Hash.String()][1].TransactionHash)
+	gotTX := make(chan struct{})
+	go func() {
+		defer close(gotTX)
+		tx, err := bi.WaitForTransactionSuccess(ctx, txHash, nil)
+		require.NoError(t, err)
+		assert.Equal(t, ethtypes.HexUint64(tx.BlockNumber), blocks[0].Number)
+		assert.Equal(t, txHash, tx.Hash)
+	}()
+
+	// Wait for initial query to fail
+	for bi.txWaiters.InFlightCount() == 0 {
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	utBatchNotify := make(chan []*pldapi.IndexedBlock)
+	addBlockPostCommit(bi, func(blocks []*pldapi.IndexedBlock) { utBatchNotify <- blocks })
+
+	bi.startOrReset() // do not start block listener
+
+	for i := 0; i < len(blocks); i++ {
+		notifiedBlocks := <-utBatchNotify
+		assert.Len(t, notifiedBlocks, 1) // We should get one block per batch
+		checkIndexedBlockEqual(t, blocks[i], notifiedBlocks[0])
+	}
+
+	<-gotTX
+
+	tx, err := bi.WaitForTransactionAnyResult(ctx, txHash)
+	require.NoError(t, err)
+	assert.Equal(t, pldapi.TXResult_SUCCESS, tx.Result.V())
+	assert.Equal(t, ethtypes.HexUint64(tx.BlockNumber), blocks[0].Number)
+	assert.Equal(t, txHash, tx.Hash)
+}
+
 // This is to test that we can store more than 65k events in a single DB TX
 func TestBlockIndexerManyEventsWaitForTransactionSuccess(t *testing.T) {
 	ctx, bi, mRPC, blDone := newTestBlockIndexer(t)

--- a/core/go/pkg/persistence/gorm.go
+++ b/core/go/pkg/persistence/gorm.go
@@ -22,6 +22,7 @@ import (
 	"html/template"
 	"os"
 	"runtime/debug"
+	"slices"
 	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -33,7 +34,10 @@ import (
 	"github.com/kaleido-io/paladin/core/internal/msgs"
 	"github.com/kaleido-io/paladin/sdk/go/pkg/pldtypes"
 
+	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
 	// Import migrate file source
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
@@ -194,6 +198,9 @@ func (gp *provider) Transaction(parentCtx context.Context, fn func(ctx context.C
 	// Run the database transaction itself
 	err = gp.gdb.Transaction(func(gormTX *gorm.DB) error {
 		tx.gdb = gormTX.WithContext(tx.txCtx)
+		// If support use ANY to get around the 65535 parameter limit
+		// in a WHERE IN clause
+		UseAny(tx.gdb)
 		innerErr := fn(tx.txCtx, tx)
 		for _, fn := range tx.preCommits {
 			if innerErr == nil {
@@ -216,4 +223,69 @@ func (gp *provider) Transaction(parentCtx context.Context, fn func(ctx context.C
 
 func (gp *provider) NOTX() DBTX {
 	return newNOTX(gp.gdb)
+}
+
+// From https://github.com/go-gorm/gorm/issues/6849#issuecomment-1976157903
+var (
+	whereClause     = clause.Where{}.Name()
+	postgresDialect = postgres.Dialector{}.Name()
+)
+
+// ANY is a custom implementation of the clause.IN which binds array of Values directly to a single variable
+// it has been implemented to address the limitation of "protocol limited to 65535 parameters".
+type ANY struct {
+	clause.IN
+}
+
+// UseAny configures the DB to use the ANY type for IN clauses to resolve parameter limitations.
+func UseAny(db *gorm.DB) {
+	currentDialect := db.Dialector.Name()
+	if currentDialect != postgresDialect {
+		log.L(context.Background()).Infof("ANY clause not support with %q dialect", currentDialect)
+		return
+	}
+
+	db.ClauseBuilders[whereClause] = func(c clause.Clause, builder clause.Builder) {
+		where := c.Expression.(clause.Where)
+		for i, expr := range where.Exprs {
+			if in, ok := expr.(clause.IN); ok {
+				where.Exprs[i] = ANY{IN: in}
+			}
+		}
+		c.Build(builder)
+	}
+}
+
+// Build constructs the postgres ANY clause, used to make queries with large value lists work
+func (c ANY) Build(builder clause.Builder) {
+	// Only replace clause.IN with ANY for value lists, not subqueries
+	hasNonValue := slices.ContainsFunc(c.Values, func(v any) bool {
+		switch v.(type) {
+		case sql.NamedArg, clause.Column, clause.Table, clause.Interface, clause.Expression, []any, *gorm.DB:
+			return true
+		}
+		return false
+	})
+
+	// use clause.IN as default
+	if hasNonValue || len(c.Values) <= 1 {
+		c.IN.Build(builder)
+		return
+	}
+
+	builder.WriteQuoted(c.Column)
+	stmt := builder.(*gorm.Statement)
+
+	// actual binding of the array
+	// replacing `IN ($1, $2, $3)` with `= ANY ($1)`
+	// which then translates to `= ANY([element, element2, element3, ...])`
+	_, _ = builder.WriteString(" = ANY (")
+	addBulk(stmt, c.Values)
+	_, _ = builder.WriteString(")")
+}
+
+// addBulk integrates a list of values into the query, leveraging postgres's array binding support
+func addBulk(stmt *gorm.Statement, v any) {
+	stmt.Vars = append(stmt.Vars, v)
+	stmt.DB.Dialector.BindVarTo(stmt, stmt, v)
 }

--- a/core/go/pkg/persistence/gorm.go
+++ b/core/go/pkg/persistence/gorm.go
@@ -22,7 +22,6 @@ import (
 	"html/template"
 	"os"
 	"runtime/debug"
-	"slices"
 	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -34,9 +33,7 @@ import (
 	"github.com/kaleido-io/paladin/core/internal/msgs"
 	"github.com/kaleido-io/paladin/sdk/go/pkg/pldtypes"
 
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 
 	// Import migrate file source
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -198,9 +195,6 @@ func (gp *provider) Transaction(parentCtx context.Context, fn func(ctx context.C
 	// Run the database transaction itself
 	err = gp.gdb.Transaction(func(gormTX *gorm.DB) error {
 		tx.gdb = gormTX.WithContext(tx.txCtx)
-		// If support use ANY to get around the 65535 parameter limit
-		// in a WHERE IN clause
-		UseAny(tx.gdb)
 		innerErr := fn(tx.txCtx, tx)
 		for _, fn := range tx.preCommits {
 			if innerErr == nil {
@@ -223,69 +217,4 @@ func (gp *provider) Transaction(parentCtx context.Context, fn func(ctx context.C
 
 func (gp *provider) NOTX() DBTX {
 	return newNOTX(gp.gdb)
-}
-
-// From https://github.com/go-gorm/gorm/issues/6849#issuecomment-1976157903
-var (
-	whereClause     = clause.Where{}.Name()
-	postgresDialect = postgres.Dialector{}.Name()
-)
-
-// ANY is a custom implementation of the clause.IN which binds array of Values directly to a single variable
-// it has been implemented to address the limitation of "protocol limited to 65535 parameters".
-type ANY struct {
-	clause.IN
-}
-
-// UseAny configures the DB to use the ANY type for IN clauses to resolve parameter limitations.
-func UseAny(db *gorm.DB) {
-	currentDialect := db.Dialector.Name()
-	if currentDialect != postgresDialect {
-		log.L(context.Background()).Infof("ANY clause not support with %q dialect", currentDialect)
-		return
-	}
-
-	db.ClauseBuilders[whereClause] = func(c clause.Clause, builder clause.Builder) {
-		where := c.Expression.(clause.Where)
-		for i, expr := range where.Exprs {
-			if in, ok := expr.(clause.IN); ok {
-				where.Exprs[i] = ANY{IN: in}
-			}
-		}
-		c.Build(builder)
-	}
-}
-
-// Build constructs the postgres ANY clause, used to make queries with large value lists work
-func (c ANY) Build(builder clause.Builder) {
-	// Only replace clause.IN with ANY for value lists, not subqueries
-	hasNonValue := slices.ContainsFunc(c.Values, func(v any) bool {
-		switch v.(type) {
-		case sql.NamedArg, clause.Column, clause.Table, clause.Interface, clause.Expression, []any, *gorm.DB:
-			return true
-		}
-		return false
-	})
-
-	// use clause.IN as default
-	if hasNonValue || len(c.Values) <= 1 {
-		c.IN.Build(builder)
-		return
-	}
-
-	builder.WriteQuoted(c.Column)
-	stmt := builder.(*gorm.Statement)
-
-	// actual binding of the array
-	// replacing `IN ($1, $2, $3)` with `= ANY ($1)`
-	// which then translates to `= ANY([element, element2, element3, ...])`
-	_, _ = builder.WriteString(" = ANY (")
-	addBulk(stmt, c.Values)
-	_, _ = builder.WriteString(")")
-}
-
-// addBulk integrates a list of values into the query, leveraging postgres's array binding support
-func addBulk(stmt *gorm.Statement, v any) {
-	stmt.Vars = append(stmt.Vars, v)
-	stmt.DB.Dialector.BindVarTo(stmt, stmt, v)
 }


### PR DESCRIPTION
When configuring Paladin to index a large public chain, it will have to deal with a larger amount of data to storage in the database. The block indexer has a guarantee that it will store the block, the transactions within that block and the events within that block in one single DB transaction. 

I hit an issue where in a single transaction there we over 15k events emitted and the database `INSERT indexed_events` failed with `extended protocol limited to 65535 parameters`. This is a limit set by Postgres on the amount of parameters in an SQL statement. So it's the amount of columns values times the number of rows you want to insert, in the case of events we store 5 things: `("block_number","transaction_index","log_index","transaction_hash","signature")` so with 15k events it exceeds the **65535** limit. 

Turns out Gorm has a `CreateInBatches` method that will split inserts into multiple statements, enabled that for the block indexer and added a couple of tests.

I did explore worrying about the limit on a WHERE clause on find such as https://github.com/LF-Decentralized-Trust-labs/paladin/blob/d4ab1541a87bf36d74c429ce88152e02501cb839/core/go/internal/publictxmgr/transaction_manager.go#L788-L794 due to the complexity of fixing it,  the unlikely scenario of 65000 TX in a single block or multiple and the ability to configure the batch size of blocks to commit then this is not needed at this point. See https://github.com/go-gorm/gorm/issues/6849#issuecomment-2842137959 