### PR TITLE
Accept eth address as from on transaction submission

### DIFF
--- a/core/go/internal/txmgr/transaction_submission.go
+++ b/core/go/internal/txmgr/transaction_submission.go
@@ -575,13 +575,13 @@ func (tm *txManager) resolveNewTransaction(ctx context.Context, dbTX persistence
 		(submitMode == pldapi.SubmitModeCall && tx.From == "") /* call is allowed no sender */
 	if !bypassFromCheck {
 		if _, err := pldtypes.ParseEthAddress(tx.From); err == nil {
-			// Doing the reverse lookup here means that we can persist the identity on the transaction. It does mean that the
-			// identity will later be resolved back to the verifier but this should just be a cache read
+			// Doing the reverse lookup here means that we can persist the identifier on the transaction. It does mean that the
+			// identifier will later be resolved back to the verifier but this should just be a cache read
 			mapping, err := tm.keyManager.ReverseKeyLookup(ctx, dbTX, algorithms.ECDSA_SECP256K1, verifiers.ETH_ADDRESS, tx.From)
-			if err != nil {
-				return nil, err
+			if err == nil {
+				tx.From = mapping.Identifier
 			}
-			tx.From = mapping.Identifier
+			// else 'from' does not exist as a verifier, treat it as an identifier
 		}
 
 		identifier, node, err := pldtypes.PrivateIdentityLocator(tx.From).Validate(ctx, tm.localNodeName, false)


### PR DESCRIPTION
If the value of `from` when submitting a transaction is an 0x address, use it as the verifier for the signing key. 

Following on from feedback on a [previous PR](https://github.com/LF-Decentralized-Trust-labs/paladin/pull/643/commits/c1a05c706de57c84042d017cd23dd20a414b8c3f#r2098369056) which had a first attempt at this change, I have **not** introduced a restriction on 0x addresses being used as identifiers. This is to accommodate the use case that keys are already pre-created in the backend signer,  are only loaded into Paladin when that key is resolved, and the 0x address is what is needed to link the two.

This has implications for the behaviour in different functions:

### `keymgr_resolveKey`/`ptx_resolveVerifier`/`keymgr_resolveEthAddress`

I have not changed the implementation here as I do not think it is necessary.

These methods are explicit in that they resolve from `identifier` to `verifier`. If a 0x address is provided as a parameter it will always be assumed to be an identifier. If the identifier does not exist it will result in the creation of a new identifier.

It is not possible to police what the signer does with that identifier when generating a verifier for the new identity. If we want to support key creation resulting in the signer linking the identifier to an existing key with the same 0x address as the verifier, then it will also be possible that the signer generates a completely different 0x address to be the verifier.

### `ptx_sendTransaction`/`ptx_sendTransactions`/`ptx_call`

This PR changes the behaviour of these functions.

Previous behaviour- `from` is always an identifier.

New behaviour- `from` may be an identifier or a verifier. If `from` is a `0x` address assume first it is a verifier. If the verifier doesn't exist, then treat it as an identifier (which may result in identifier creation on resolution).