### PR TITLE
zeto: revert during assembly for failures in acquiring input states

### DIFF
--- a/domains/zeto/internal/zeto/fungible/handler_withdraw_test.go
+++ b/domains/zeto/internal/zeto/fungible/handler_withdraw_test.go
@@ -153,9 +153,8 @@ func TestWithdrawAssemble(t *testing.T) {
 			}, nil
 		},
 	}
-	res, err := h.Assemble(ctx, tx, req)
+	_, err = h.Assemble(ctx, tx, req)
 	require.NoError(t, err)
-	assert.Equal(t, "100", *res.AssembledTransaction.DomainData)
 
 	tx.DomainConfig.TokenName = constants.TOKEN_ANON_NULLIFIER
 	(*tx.DomainConfig.Circuits)["withdraw"] = &zetosignerapi.Circuit{Name: "withdraw_nullifier", Type: "withdraw", UsesNullifiers: true}
@@ -180,7 +179,7 @@ func TestWithdrawAssemble(t *testing.T) {
 			}, nil
 		},
 	}
-	res, err = h.Assemble(ctx, tx, req)
+	_, err = h.Assemble(ctx, tx, req)
 	require.ErrorContains(t, err, "PD210042: Failed to format proving request. PD210052: Failed to generate merkle proofs.")
 
 	called = 0
@@ -204,9 +203,8 @@ func TestWithdrawAssemble(t *testing.T) {
 			}, nil
 		},
 	}
-	res, err = h.Assemble(ctx, tx, req)
+	_, err = h.Assemble(ctx, tx, req)
 	require.NoError(t, err)
-	assert.Equal(t, "100", *res.AssembledTransaction.DomainData)
 }
 
 func TestWithdrawEndorse(t *testing.T) {
@@ -239,7 +237,6 @@ func TestWithdrawPrepare(t *testing.T) {
 			},
 		},
 	}
-	amountStr := "100"
 	req := &prototk.PrepareTransactionRequest{
 		InputStates: []*prototk.EndorsableState{
 			{
@@ -254,7 +251,6 @@ func TestWithdrawPrepare(t *testing.T) {
 			},
 		},
 		Transaction: txSpec,
-		DomainData:  &amountStr,
 	}
 	ctx := context.Background()
 	_, err := h.Prepare(ctx, tx, req)

--- a/domains/zeto/internal/zeto/fungible/states.go
+++ b/domains/zeto/internal/zeto/fungible/states.go
@@ -92,16 +92,22 @@ func makeNewInfoState(ctx context.Context, dataSchema *prototk.StateSchema, info
 	}, nil
 }
 
