### PR TITLE
zeto: ensure UTXO params are always initialized as arrays

### DIFF
--- a/domains/zeto/internal/zeto/fungible/utils.go
+++ b/domains/zeto/internal/zeto/fungible/utils.go
@@ -269,7 +269,7 @@ func formatTransferProvingRequest(ctx context.Context, callbacks plugintk.Domain
 }
 
 func trimZeroUtxos(utxos []string) []string {
-	var trimmed []string
+	trimmed := make([]string, 0, len(utxos))
 	for _, utxo := range utxos {
 		if utxo != "0" {
 			trimmed = append(trimmed, utxo)


### PR DESCRIPTION
Ensure we don't accidentally pass "null" to the base ledger for inputs or outputs.

Resolves #698 