-func prepareInputsForTransfer(ctx context.Context, callbacks plugintk.DomainCallbacks, coinSchema *pb.StateSchema, useNullifiers bool, stateQueryContext, senderKey string, params []*types.FungibleTransferParamEntry) ([]*types.ZetoCoin, []*pb.StateRef, *big.Int, *big.Int, error) {
-	expectedTotal := big.NewInt(0)
+type preparedInputs struct {
+	coins  []*types.ZetoCoin
+	states []*prototk.StateRef
+	total  *big.Int
+}
+
+func prepareInputsForTransfer(ctx context.Context, callbacks plugintk.DomainCallbacks, coinSchema *pb.StateSchema, useNullifiers bool, stateQueryContext, senderKey string, params []*types.FungibleTransferParamEntry) (inputs *preparedInputs, expectedTotal *big.Int, revert bool, err error) {
+	expectedTotal = big.NewInt(0)
 	for _, param := range params {
 		expectedTotal = expectedTotal.Add(expectedTotal, param.Amount.Int())
 	}
-
-	return buildInputsForExpectedTotal(ctx, callbacks, coinSchema, useNullifiers, stateQueryContext, senderKey, expectedTotal, false)
+	inputs, revert, err = buildInputsForExpectedTotal(ctx, callbacks, coinSchema, useNullifiers, stateQueryContext, senderKey, expectedTotal, false)
+	return
 }
 
-func buildInputsForExpectedTotal(ctx context.Context, callbacks plugintk.DomainCallbacks, coinSchema *pb.StateSchema, useNullifiers bool, stateQueryContext, senderKey string, expectedTotal *big.Int, locked bool) ([]*types.ZetoCoin, []*pb.StateRef, *big.Int, *big.Int, error) {
+func buildInputsForExpectedTotal(ctx context.Context, callbacks plugintk.DomainCallbacks, coinSchema *pb.StateSchema, useNullifiers bool, stateQueryContext, senderKey string, expectedTotal *big.Int, locked bool) (inputs *preparedInputs, revert bool, err error) {
 	var lastStateTimestamp int64
 	total := big.NewInt(0)
 	stateRefs := []*pb.StateRef{}
@@ -118,16 +124,16 @@ func buildInputsForExpectedTotal(ctx context.Context, callbacks plugintk.DomainC
 		}
 		states, err := findAvailableStates(ctx, callbacks, coinSchema, useNullifiers, stateQueryContext, queryBuilder.Query().String())
 		if err != nil {
-			return nil, nil, nil, nil, i18n.NewError(ctx, msgs.MsgErrorQueryAvailCoins, err)
+			return nil, false, i18n.NewError(ctx, msgs.MsgErrorQueryAvailCoins, err)
 		}
 		if len(states) == 0 {
-			return nil, nil, nil, nil, i18n.NewError(ctx, msgs.MsgInsufficientFunds, total.Text(10))
+			return nil, true, i18n.NewError(ctx, msgs.MsgInsufficientFunds, total.Text(10))
 		}
 		for _, state := range states {
 			lastStateTimestamp = state.CreatedAt
 			coin, err := makeCoin(state.DataJson)
 			if err != nil {
-				return nil, nil, nil, nil, i18n.NewError(ctx, msgs.MsgInvalidCoin, state.Id, err)
+				return nil, false, i18n.NewError(ctx, msgs.MsgInvalidCoin, state.Id, err)
 			}
 			total = total.Add(total, coin.Amount.Int())
 			stateRefs = append(stateRefs, &pb.StateRef{
@@ -136,11 +142,14 @@ func buildInputsForExpectedTotal(ctx context.Context, callbacks plugintk.DomainC
 			})
 			coins = append(coins, coin)
 			if total.Cmp(expectedTotal) >= 0 {
-				remainder := big.NewInt(0).Sub(total, expectedTotal)
-				return coins, stateRefs, total, remainder, nil
+				return &preparedInputs{
+					coins:  coins,
+					states: stateRefs,
+					total:  total,
+				}, false, nil
 			}
 			if len(stateRefs) >= MAX_INPUT_COUNT {
-				return nil, nil, nil, nil, i18n.NewError(ctx, msgs.MsgMaxCoinsReached, MAX_INPUT_COUNT)
+				return nil, true, i18n.NewError(ctx, msgs.MsgMaxCoinsReached, MAX_INPUT_COUNT)
 			}
 		}
 	}

--- a/domains/zeto/internal/zeto/fungible/states.go
+++ b/domains/zeto/internal/zeto/fungible/states.go
@@ -133,7 +133,7 @@ func buildInputsForExpectedTotal(ctx context.Context, callbacks plugintk.DomainC
 			lastStateTimestamp = state.CreatedAt
 			coin, err := makeCoin(state.DataJson)
 			if err != nil {
-				return nil, false, i18n.NewError(ctx, msgs.MsgInvalidCoin, state.Id, err)
+				return nil, true, i18n.NewError(ctx, msgs.MsgInvalidCoin, state.Id, err)
 			}
 			total = total.Add(total, coin.Amount.Int())
 			stateRefs = append(stateRefs, &pb.StateRef{

--- a/domains/zeto/internal/zeto/fungible/states_test.go
+++ b/domains/zeto/internal/zeto/fungible/states_test.go
@@ -40,13 +40,13 @@ func TestPrepareInputs(t *testing.T) {
 
 	stateQueryContext := "test"
 	ctx := context.Background()
-	_, _, _, _, err := prepareInputsForTransfer(ctx, callbacks, coinSchema, false, stateQueryContext, "Alice", []*types.FungibleTransferParamEntry{{Amount: pldtypes.Uint64ToUint256(100)}})
+	_, _, _, err := prepareInputsForTransfer(ctx, callbacks, coinSchema, false, stateQueryContext, "Alice", []*types.FungibleTransferParamEntry{{Amount: pldtypes.Uint64ToUint256(100)}})
 	assert.EqualError(t, err, "PD210032: Failed to query the state store for available coins. test error")
 
 	testCallbacks.MockFindAvailableStates = func() (*prototk.FindAvailableStatesResponse, error) {
 		return &prototk.FindAvailableStatesResponse{}, nil
 	}
-	_, _, _, _, err = prepareInputsForTransfer(ctx, callbacks, coinSchema, false, stateQueryContext, "Alice", []*types.FungibleTransferParamEntry{{Amount: pldtypes.Uint64ToUint256(100)}})
+	_, _, _, err = prepareInputsForTransfer(ctx, callbacks, coinSchema, false, stateQueryContext, "Alice", []*types.FungibleTransferParamEntry{{Amount: pldtypes.Uint64ToUint256(100)}})
 	assert.EqualError(t, err, "PD210033: Insufficient funds (available=0)")
 
 	testCallbacks.MockFindAvailableStates = func() (*prototk.FindAvailableStatesResponse, error) {
@@ -59,7 +59,7 @@ func TestPrepareInputs(t *testing.T) {
 			},
 		}, nil
 	}
-	_, _, _, _, err = prepareInputsForTransfer(ctx, callbacks, coinSchema, false, stateQueryContext, "Alice", []*types.FungibleTransferParamEntry{{Amount: pldtypes.Uint64ToUint256(100)}})
+	_, _, _, err = prepareInputsForTransfer(ctx, callbacks, coinSchema, false, stateQueryContext, "Alice", []*types.FungibleTransferParamEntry{{Amount: pldtypes.Uint64ToUint256(100)}})
 	assert.EqualError(t, err, "PD210034: Coin state-1 is invalid: invalid character 'b' looking for beginning of value")
 
 	testCallbacks.MockFindAvailableStates = func() (*prototk.FindAvailableStatesResponse, error) {
@@ -78,6 +78,6 @@ func TestPrepareInputs(t *testing.T) {
 			},
 		}, nil
 	}
-	_, _, _, _, err = prepareInputsForTransfer(ctx, callbacks, coinSchema, false, stateQueryContext, "Alice", []*types.FungibleTransferParamEntry{{Amount: pldtypes.Uint64ToUint256(200)}})
+	_, _, _, err = prepareInputsForTransfer(ctx, callbacks, coinSchema, false, stateQueryContext, "Alice", []*types.FungibleTransferParamEntry{{Amount: pldtypes.Uint64ToUint256(200)}})
 	assert.EqualError(t, err, "PD210035: Need more than maximum number (10) of coins to fulfill the transfer amount total")
 }

--- a/example/zeto/src/index.ts
+++ b/example/zeto/src/index.ts
@@ -52,6 +52,9 @@ async function main(): Promise<boolean> {
   });
   if (!checkReceipt(receipt)) return false;
 
+  // TODO: remove
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+
   // Transfer some cash from bank1 to bank2
   logger.log(
     "- Bank1 transferring CBDC to bank2 to pay for some asset trades ..."


### PR DESCRIPTION
Failures that involve malformed or insufficient inputs should result in a revert, rather than an error (which will retry forever).