### PR TITLE
sdk: do not block on receipt polling by default

### DIFF
--- a/.github/workflows/build-chart.yaml
+++ b/.github/workflows/build-chart.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: E2E Test
         run: |
-          ./gradlew --no-daemon --parallel e2e \
+          ./gradlew --no-daemon e2e \
             -PclusterName=${{ env.CLUSTER_NAME }} \
             -Pnamespace=${{ env.NAMESPACE }} \
             -PbuildOperator=${{ inputs.build-operator }} \

--- a/doc-site/docs/tutorials/notarized-tokens.md
+++ b/doc-site/docs/tutorials/notarized-tokens.md
@@ -40,10 +40,12 @@ First, create a **Noto Factory** instance and deploy a new token. **Node1** will
 ```typescript
 logger.log("Step 1: Deploying a Noto cash token...");
 const notoFactory = new NotoFactory(paladinClientNode1, "noto");
-const cashToken = await notoFactory.newNoto(verifierNode1, {
-  notary: verifierNode1,
-  notaryMode: "basic",
-});
+const cashToken = await notoFactory
+  .newNoto(verifierNode1, {
+    notary: verifierNode1,
+    notaryMode: "basic",
+  })
+  .waitForDeploy();
 if (!cashToken) {
   logger.error("Failed to deploy the Noto cash token!");
   return false;
@@ -68,11 +70,13 @@ With the token contract deployed, let’s **mint** an initial supply of tokens f
 
 ```typescript
 logger.log("Step 2: Minting 2000 units of cash to Node1...");
-const mintReceipt = await cashToken.mint(verifierNode1, {
-  to: verifierNode1,
-  amount: 2000,
-  data: "0x",
-});
+const mintReceipt = await cashToken
+  .mint(verifierNode1, {
+    to: verifierNode1,
+    amount: 2000,
+    data: "0x",
+  })
+  .waitForReceipt();
 if (!mintReceipt) {
   logger.error("Failed to mint cash tokens!");
   return false;
@@ -102,11 +106,13 @@ Now that Node1 has tokens, let’s **transfer some to Node2**. This works simila
 
 ```typescript
 logger.log("Step 3: Transferring 1000 units of cash from Node1 to Node2...");
-const transferToNode2 = await cashToken.transfer(verifierNode1, {
-  to: verifierNode2,
-  amount: 1000,
-  data: "0x",
-});
+const transferToNode2 = await cashToken
+  .transfer(verifierNode1, {
+    to: verifierNode2,
+    amount: 1000,
+    data: "0x",
+  })
+  .waitForReceipt();
 if (!transferToNode2) {
   logger.error("Failed to transfer cash to Node2!");
   return false;
@@ -122,11 +128,14 @@ Now let’s see how **Node2** transfers tokens to **Node3**. Since Node2 is init
 
 ```typescript
 logger.log("Step 4: Transferring 800 units of cash from Node2 to Node3...");
-const transferToNode3 = await cashToken.using(paladinClientNode2).transfer(verifierNode2, {
-  to: verifierNode3,
-  amount: 800,
-  data: "0x",
-});
+const transferToNode3 = await cashToken
+  .using(paladinClientNode2)
+  .transfer(verifierNode2, {
+    to: verifierNode3,
+    amount: 800,
+    data: "0x",
+  })
+  .waitForReceipt();
 if (!transferToNode3) {
   logger.error("Failed to transfer cash to Node3!");
   return false;

--- a/doc-site/docs/tutorials/private-stablecoin.md
+++ b/doc-site/docs/tutorials/private-stablecoin.md
@@ -38,17 +38,21 @@ The example begins by deploying both the public ERC20 and private Zeto contracts
 ```typescript
 // Deploy private stablecoin using Zeto_AnonNullifierKyc
 const zetoFactory = new ZetoFactory(paladin1, "zeto");
-const privateStablecoin = await zetoFactory.newZeto(financialInstitution, {
-  tokenName: "Zeto_AnonNullifierKyc",
-});
+const privateStablecoin = await zetoFactory
+  .newZeto(financialInstitution, {
+    tokenName: "Zeto_AnonNullifierKyc",
+  })
+  .waitForDeploy();
 
 // Deploy public ERC20 stablecoin
 const publicStablecoinAddress = await deployERC20(paladin1, financialInstitution);
 
 // Connect the ERC20 to the Zeto contract for deposit/withdraw
-await privateStablecoin.setERC20(financialInstitution, {
-  erc20: publicStablecoinAddress,
-});
+await privateStablecoin
+  .setERC20(financialInstitution, {
+    erc20: publicStablecoinAddress,
+  })
+  .waitForReceipt();
 ```
 
 The `Zeto_AnonNullifierKyc` contract provides:
@@ -121,9 +125,12 @@ await approveERC20(
 );
 
 // Client A deposits ERC20 tokens to get private Zeto tokens
-const depositReceipt = await privateStablecoin.using(paladin2).deposit(clientA, {
-  amount: 75000,
-});
+const depositReceipt = await privateStablecoin
+  .using(paladin2)
+  .deposit(clientA, {
+    amount: 75000,
+  })
+  .waitForReceipt();
 ```
 
 **Privacy Benefits:**
@@ -148,7 +155,8 @@ const transferReceipt = await privateStablecoin
         data: "0x",
       },
     ],
-  });
+  })
+  .waitForReceipt();
 ```
 
 **KYC-Verified Privacy Features:**
@@ -167,7 +175,8 @@ const withdrawReceipt = await privateStablecoin
   .using(paladin3)
   .withdraw(clientB, {
     amount: 15000, // Withdraw 15,000 tokens
-  });
+  })
+  .waitForReceipt();
 ```
 
 **Withdrawal Benefits:**

--- a/doc-site/docs/tutorials/private-storage.md
+++ b/doc-site/docs/tutorials/private-storage.md
@@ -49,13 +49,7 @@ const memberPrivacyGroup = await penteFactory.newPrivacyGroup({
   members: [verifierNode1, verifierNode2],
   evmVersion: "shanghai",
   externalCallsEnabled: true,
-});
-
-if (!checkDeploy(memberPrivacyGroup)) {
-  logger.error("Failed to create the privacy group.");
-  return false;
-}
-logger.log("Privacy group created successfully!");
+}).waitForDeploy();
 ```
 
 #### Key Points:
@@ -71,18 +65,12 @@ logger.log("Privacy group created successfully!");
 Now that the **privacy group** is established, **deploy** the `Storage` contract inside this group.
 
 ```typescript
-logger.log("Deploying a private Storage contract...");
+logger.log("Deploying a smart contract to the privacy group...");
 const contractAddress = await memberPrivacyGroup.deploy({
   abi: storageJson.abi,
   bytecode: storageJson.bytecode,
   from: verifierNode1.lookup,
-});
-
-if (!contractAddress) {
-  logger.error("Failed to deploy the private Storage contract.");
-  return false;
-}
-logger.log(`Private smart contract deployed! Address: ${contractAddress}`);
+}).waitForDeploy();
 ```
 
 #### Key Points
@@ -99,18 +87,21 @@ logger.log(`Private smart contract deployed! Address: ${contractAddress}`);
 Now that the contract is deployed, **Node1** can store a value.
 
 ```typescript
-const privateStorage = new PrivateStorage(memberPrivacyGroup, contractAddress);
+const privateStorageContract = new PrivateStorage(
+  memberPrivacyGroup,
+  contractAddress
+);
 
 const valueToStore = 125; // Example value to store
 logger.log(`Storing a value "${valueToStore}" in the contract...`);
-const storeTx = await privateStorageContract.sendTransaction({
+const storeReceipt = await privateStorageContract.sendTransaction({
   from: verifierNode1.lookup,
   function: "store",
   data: { num: valueToStore },
-});
+}).waitForReceipt();
 logger.log(
   "Value stored successfully! Transaction hash:",
-  storeTx?.transactionHash
+  storeReceipt?.transactionHash
 );
 ```
 

--- a/doc-site/docs/tutorials/zkp-cbdc.md
+++ b/doc-site/docs/tutorials/zkp-cbdc.md
@@ -20,9 +20,11 @@ Below is a walkthrough of each step in the example, with an explanation of what 
 
 ```typescript
 const zetoFactory = new ZetoFactory(paladin3, 'zeto');
-const zetoCBDC = await zetoFactory.newZeto(cbdcIssuer, {
-  tokenName: 'Zeto_AnonNullifier',
-});
+const zetoCBDC1 = await zetoFactory
+  .newZeto(cbdcIssuer, {
+    tokenName: 'Zeto_AnonNullifier',
+  })
+  .waitForDeploy();
 ```
 
 This creates a new instance of the Zeto domain, using the [Zeto_AnonNullifier](https://github.com/hyperledger-labs/zeto/tree/main?tab=readme-ov-file#zeto_anonnullifier) contract. This results in a new cloned contract on the base ledger, with a new unique address. This Zeto token contract will be used to represent
@@ -34,20 +36,22 @@ deployer account of the contract.
 ### Issue cash
 
 ```typescript
-let receipt = await zetoCBDC.mint(cbdcIssuer, {
-  mints: [
-    {
-      to: bank1,
-      amount: 100000,
-      data: "0x",
-    },
-    {
-      to: bank2,
-      amount: 100000,
-      data: "0x",
-    },
-  ],
-});
+let receipt = await zetoCBDC1
+  .mint(cbdcIssuer, {
+    mints: [
+      {
+        to: bank1,
+        amount: 100000,
+        data: "0x",
+      },
+      {
+        to: bank2,
+        amount: 100000,
+        data: "0x",
+      },
+    ],
+  })
+  .waitForReceipt();
 ```
 
 The cash issuer mints cash to the commercial banks, `bank1` and `bank2`.
@@ -55,15 +59,18 @@ The cash issuer mints cash to the commercial banks, `bank1` and `bank2`.
 ### Bank1 transfers tokens to bank2 as payment
 
 ```typescript
-receipt = await zetoCBDC.using(paladin1).transfer(bank1, {
-  transfers: [
-    {
-      to: bank2,
-      amount: 1000,
-      data: "0x",
-    },
-  ],
-});
+receipt = await zetoCBDC1
+  .using(paladin1)
+  .transfer(bank1, {
+    transfers: [
+      {
+        to: bank2,
+        amount: 1000,
+        data: "0x",
+      },
+    ],
+  })
+  .waitForReceipt();
 ```
 
 Bank1 can call the `transfer` function to transfer zeto tokens to multiple parties, up to 10. Note that the identity `bank1` exists on the `paladin1` instance,
@@ -78,10 +85,11 @@ Below is a walkthrough of each step in the example, with an explanation of what 
 ### Create CBDC token
 
 ```typescript
-const zetoFactory = new ZetoFactory(paladin3, 'zeto');
-const zetoCBDC = await zetoFactory.newZeto(cbdcIssuer, {
-  tokenName: 'Zeto_AnonNullifier',
-});
+const zetoCBDC2 = await zetoFactory
+  .newZeto(cbdcIssuer, {
+    tokenName: 'Zeto_AnonNullifier',
+  })
+  .waitForDeploy();
 ```
 
 This creates a new instance of the Zeto domain, using the [Zeto_AnonNullifier](https://github.com/hyperledger-labs/zeto/tree/main?tab=readme-ov-file#zeto_anonnullifier) contract. This results in a new cloned contract on the base ledger, with a new unique address. This Zeto token contract will be used to represent
@@ -98,9 +106,11 @@ This deploys the ERC20 token which will be used by the authority to regulate the
 ### Configure the Zeto token contract to accept deposits and withdraws from the ERC20
 
 ```typescript
-const result2 = await zetoCBDC.setERC20(cbdcIssuer, {
-  _erc20: erc20Address as string,
-});
+const result2 = await zetoCBDC2
+  .setERC20(cbdcIssuer, {
+    erc20: erc20Address as string,
+  })
+  .waitForReceipt();
 ```
 
 When the `deposit` function is called on the Zeto contract, this ERC20 contract will be called to draw the requested funds from the depositor's account. Conversely, when the `withdraw` function is called, this ERC20 contract will be called to transfer back the ERC20 balance to the withdrawer's account.
@@ -116,9 +126,12 @@ Because the ERC20 implementation provides full transparency of the token operati
 ### Banks exchange ERC20 balances for Zeto tokens - deposit
 
 ```typescript
-const result4 = await zetoCBDC.using(paladin1).deposit(bank1, {
-  amount: 10000,
-});
+const result4 = await zetoCBDC2
+  .using(paladin1)
+  .deposit(bank1, {
+    amount: 10000,
+  })
+  .waitForReceipt();
 ```
 
 After having been minted ERC20 balances, a partcipant like `bank1` can call `deposit` on the Paladin Zeto domain to exchange for Zeto tokens. Behind the scenes, the ERC20 balance is transferred to the Zeto contract which will hold until `withdraw` is called later.
@@ -126,15 +139,18 @@ After having been minted ERC20 balances, a partcipant like `bank1` can call `dep
 ### Bank1 transfers tokens to bank2 as payment
 
 ```typescript
-receipt = await zetoCBDC.using(paladin1).transfer(bank1, {
-  transfers: [
-    {
-      to: bank2,
-      amount: 1000,
-      data: "0x",
-    },
-  ],
-});
+receipt = await zetoCBDC2
+  .using(paladin1)
+  .transfer(bank1, {
+    transfers: [
+      {
+        to: bank2,
+        amount: 1000,
+        data: "0x",
+      },
+    ],
+  })
+  .waitForReceipt();
 ```
 
 Bank1 can call the `transfer` function to transfer zeto tokens to multiple parties, up to 10. Note that the identity `bank1` exists on the `paladin1` instance,
@@ -143,9 +159,12 @@ therefore it must use that instance to send the transfer transction (`.using(pal
 ### Bank1 exchanges Zeto tokens for ERC20 balances - withdraw
 
 ```typescript
-const result5 = await zetoCBDC.using(paladin1).withdraw(bank1, {
-  amount: 1000,
-});
+const result5 = await zetoCBDC2
+  .using(paladin1)
+  .withdraw(bank1, {
+    amount: 1000,
+  })
+  .waitForReceipt();
 ```
 
 A participant like `bank1` who has unspent Zeto tokens can call `withdraw` on the Paladin Zeto domain to exchange them for ERC20 balances. Behind the scenes, the requested amount are "burnt" in the Zeto contract, and the corresponding ERC20 amount are released by the Zeto contract, by transferring to the requesting account.

--- a/example/bond/src/helpers/bondsubscription.ts
+++ b/example/bond/src/helpers/bondsubscription.ts
@@ -34,12 +34,14 @@ export const newBondSubscription = async (
   if (bondSubscriptionConstructor === undefined) {
     throw new Error("Bond subscription constructor not found");
   }
-  const address = await pente.deploy({
-    abi: bondSubscription.abi,
-    bytecode: bondSubscription.bytecode,
-    from: from.lookup,
-    inputs: params
-  });
+  const address = await pente
+    .deploy({
+      abi: bondSubscription.abi,
+      bytecode: bondSubscription.bytecode,
+      from: from.lookup,
+      inputs: params,
+    })
+    .waitForDeploy();
   return address ? new BondSubscription(pente, address) : undefined;
 };
 
@@ -59,7 +61,7 @@ export class BondSubscription extends PentePrivateContract<BondSubscriptionConst
     return this.sendTransaction({
       from: from.lookup,
       function: "preparePayment",
-      data: params
+      data: params,
     });
   }
 
@@ -67,14 +69,14 @@ export class BondSubscription extends PentePrivateContract<BondSubscriptionConst
     return this.sendTransaction({
       from: from.lookup,
       function: "prepareBond",
-      data: params
+      data: params,
     });
   }
 
-  async distribute(from: PaladinVerifier) {
+  distribute(from: PaladinVerifier) {
     return this.sendTransaction({
       from: from.lookup,
-      function: "distribute"
+      function: "distribute",
     });
   }
 }

--- a/example/bond/src/helpers/bondtracker.ts
+++ b/example/bond/src/helpers/bondtracker.ts
@@ -23,12 +23,14 @@ export const newBondTracker = async (
   from: PaladinVerifier,
   params: BondTrackerConstructorParams
 ) => {
-  const address = await pente.deploy({
+  const address = await pente
+    .deploy({
       abi: bondTracker.abi,
       bytecode: bondTracker.bytecode,
       from: from.lookup,
-      inputs: params
-  });
+      inputs: params,
+    })
+    .waitForDeploy();
   return address ? new BondTracker(pente, address) : undefined;
 };
 
@@ -48,14 +50,14 @@ export class BondTracker extends PentePrivateContract<BondTrackerConstructorPara
     return this.sendTransaction({
       from: from.lookup,
       function: "beginDistribution",
-      data: params
+      data: params,
     });
   }
 
   async investorList(from: PaladinVerifier) {
     const result = await this.call({
-        from: from.lookup,
-        function: "investorList"
+      from: from.lookup,
+      function: "investorList",
     });
     return new InvestorList(this.evm, result[0]);
   }

--- a/example/bond/src/helpers/investorlist.ts
+++ b/example/bond/src/helpers/investorlist.ts
@@ -25,7 +25,7 @@ export class InvestorList extends PentePrivateContract<{}> {
     return this.sendTransaction({
       from: from.lookup,
       function: "addInvestor",
-      data: params
+      data: params,
     });
   }
 }

--- a/example/event-listener/src/index.ts
+++ b/example/event-listener/src/index.ts
@@ -18,33 +18,32 @@ async function main(): Promise<boolean> {
   // Create a privacy group for Node1 alone
   logger.log("Creating a privacy group for Node1...");
   const penteFactory = new PenteFactory(paladin, "pente");
-  const memberPrivacyGroup = await penteFactory.newPrivacyGroup({
-    members: [verifierNode1],
-    evmVersion: "shanghai",
-    externalCallsEnabled: true,
-  });
+  const memberPrivacyGroup = await penteFactory
+    .newPrivacyGroup({
+      members: [verifierNode1],
+      evmVersion: "shanghai",
+      externalCallsEnabled: true,
+    })
+    .waitForDeploy();
   if (!checkDeploy(memberPrivacyGroup)) return false;
 
   // Deploy a smart contract within the privacy group
   logger.log("Deploying a smart contract to the privacy group...");
-  const contractAddress = await memberPrivacyGroup.deploy({
+  const deploy = memberPrivacyGroup.deploy({
     abi: helloWorldJson.abi,
     bytecode: helloWorldJson.bytecode,
     from: verifierNode1.lookup,
   });
-  if (!contractAddress) {
+  const receipt = await deploy.waitForReceipt();
+  const contractAddress = await deploy.waitForDeploy();
+  if (!receipt || !contractAddress) {
     logger.error("Failed to deploy the contract. No address returned.");
     return false;
   }
-  logger.log(`Contract deployed successfully! Address: ${contractAddress}`);
-
-  // Check the latest sequence received
-  const receipts = await paladin.queryTransactionReceipts({
-    limit: 1,
-    sort: ["-sequence"],
-  });
-  const lastSequence = receipts[0].sequence;
-  logger.log(`Last sequence received: ${lastSequence}`);
+  const lastSequence = receipt.sequence;
+  logger.log(
+    `Contract deployed successfully! Address: ${contractAddress} Sequence: ${lastSequence}`
+  );
 
   // Create a new listener (deleting one if it already exists)
   logger.log("Creating a receipt listener...");
@@ -74,7 +73,9 @@ async function main(): Promise<boolean> {
     if (receipt.domain === undefined) {
       return;
     }
-    logger.log(`Processing receipt ${receipt.id} (sequence: ${receipt.sequence})`);
+    logger.log(
+      `Processing receipt ${receipt.id} (sequence: ${receipt.sequence})`
+    );
     const domainReceipt = await paladin.getDomainReceipt(
       receipt.domain,
       receipt.id
@@ -82,10 +83,14 @@ async function main(): Promise<boolean> {
     if (domainReceipt !== undefined && "receipt" in domainReceipt) {
       // Skip if this receipt is not for our contract
       if (domainReceipt.receipt.to !== contractAddress) {
-        logger.log(`Skipping receipt ${receipt.id} - not for our contract (to: ${domainReceipt.receipt.to})`);
+        logger.log(
+          `Skipping receipt ${receipt.id} - not for our contract (to: ${domainReceipt.receipt.to})`
+        );
         return;
       }
-      logger.log(`Processing contract receipt ${receipt.id} (to: ${domainReceipt.receipt.to})`);
+      logger.log(
+        `Processing contract receipt ${receipt.id} (to: ${domainReceipt.receipt.to})`
+      );
       for (const log of domainReceipt.receipt.logs ?? []) {
         const decoded = await paladin.decodeEvent(log.topics, log.data);
         const message = decoded?.data?.message;
@@ -106,7 +111,9 @@ async function main(): Promise<boolean> {
         event.method === "ptx_subscription" &&
         "receipts" in event.params.result
       ) {
-        logger.log(`Received receipt batch with ${event.params.result.receipts.length} receipts`);
+        logger.log(
+          `Received receipt batch with ${event.params.result.receipts.length} receipts`
+        );
         for (const receipt of event.params.result.receipts) {
           // Process each transaction receipt
           await processReceipt(receipt);
@@ -126,22 +133,22 @@ async function main(): Promise<boolean> {
 
   // Call the sayHello function
   logger.log(`Saying hello to '${name}'...`);
-  const txResult = await memberPrivacyGroup.sendTransaction({
+  const txId = await memberPrivacyGroup.sendTransaction({
     methodAbi: sayHelloMethod,
     from: verifierNode1.lookup,
     to: contractAddress,
     data: { name },
-  });
-  if (txResult) {
-    logger.log(`Transaction sent with ID: ${txResult.id}`);
-  }
+  }).id;
+  logger.log(`Transaction sent with ID: ${txId}`);
 
   // Wait to receive the receipt
   const attempts = 10;
-  const delay = 100;
+  const delay = 500;
   for (let i = 0; i < attempts; i++) {
     if (received) {
-      logger.log(`Successfully received welcome message after ${i + 1} attempts`);
+      logger.log(
+        `Successfully received welcome message after ${i + 1} attempts`
+      );
       break;
     }
     await new Promise((resolve) => setTimeout(resolve, delay));

--- a/example/notarized-tokens/src/index.ts
+++ b/example/notarized-tokens/src/index.ts
@@ -18,10 +18,12 @@ async function main(): Promise<boolean> {
   // Step 1: Deploy a Noto token to represent cash
   logger.log("Step 1: Deploying a Noto cash token...");
   const notoFactory = new NotoFactory(paladinClientNode1, "noto");
-  const cashToken = await notoFactory.newNoto(verifierNode1, {
-    notary: verifierNode1,
-    notaryMode: "basic"
-  });
+  const cashToken = await notoFactory
+    .newNoto(verifierNode1, {
+      notary: verifierNode1,
+      notaryMode: "basic",
+    })
+    .waitForDeploy();
   if (!cashToken) {
     logger.error("Failed to deploy the Noto cash token!");
     return false;
@@ -30,48 +32,67 @@ async function main(): Promise<boolean> {
 
   // Step 2: Mint cash tokens
   logger.log("Step 2: Minting 2000 units of cash to Node1...");
-  const mintReceipt = await cashToken.mint(verifierNode1, {
-    to: verifierNode1,
-    amount: 2000,
-    data: "0x",
-  });
+  const mintReceipt = await cashToken
+    .mint(verifierNode1, {
+      to: verifierNode1,
+      amount: 2000,
+      data: "0x",
+    })
+    .waitForReceipt();
   if (!mintReceipt) {
     logger.error("Failed to mint cash tokens!");
     return false;
   }
   logger.log("Successfully minted 2000 units of cash to Node1!");
-  let balanceNode1 = await cashToken.balanceOf(verifierNode1, { "account": verifierNode1.lookup });
-  logger.log(`Node1 State: ${balanceNode1.totalBalance} units of cash, ${balanceNode1.totalStates} states, overflow: ${balanceNode1.overflow}`);
+  let balanceNode1 = await cashToken.balanceOf(verifierNode1, {
+    account: verifierNode1.lookup,
+  });
+  logger.log(
+    `Node1 State: ${balanceNode1.totalBalance} units of cash, ${balanceNode1.totalStates} states, overflow: ${balanceNode1.overflow}`
+  );
 
   // Step 3: Transfer cash to Node2
   logger.log("Step 3: Transferring 1000 units of cash from Node1 to Node2...");
-  const transferToNode2 = await cashToken.transfer(verifierNode1, {
-    to: verifierNode2,
-    amount: 1000,
-    data: "0x",
-  });
+  const transferToNode2 = await cashToken
+    .transfer(verifierNode1, {
+      to: verifierNode2,
+      amount: 1000,
+      data: "0x",
+    })
+    .waitForReceipt();
   if (!transferToNode2) {
     logger.error("Failed to transfer cash to Node2!");
     return false;
   }
   logger.log("Successfully transferred 1000 units of cash to Node2!");
-  let balanceNode2 = await cashToken.balanceOf(verifierNode1, { "account": verifierNode2.lookup });
-  logger.log(`Node2 State: ${balanceNode2.totalBalance} units of cash, ${balanceNode2.totalStates} states, overflow: ${balanceNode2.overflow}`);
+  let balanceNode2 = await cashToken.balanceOf(verifierNode1, {
+    account: verifierNode2.lookup,
+  });
+  logger.log(
+    `Node2 State: ${balanceNode2.totalBalance} units of cash, ${balanceNode2.totalStates} states, overflow: ${balanceNode2.overflow}`
+  );
 
   // Step 4: Transfer cash to Node3 from Node2
   logger.log("Step 4: Transferring 800 units of cash from Node2 to Node3...");
-  const transferToNode3 = await cashToken.using(paladinClientNode2).transfer(verifierNode2, {
-    to: verifierNode3,
-    amount: 800,
-    data: "0x",
-  });
+  const transferToNode3 = await cashToken
+    .using(paladinClientNode2)
+    .transfer(verifierNode2, {
+      to: verifierNode3,
+      amount: 800,
+      data: "0x",
+    })
+    .waitForReceipt();
   if (!transferToNode3) {
     logger.error("Failed to transfer cash to Node3!");
     return false;
   }
   logger.log("Successfully transferred 800 units of cash to Node3!");
-  let balanceNode3 = await cashToken.balanceOf(verifierNode1, { "account": verifierNode3.lookup });
-  logger.log(`Node3 State: ${balanceNode3.totalBalance} units of cash, ${balanceNode3.totalStates} states, overflow: ${balanceNode3.overflow}`);
+  let balanceNode3 = await cashToken.balanceOf(verifierNode1, {
+    account: verifierNode3.lookup,
+  });
+  logger.log(
+    `Node3 State: ${balanceNode3.totalBalance} units of cash, ${balanceNode3.totalStates} states, overflow: ${balanceNode3.overflow}`
+  );
 
   // All steps completed successfully
   logger.log("All operations completed successfully!");

--- a/example/privacy-storage/src/helpers/storage.ts
+++ b/example/privacy-storage/src/helpers/storage.ts
@@ -13,7 +13,7 @@ export const newPrivateStorage = async (
     abi: storage.abi,
     bytecode: storage.bytecode,
     from: from.lookup,
-  });
+  }).waitForDeploy();
   return address ? new PrivateStorage(pente, address) : undefined;
 };
 

--- a/example/privacy-storage/src/index.ts
+++ b/example/privacy-storage/src/index.ts
@@ -25,8 +25,7 @@ async function main(): Promise<boolean> {
     members: [verifierNode1, verifierNode2],
     evmVersion: "shanghai",
     externalCallsEnabled: true,
-  });
-
+  }).waitForDeploy();
   if (!checkDeploy(memberPrivacyGroup)) return false;
 
   logger.log(`Privacy group created, ID: ${memberPrivacyGroup?.group.id}`);
@@ -37,8 +36,7 @@ async function main(): Promise<boolean> {
     abi: storageJson.abi,
     bytecode: storageJson.bytecode,
     from: verifierNode1.lookup,
-  });
-
+  }).waitForDeploy();
   if (!contractAddress) {
     logger.error("Failed to deploy the contract. No address returned.");
     return false;
@@ -55,14 +53,14 @@ async function main(): Promise<boolean> {
   // Store a value in the contract
   const valueToStore = 125; // Example value to store
   logger.log(`Storing a value "${valueToStore}" in the contract...`);
-  const storeTx = await privateStorageContract.sendTransaction({
+  const storeReceipt = await privateStorageContract.sendTransaction({
     from: verifierNode1.lookup,
     function: "store",
     data: { num: valueToStore },
-  });
+  }).waitForReceipt();
   logger.log(
     "Value stored successfully! Transaction hash:",
-    storeTx?.transactionHash
+    storeReceipt?.transactionHash
   );
 
   // Retrieve the value as Node1

--- a/example/privacy-storage/src/update.ts
+++ b/example/privacy-storage/src/update.ts
@@ -1,9 +1,6 @@
 import PaladinClient, {
-  PenteFactory,
-  PentePrivacyGroup,
+  PenteFactory
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
-import { checkDeploy } from "paladin-example-common";
-import storageJson from "./abis/Storage.json";
 import { PrivateStorage } from "./helpers/storage";
 
 const logger = console;
@@ -73,14 +70,16 @@ async function main(): Promise<boolean> {
   const valueToStore = parseInt(retrievedValueNode1["value"]) + valueToAdd;
 
   logger.log(`Storing the new value "${valueToStore}" in the contract...`);
-  const storeTx = await privateStorageContract.sendTransaction({
-    from: verifierNode1.lookup,
-    function: "store",
-    data: { num: valueToStore },
-  });
+  const storeReceipt = await privateStorageContract
+    .sendTransaction({
+      from: verifierNode1.lookup,
+      function: "store",
+      data: { num: valueToStore },
+    })
+    .waitForReceipt();
   logger.log(
     "Value stored successfully! Transaction hash:",
-    storeTx?.transactionHash
+    storeReceipt?.transactionHash
   );
 
   // Retrieve the value as Node1

--- a/example/swap/src/helpers/erc20tracker.ts
+++ b/example/swap/src/helpers/erc20tracker.ts
@@ -20,7 +20,7 @@ export const newERC20Tracker = async (
     bytecode: erc20Tracker.bytecode,
     from: from.lookup,
     inputs: params,
-  });
+  }).waitForDeploy();
   return address ? new BondTracker(pente, address) : undefined;
 };
 

--- a/example/zeto/src/index.ts
+++ b/example/zeto/src/index.ts
@@ -29,32 +29,44 @@ async function main(): Promise<boolean> {
   );
   logger.log("- Deploying Zeto token...");
   const zetoFactory = new ZetoFactory(paladin3, "zeto");
-  const zetoCBDC1 = await zetoFactory.newZeto(cbdcIssuer, {
-    tokenName: "Zeto_AnonNullifier",
-  });
+  const zetoCBDC1 = await zetoFactory
+    .newZeto(cbdcIssuer, {
+      tokenName: "Zeto_AnonNullifier",
+    })
+    .waitForDeploy();
   if (!checkDeploy(zetoCBDC1)) return false;
 
   // Issue some cash
   logger.log("- Issuing CBDC to bank1 and bank2 with private minting...");
-  let receipt = await zetoCBDC1.mint(cbdcIssuer, {
-    mints: [
-      {
-        to: bank1,
-        amount: 100000,
-        data: "0x",
-      },
-      {
-        to: bank2,
-        amount: 100000,
-        data: "0x",
-      },
-    ],
-  });
+  let receipt = await zetoCBDC1
+    .mint(cbdcIssuer, {
+      mints: [
+        {
+          to: bank1,
+          amount: 100000,
+          data: "0x",
+        },
+        {
+          to: bank2,
+          amount: 100000,
+          data: "0x",
+        },
+      ],
+    })
+    .waitForReceipt();
   if (!checkReceipt(receipt)) return false;
-  let bank1Balance = await zetoCBDC1.using(paladin1).balanceOf(bank1, {account: bank1.lookup});
-  logger.log(`bank1 State: ${bank1Balance.totalBalance} units of cash, ${bank1Balance.totalStates} states, overflow: ${bank1Balance.overflow}`);
-  let bank2Balance = await zetoCBDC1.using(paladin2).balanceOf(bank2, {account: bank2.lookup});
-  logger.log(`bank2 State: ${bank2Balance.totalBalance} units of cash, ${bank2Balance.totalStates} states, overflow: ${bank2Balance.overflow}`);
+  let bank1Balance = await zetoCBDC1
+    .using(paladin1)
+    .balanceOf(bank1, { account: bank1.lookup });
+  logger.log(
+    `bank1 State: ${bank1Balance.totalBalance} units of cash, ${bank1Balance.totalStates} states, overflow: ${bank1Balance.overflow}`
+  );
+  let bank2Balance = await zetoCBDC1
+    .using(paladin2)
+    .balanceOf(bank2, { account: bank2.lookup });
+  logger.log(
+    `bank2 State: ${bank2Balance.totalBalance} units of cash, ${bank2Balance.totalStates} states, overflow: ${bank2Balance.overflow}`
+  );
 
   // TODO: remove
   await new Promise((resolve) => setTimeout(resolve, 3000));
@@ -63,29 +75,42 @@ async function main(): Promise<boolean> {
   logger.log(
     "- Bank1 transferring CBDC to bank2 to pay for some asset trades ..."
   );
-  receipt = await zetoCBDC1.using(paladin1).transfer(bank1, {
-    transfers: [
-      {
-        to: bank2,
-        amount: 1000,
-        data: "0x",
-      },
-    ],
-  });
+  receipt = await zetoCBDC1
+    .using(paladin1)
+    .transfer(bank1, {
+      transfers: [
+        {
+          to: bank2,
+          amount: 1000,
+          data: "0x",
+        },
+      ],
+    })
+    .waitForReceipt();
   if (!checkReceipt(receipt)) return false;
-  bank1Balance = await zetoCBDC1.using(paladin1).balanceOf(bank1, {account: bank1.lookup});
-  logger.log(`bank1 State: ${bank1Balance.totalBalance} units of cash, ${bank1Balance.totalStates} states, overflow: ${bank1Balance.overflow}`);
-  bank2Balance = await zetoCBDC1.using(paladin2).balanceOf(bank2, {account: bank2.lookup});
-  logger.log(`bank2 State: ${bank2Balance.totalBalance} units of cash, ${bank2Balance.totalStates} states, overflow: ${bank2Balance.overflow}`);
+  bank1Balance = await zetoCBDC1
+    .using(paladin1)
+    .balanceOf(bank1, { account: bank1.lookup });
+  logger.log(
+    `bank1 State: ${bank1Balance.totalBalance} units of cash, ${bank1Balance.totalStates} states, overflow: ${bank1Balance.overflow}`
+  );
+  bank2Balance = await zetoCBDC1
+    .using(paladin2)
+    .balanceOf(bank2, { account: bank2.lookup });
+  logger.log(
+    `bank2 State: ${bank2Balance.totalBalance} units of cash, ${bank2Balance.totalStates} states, overflow: ${bank2Balance.overflow}`
+  );
   logger.log("\nUse case #1 complete!\n");
 
   logger.log(
     "Use case #2: Privacy-preserving CBDC token, using public minting of an ERC20 token..."
   );
   logger.log("- Deploying Zeto token...");
-  const zetoCBDC2 = await zetoFactory.newZeto(cbdcIssuer, {
-    tokenName: "Zeto_AnonNullifier",
-  });
+  const zetoCBDC2 = await zetoFactory
+    .newZeto(cbdcIssuer, {
+      tokenName: "Zeto_AnonNullifier",
+    })
+    .waitForDeploy();
   if (!checkDeploy(zetoCBDC2)) return false;
 
   logger.log("- Deploying ERC20 token to manage the CBDC supply publicly...");
@@ -93,9 +118,11 @@ async function main(): Promise<boolean> {
   logger.log(`  ERC20 deployed at: ${erc20Address}`);
 
   logger.log("- Setting ERC20 to the Zeto token contract ...");
-  const result2 = await zetoCBDC2.setERC20(cbdcIssuer, {
-    erc20: erc20Address as string,
-  });
+  const result2 = await zetoCBDC2
+    .setERC20(cbdcIssuer, {
+      erc20: erc20Address as string,
+    })
+    .waitForReceipt();
   if (!checkReceipt(result2)) return false;
 
   logger.log("- Issuing CBDC to bank1 with public minting in ERC20...");
@@ -106,36 +133,57 @@ async function main(): Promise<boolean> {
   await approveERC20(paladin1, bank1, zetoCBDC2.address, erc20Address!, 10000);
 
   logger.log("- Bank1 deposit ERC20 balance to Zeto ...");
-  const result4 = await zetoCBDC2.using(paladin1).deposit(bank1, {
-    amount: 10000,
-  });
+  const result4 = await zetoCBDC2
+    .using(paladin1)
+    .deposit(bank1, {
+      amount: 10000,
+    })
+    .waitForReceipt();
   if (!checkReceipt(result4)) return false;
-  bank1Balance = await zetoCBDC2.using(paladin1).balanceOf(bank1, {account: bank1.lookup});
-  logger.log(`bank1 State: ${bank1Balance.totalBalance} units of cash, ${bank1Balance.totalStates} states, overflow: ${bank1Balance.overflow}`);
+  bank1Balance = await zetoCBDC2
+    .using(paladin1)
+    .balanceOf(bank1, { account: bank1.lookup });
+  logger.log(
+    `bank1 State: ${bank1Balance.totalBalance} units of cash, ${bank1Balance.totalStates} states, overflow: ${bank1Balance.overflow}`
+  );
 
   // Transfer some cash from bank1 to bank2
   logger.log(
     "- Bank1 transferring CBDC to bank2 to pay for some asset trades ..."
   );
-  receipt = await zetoCBDC2.using(paladin1).transfer(bank1, {
-    transfers: [
-      {
-        to: bank2,
-        amount: 1000,
-        data: "0x",
-      },
-    ],
-  });
+  receipt = await zetoCBDC2
+    .using(paladin1)
+    .transfer(bank1, {
+      transfers: [
+        {
+          to: bank2,
+          amount: 1000,
+          data: "0x",
+        },
+      ],
+    })
+    .waitForReceipt();
   if (!checkReceipt(receipt)) return false;
-  bank1Balance = await zetoCBDC2.using(paladin1).balanceOf(bank1, {account: bank1.lookup});
-  logger.log(`bank1 State: ${bank1Balance.totalBalance} units of cash, ${bank1Balance.totalStates} states, overflow: ${bank1Balance.overflow}`);
-  bank2Balance = await zetoCBDC2.using(paladin2).balanceOf(bank2, {account: bank2.lookup});
-  logger.log(`bank2 State: ${bank2Balance.totalBalance} units of cash, ${bank2Balance.totalStates} states, overflow: ${bank2Balance.overflow}`);
+  bank1Balance = await zetoCBDC2
+    .using(paladin1)
+    .balanceOf(bank1, { account: bank1.lookup });
+  logger.log(
+    `bank1 State: ${bank1Balance.totalBalance} units of cash, ${bank1Balance.totalStates} states, overflow: ${bank1Balance.overflow}`
+  );
+  bank2Balance = await zetoCBDC2
+    .using(paladin2)
+    .balanceOf(bank2, { account: bank2.lookup });
+  logger.log(
+    `bank2 State: ${bank2Balance.totalBalance} units of cash, ${bank2Balance.totalStates} states, overflow: ${bank2Balance.overflow}`
+  );
 
   logger.log("- Bank1 withdraws Zeto back to ERC20 balance ...");
-  const result5 = await zetoCBDC2.using(paladin1).withdraw(bank1, {
-    amount: 1000,
-  });
+  const result5 = await zetoCBDC2
+    .using(paladin1)
+    .withdraw(bank1, {
+      amount: 1000,
+    })
+    .waitForReceipt();
   if (!checkReceipt(result5)) return false;
   logger.log("\nUse case #2 complete!");
 

--- a/sdk/typescript/src/domains/noto.ts
+++ b/sdk/typescript/src/domains/noto.ts
@@ -5,12 +5,7 @@ import * as notoPrivateJSON from "./abis/INotoPrivate.json";
 import * as notoJSON from "./abis/INoto.json";
 import { penteGroupABI } from "./pente";
 import { PaladinVerifier } from "../verifier";
-
-const DEFAULT_POLL_TIMEOUT = 10000;
-
-export interface NotoOptions {
-  pollTimeout?: number;
-}
+import { TransactionWrapper } from "../transaction";
 
 export const notoConstructorABI = (
   withHooks: boolean
@@ -138,101 +133,91 @@ export interface NotoBalanceOfResult {
   overflow: boolean;
 }
 
-export class NotoFactory {
-  private options: Required<NotoOptions>;
-
-  constructor(
-    private paladin: PaladinClient,
-    public readonly domain: string,
-    options?: NotoOptions
-  ) {
-    this.options = {
-      pollTimeout: DEFAULT_POLL_TIMEOUT,
-      ...options,
-    };
+export class NotoWrapper extends TransactionWrapper {
+  async waitForDeploy(waitMs?: number) {
+    const receipt = await this.waitForReceipt(waitMs);
+    return receipt?.contractAddress
+      ? new NotoInstance(this.paladin, receipt.contractAddress)
+      : undefined;
   }
+}
+
+export class NotoFactory {
+  constructor(private paladin: PaladinClient, public readonly domain: string) {}
 
   using(paladin: PaladinClient) {
-    return new NotoFactory(paladin, this.domain, this.options);
+    return new NotoFactory(paladin, this.domain);
   }
 
-  async newNoto(from: PaladinVerifier, data: NotoConstructorParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      domain: this.domain,
-      abi: [notoConstructorABI(!!data.options?.hooks)],
-      function: "",
-      from: from.lookup,
-      data: {
-        ...data,
-        notary: data.notary.lookup,
-        options: {
-          basic: {
-            restrictMint: true,
-            allowBurn: true,
-            allowLock: true,
-            ...data.options?.basic,
+  newNoto(from: PaladinVerifier, data: NotoConstructorParams) {
+    return new NotoWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        domain: this.domain,
+        abi: [notoConstructorABI(!!data.options?.hooks)],
+        function: "",
+        from: from.lookup,
+        data: {
+          ...data,
+          notary: data.notary.lookup,
+          options: {
+            basic: {
+              restrictMint: true,
+              allowBurn: true,
+              allowLock: true,
+              ...data.options?.basic,
+            },
+            ...data.options,
           },
-          ...data.options,
         },
-      },
-    });
-    const receipt = await this.paladin.pollForReceipt(
-      txID,
-      this.options.pollTimeout
+      })
     );
-    return receipt?.contractAddress === undefined
-      ? undefined
-      : new NotoInstance(this.paladin, receipt.contractAddress, this.options);
   }
 }
 
 export class NotoInstance {
-  private options: Required<NotoOptions>;
-
   constructor(
     private paladin: PaladinClient,
-    public readonly address: string,
-    options?: NotoOptions
-  ) {
-    this.options = {
-      pollTimeout: DEFAULT_POLL_TIMEOUT,
-      ...options,
-    };
-  }
+    public readonly address: string
+  ) {}
 
   using(paladin: PaladinClient) {
-    return new NotoInstance(paladin, this.address, this.options);
+    return new NotoInstance(paladin, this.address);
   }
 
-  async mint(from: PaladinVerifier, data: NotoMintParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: notoPrivateJSON.abi,
-      function: "mint",
-      to: this.address,
-      from: from.lookup,
-      data: {
-        ...data,
-        to: data.to.lookup,
-      },
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  mint(from: PaladinVerifier, data: NotoMintParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: notoPrivateJSON.abi,
+        function: "mint",
+        to: this.address,
+        from: from.lookup,
+        data: {
+          ...data,
+          to: data.to.lookup,
+        },
+      })
+    );
   }
 
-  async transfer(from: PaladinVerifier, data: NotoTransferParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: notoPrivateJSON.abi,
-      function: "transfer",
-      to: this.address,
-      from: from.lookup,
-      data: {
-        ...data,
-        to: data.to.lookup,
-      },
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  transfer(from: PaladinVerifier, data: NotoTransferParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: notoPrivateJSON.abi,
+        function: "transfer",
+        to: this.address,
+        from: from.lookup,
+        data: {
+          ...data,
+          to: data.to.lookup,
+        },
+      })
+    );
   }
 
   prepareTransfer(from: PaladinVerifier, data: NotoTransferParams) {
@@ -253,101 +238,115 @@ export class NotoInstance {
     from: PaladinVerifier,
     data: NotoApproveTransferParams
   ) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: notoPrivateJSON.abi,
-      function: "approveTransfer",
-      to: this.address,
-      from: from.lookup,
-      data,
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: notoPrivateJSON.abi,
+        function: "approveTransfer",
+        to: this.address,
+        from: from.lookup,
+        data,
+      })
+    );
   }
 
-  async burn(from: PaladinVerifier, data: NotoBurnParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: notoPrivateJSON.abi,
-      function: "burn",
-      to: this.address,
-      from: from.lookup,
-      data,
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  burn(from: PaladinVerifier, data: NotoBurnParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: notoPrivateJSON.abi,
+        function: "burn",
+        to: this.address,
+        from: from.lookup,
+        data,
+      })
+    );
   }
 
-  async lock(from: PaladinVerifier, data: NotoLockParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: notoPrivateJSON.abi,
-      function: "lock",
-      to: this.address,
-      from: from.lookup,
-      data,
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  lock(from: PaladinVerifier, data: NotoLockParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: notoPrivateJSON.abi,
+        function: "lock",
+        to: this.address,
+        from: from.lookup,
+        data,
+      })
+    );
   }
 
-  async unlock(from: PaladinVerifier, data: NotoUnlockParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: notoPrivateJSON.abi,
-      function: "unlock",
-      to: this.address,
-      from: from.lookup,
-      data: {
-        ...data,
-        from: data.from.lookup,
-        recipients: data.recipients.map((recipient) => ({
-          to: recipient.to.lookup,
-          amount: recipient.amount,
-        })),
-      },
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  unlock(from: PaladinVerifier, data: NotoUnlockParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: notoPrivateJSON.abi,
+        function: "unlock",
+        to: this.address,
+        from: from.lookup,
+        data: {
+          ...data,
+          from: data.from.lookup,
+          recipients: data.recipients.map((recipient) => ({
+            to: recipient.to.lookup,
+            amount: recipient.amount,
+          })),
+        },
+      })
+    );
   }
 
-  async unlockAsDelegate(from: PaladinVerifier, data: NotoUnlockPublicParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PUBLIC,
-      abi: notoJSON.abi,
-      function: "unlock",
-      to: this.address,
-      from: from.lookup,
-      data,
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  unlockAsDelegate(from: PaladinVerifier, data: NotoUnlockPublicParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PUBLIC,
+        abi: notoJSON.abi,
+        function: "unlock",
+        to: this.address,
+        from: from.lookup,
+        data,
+      })
+    );
   }
 
-  async prepareUnlock(from: PaladinVerifier, data: NotoUnlockParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: notoPrivateJSON.abi,
-      function: "prepareUnlock",
-      to: this.address,
-      from: from.lookup,
-      data: {
-        ...data,
-        from: data.from.lookup,
-        recipients: data.recipients.map((recipient) => ({
-          to: recipient.to.lookup,
-          amount: recipient.amount,
-        })),
-      },
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  prepareUnlock(from: PaladinVerifier, data: NotoUnlockParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: notoPrivateJSON.abi,
+        function: "prepareUnlock",
+        to: this.address,
+        from: from.lookup,
+        data: {
+          ...data,
+          from: data.from.lookup,
+          recipients: data.recipients.map((recipient) => ({
+            to: recipient.to.lookup,
+            amount: recipient.amount,
+          })),
+        },
+      })
+    );
   }
 
-  async delegateLock(from: PaladinVerifier, data: NotoDelegateLockParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: notoPrivateJSON.abi,
-      function: "delegateLock",
-      to: this.address,
-      from: from.lookup,
-      data,
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  delegateLock(from: PaladinVerifier, data: NotoDelegateLockParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: notoPrivateJSON.abi,
+        function: "delegateLock",
+        to: this.address,
+        from: from.lookup,
+        data,
+      })
+    );
   }
 
   encodeUnlock(data: NotoUnlockPublicParams) {
@@ -360,8 +359,11 @@ export class NotoInstance {
     ]);
   }
 
-  async balanceOf(from: PaladinVerifier, data: NotoBalanceOfParams): Promise<NotoBalanceOfResult> {
-    return await this.paladin.call({
+  balanceOf(
+    from: PaladinVerifier,
+    data: NotoBalanceOfParams
+  ): Promise<NotoBalanceOfResult> {
+    return this.paladin.call({
       type: TransactionType.PRIVATE,
       domain: "noto",
       abi: notoPrivateJSON.abi,

--- a/sdk/typescript/src/domains/noto.ts
+++ b/sdk/typescript/src/domains/noto.ts
@@ -5,7 +5,7 @@ import * as notoPrivateJSON from "./abis/INotoPrivate.json";
 import * as notoJSON from "./abis/INoto.json";
 import { penteGroupABI } from "./pente";
 import { PaladinVerifier } from "../verifier";
-import { TransactionWrapper } from "../transaction";
+import { TransactionFuture } from "../transaction";
 
 export const notoConstructorABI = (
   withHooks: boolean
@@ -133,7 +133,8 @@ export interface NotoBalanceOfResult {
   overflow: boolean;
 }
 
-export class NotoWrapper extends TransactionWrapper {
+// Represents an in-flight Noto deployment
+export class NotoFuture extends TransactionFuture {
   async waitForDeploy(waitMs?: number) {
     const receipt = await this.waitForReceipt(waitMs);
     return receipt?.contractAddress
@@ -150,7 +151,7 @@ export class NotoFactory {
   }
 
   newNoto(from: PaladinVerifier, data: NotoConstructorParams) {
-    return new NotoWrapper(
+    return new NotoFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -187,7 +188,7 @@ export class NotoInstance {
   }
 
   mint(from: PaladinVerifier, data: NotoMintParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -204,7 +205,7 @@ export class NotoInstance {
   }
 
   transfer(from: PaladinVerifier, data: NotoTransferParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -238,7 +239,7 @@ export class NotoInstance {
     from: PaladinVerifier,
     data: NotoApproveTransferParams
   ) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -252,7 +253,7 @@ export class NotoInstance {
   }
 
   burn(from: PaladinVerifier, data: NotoBurnParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -266,7 +267,7 @@ export class NotoInstance {
   }
 
   lock(from: PaladinVerifier, data: NotoLockParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -280,7 +281,7 @@ export class NotoInstance {
   }
 
   unlock(from: PaladinVerifier, data: NotoUnlockParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -301,7 +302,7 @@ export class NotoInstance {
   }
 
   unlockAsDelegate(from: PaladinVerifier, data: NotoUnlockPublicParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PUBLIC,
@@ -315,7 +316,7 @@ export class NotoInstance {
   }
 
   prepareUnlock(from: PaladinVerifier, data: NotoUnlockParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -336,7 +337,7 @@ export class NotoInstance {
   }
 
   delegateLock(from: PaladinVerifier, data: NotoDelegateLockParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,

--- a/sdk/typescript/src/domains/pente.ts
+++ b/sdk/typescript/src/domains/pente.ts
@@ -14,8 +14,7 @@ import {
 import PaladinClient from "../paladin";
 import { PaladinVerifier } from "../verifier";
 import * as penteJSON from "./abis/PentePrivacyGroup.json";
-
-const DEFAULT_POLL_TIMEOUT = 10000;
+import { TransactionWrapper } from "../transaction";
 
 export interface PenteGroupTransactionInput {
   from: string;
@@ -39,10 +38,6 @@ export interface PenteDeploy {
   bytecode: string;
   from: string;
   inputs?: any;
-}
-
-export interface PenteOptions {
-  pollTimeout?: number;
 }
 
 export const penteGroupABI = {
@@ -89,49 +84,60 @@ export const resolveGroup = (
   return { members, salt: group.salt };
 };
 
-export class PenteFactory {
-  private options: Required<PenteOptions>;
+export class PentePrivacyGroupWrapper {
+  public tx: Promise<TransactionWrapper | undefined>;
 
   constructor(
     private paladin: PaladinClient,
-    public readonly domain: string,
-    options?: PenteOptions
+    private group: IPrivacyGroup | Promise<IPrivacyGroup>
   ) {
-    this.options = {
-      pollTimeout: DEFAULT_POLL_TIMEOUT,
-      ...options,
-    };
+    this.tx = Promise.resolve(group).then((group) =>
+      group.genesisTransaction
+        ? new TransactionWrapper(paladin, group.genesisTransaction)
+        : undefined
+    );
   }
+
+  async waitForReceipt(waitMs?: number, full = false) {
+    const tx = await this.tx;
+    return tx?.waitForReceipt(waitMs, full);
+  }
+
+  async waitForDeploy(waitMs?: number) {
+    const group = await this.group;
+    const receipt = await this.waitForReceipt(waitMs);
+    group.contractAddress = receipt?.contractAddress;
+    return group.contractAddress
+      ? new PentePrivacyGroup(this.paladin, group)
+      : undefined;
+  }
+}
+
+export class PenteFactory {
+  constructor(private paladin: PaladinClient, public readonly domain: string) {}
 
   using(paladin: PaladinClient) {
-    return new PenteFactory(paladin, this.domain, this.options);
+    return new PenteFactory(paladin, this.domain);
   }
 
-  async newPrivacyGroup(input: PentePrivacyGroupParams) {
-    const group = await this.paladin.createPrivacyGroup({
-      domain: this.domain,
-      members: input.members.map((m) => m.toString()),
-      configuration: {
-        evmVersion: input.evmVersion,
-        endorsementType: input.endorsementType,
-        externalCallsEnabled:
-          input.externalCallsEnabled === true
-            ? "true"
-            : input.externalCallsEnabled === false
-            ? "false"
-            : undefined,
-      },
-    });
-    const receipt = group.genesisTransaction
-      ? await this.paladin.pollForReceipt(
-          group.genesisTransaction,
-          this.options.pollTimeout
-        )
-      : undefined;
-    group.contractAddress = receipt ? receipt.contractAddress : undefined;
-    return group.contractAddress === undefined
-      ? undefined
-      : new PentePrivacyGroup(this.paladin, group, this.options);
+  newPrivacyGroup(input: PentePrivacyGroupParams) {
+    return new PentePrivacyGroupWrapper(
+      this.paladin,
+      this.paladin.createPrivacyGroup({
+        domain: this.domain,
+        members: input.members.map((m) => m.toString()),
+        configuration: {
+          evmVersion: input.evmVersion,
+          endorsementType: input.endorsementType,
+          externalCallsEnabled:
+            input.externalCallsEnabled === true
+              ? "true"
+              : input.externalCallsEnabled === false
+              ? "false"
+              : undefined,
+        },
+      })
+    );
   }
 
   async resumePrivacyGroup(input: IPrivacyGroupResume) {
@@ -141,20 +147,18 @@ export class PenteFactory {
     );
     return existingGroup.contractAddress === undefined
       ? undefined
-      : new PentePrivacyGroup(this.paladin, existingGroup, this.options);
+      : new PentePrivacyGroup(this.paladin, existingGroup);
   }
 }
 
 export class PentePrivacyGroup {
-  private options: Required<PenteOptions>;
   public readonly address: string;
   public readonly salt: string;
   public readonly members: string[];
 
   constructor(
     private paladin: PaladinClient,
-    public readonly group: IPrivacyGroup,
-    options?: PenteOptions
+    public readonly group: IPrivacyGroup
   ) {
     if (group.contractAddress === undefined) {
       throw new Error(
@@ -164,20 +168,13 @@ export class PentePrivacyGroup {
     this.address = group.contractAddress;
     this.salt = group.id; // when bypassing privacy group helper functionality, and directly building Pente private transactions
     this.members = group.members;
-    this.options = {
-      pollTimeout: DEFAULT_POLL_TIMEOUT,
-      ...options,
-    };
   }
 
   using(paladin: PaladinClient) {
-    return new PentePrivacyGroup(paladin, this.group, this.options);
+    return new PentePrivacyGroup(paladin, this.group);
   }
 
-  async deploy(
-    params: PenteDeploy,
-    txOptions?: Partial<IPrivacyGroupEVMTXInput>
-  ) {
+  deploy(params: PenteDeploy, txOptions?: Partial<IPrivacyGroupEVMTXInput>) {
     // Find the constructor in the ABI
     const constructor: ethers.JsonFragment = params.abi.find(
       (entry) => entry.type === "constructor"
@@ -193,33 +190,29 @@ export class PentePrivacyGroup {
       function: constructor,
     };
 
-    const txID = await this.paladin.sendPrivacyGroupTransaction(transaction);
-    const receipt = await this.paladin.pollForReceipt(
-      txID,
-      this.options.pollTimeout,
-      true
+    return new PentePrivateDeployWrapper(
+      this.paladin,
+      this.paladin.sendPrivacyGroupTransaction(transaction)
     );
-    return receipt?.domainReceipt !== undefined &&
-      "receipt" in receipt.domainReceipt
-      ? receipt.domainReceipt.receipt.contractAddress
-      : undefined;
   }
 
   // sendTransaction functions in the contract (write)
-  async sendTransaction(
+  sendTransaction(
     transaction: PenteGroupTransactionInput,
     txOptions?: Partial<IPrivacyGroupEVMTXInput>
   ) {
-    const txID = await this.paladin.sendPrivacyGroupTransaction({
-      ...txOptions,
-      domain: this.group.domain,
-      group: this.group.id,
-      from: transaction.from,
-      to: transaction.to,
-      input: transaction.data,
-      function: transaction.methodAbi,
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendPrivacyGroupTransaction({
+        ...txOptions,
+        domain: this.group.domain,
+        group: this.group.id,
+        from: transaction.from,
+        to: transaction.to,
+        input: transaction.data,
+        function: transaction.methodAbi,
+      })
+    );
   }
 
   // call functions in the contract (read-only)
@@ -242,7 +235,7 @@ export class PentePrivacyGroup {
     from: PaladinVerifier,
     data: PenteApproveTransitionParams
   ) {
-    const txID = await this.paladin.sendTransaction({
+    return this.paladin.sendTransaction({
       type: TransactionType.PUBLIC,
       abi: penteJSON.abi,
       function: "approveTransition",
@@ -250,7 +243,16 @@ export class PentePrivacyGroup {
       from: from.lookup,
       data,
     });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  }
+}
+
+export class PentePrivateDeployWrapper extends TransactionWrapper {
+  async waitForDeploy(waitMs?: number) {
+    const receipt = await this.waitForReceipt(waitMs, true);
+    return receipt?.domainReceipt !== undefined &&
+      "receipt" in receipt.domainReceipt
+      ? receipt.domainReceipt.receipt.contractAddress
+      : undefined;
   }
 }
 
@@ -265,7 +267,7 @@ export abstract class PentePrivateContract<ConstructorParams> {
     paladin: PaladinClient
   ): PentePrivateContract<ConstructorParams>;
 
-  async sendTransaction(
+  sendTransaction(
     transaction: PenteContractTransactionInput,
     txOptions?: Partial<IPrivacyGroupEVMTXInput>
   ) {
@@ -286,7 +288,7 @@ export abstract class PentePrivateContract<ConstructorParams> {
     );
   }
 
-  async call(
+  call(
     transaction: PenteContractTransactionInput,
     txOptions?: Partial<IPrivacyGroupEVMCall>
   ) {

--- a/sdk/typescript/src/domains/pente.ts
+++ b/sdk/typescript/src/domains/pente.ts
@@ -145,9 +145,9 @@ export class PenteFactory {
       this.domain,
       input.id
     );
-    return existingGroup.contractAddress === undefined
-      ? undefined
-      : new PentePrivacyGroup(this.paladin, existingGroup);
+    return existingGroup?.contractAddress
+      ? new PentePrivacyGroup(this.paladin, existingGroup)
+      : undefined;
   }
 }
 

--- a/sdk/typescript/src/domains/zeto.ts
+++ b/sdk/typescript/src/domains/zeto.ts
@@ -1,20 +1,15 @@
 import { TransactionType } from "../interfaces";
 import PaladinClient from "../paladin";
+import { TransactionWrapper } from "../transaction";
 import { PaladinVerifier } from "../verifier";
 import * as zetoPrivateJSON from "./abis/IZetoFungible.json";
 import * as zetoPublicJSON from "./abis/Zeto_Anon.json";
-
-const POLL_TIMEOUT_MS = 10000;
 
 // Algorithm/verifier types specific to Zeto
 export const algorithmZetoSnarkBJJ = (domainName: string) =>
   `domain:${domainName}:snark:babyjubjub`;
 export const IDEN3_PUBKEY_BABYJUBJUB_COMPRESSED_0X =
   "iden3_pubkey_babyjubjub_compressed_0x";
-
-export interface ZetoOptions {
-  pollTimeout?: number;
-}
 
 const zetoAbi = zetoPrivateJSON.abi;
 const zetoPublicAbi = zetoPublicJSON.abi;
@@ -80,189 +75,199 @@ export interface ZetoBalanceOfResult {
   overflow: boolean;
 }
 
-export class ZetoFactory {
-  private options: Required<ZetoOptions>;
-
-  constructor(
-    private paladin: PaladinClient,
-    public readonly domain: string,
-    options?: ZetoOptions
-  ) {
-    this.options = {
-      pollTimeout: POLL_TIMEOUT_MS,
-      ...options,
-    };
+export class ZetoWrapper extends TransactionWrapper {
+  async waitForDeploy(waitMs?: number) {
+    const receipt = await this.waitForReceipt(waitMs);
+    return receipt?.contractAddress
+      ? new ZetoInstance(this.paladin, receipt.contractAddress)
+      : undefined;
   }
+}
+
+export class ZetoFactory {
+  constructor(private paladin: PaladinClient, public readonly domain: string) {}
 
   using(paladin: PaladinClient) {
-    return new ZetoFactory(paladin, this.domain, this.options);
+    return new ZetoFactory(paladin, this.domain);
   }
 
-  async newZeto(from: PaladinVerifier, data: ZetoConstructorParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      domain: this.domain,
-      abi: [zetoConstructorABI],
-      function: "",
-      from: from.lookup,
-      data,
-    });
-    const receipt = await this.paladin.pollForReceipt(
-      txID,
-      this.options.pollTimeout
+  newZeto(from: PaladinVerifier, data: ZetoConstructorParams) {
+    return new ZetoWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        domain: this.domain,
+        abi: [zetoConstructorABI],
+        function: "",
+        from: from.lookup,
+        data,
+      })
     );
-    return receipt?.contractAddress === undefined
-      ? undefined
-      : new ZetoInstance(this.paladin, receipt.contractAddress, this.options);
   }
 }
 
 export class ZetoInstance {
-  private options: Required<ZetoOptions>;
   private erc20?: string;
 
   constructor(
     private paladin: PaladinClient,
-    public readonly address: string,
-    options?: ZetoOptions
-  ) {
-    this.options = {
-      pollTimeout: POLL_TIMEOUT_MS,
-      ...options,
-    };
-  }
+    public readonly address: string
+  ) {}
 
   using(paladin: PaladinClient) {
-    const zeto = new ZetoInstance(paladin, this.address, this.options);
+    const zeto = new ZetoInstance(paladin, this.address);
     zeto.erc20 = this.erc20;
     return zeto;
   }
 
-  async mint(from: PaladinVerifier, data: ZetoMintParams) {
+  mint(from: PaladinVerifier, data: ZetoMintParams) {
     const params = {
       mints: data.mints.map((t) => ({ ...t, to: t.to.lookup })),
     };
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: zetoAbi,
-      function: "mint",
-      to: this.address,
-      from: from.lookup,
-      data: params,
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: zetoAbi,
+        function: "mint",
+        to: this.address,
+        from: from.lookup,
+        data: params,
+      })
+    );
   }
 
-  async transfer(from: PaladinVerifier, data: ZetoTransferParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: zetoAbi,
-      function: "transfer",
-      to: this.address,
-      from: from.lookup,
-      data: {
-        transfers: data.transfers.map((t) => ({ ...t, to: t.to.lookup })),
-      },
-    });
-    return this.paladin.pollForReceipt(txID, this.options.pollTimeout);
+  transfer(from: PaladinVerifier, data: ZetoTransferParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: zetoAbi,
+        function: "transfer",
+        to: this.address,
+        from: from.lookup,
+        data: {
+          transfers: data.transfers.map((t) => ({ ...t, to: t.to.lookup })),
+        },
+      })
+    );
   }
 
   transferLocked(from: PaladinVerifier, data: ZetoTransferLockedParams) {
-    return this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: zetoAbi,
-      function: "transferLocked",
-      to: this.address,
-      from: from.lookup,
-      data: {
-        lockedInputs: data.lockedInputs,
-        delegate: data.delegate,
-        transfers: data.transfers.map((t) => ({ ...t, to: t.to.lookup })),
-      },
-    });
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: zetoAbi,
+        function: "transferLocked",
+        to: this.address,
+        from: from.lookup,
+        data: {
+          lockedInputs: data.lockedInputs,
+          delegate: data.delegate,
+          transfers: data.transfers.map((t) => ({ ...t, to: t.to.lookup })),
+        },
+      })
+    );
   }
 
   prepareTransferLocked(from: PaladinVerifier, data: ZetoTransferLockedParams) {
-    return this.paladin.prepareTransaction({
-      type: TransactionType.PRIVATE,
-      abi: zetoAbi,
-      function: "transferLocked",
-      to: this.address,
-      from: from.lookup,
-      data: {
-        lockedInputs: data.lockedInputs,
-        delegate: data.delegate,
-        transfers: data.transfers.map((t) => ({ ...t, to: t.to.lookup })),
-      },
-    });
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.prepareTransaction({
+        type: TransactionType.PRIVATE,
+        abi: zetoAbi,
+        function: "transferLocked",
+        to: this.address,
+        from: from.lookup,
+        data: {
+          lockedInputs: data.lockedInputs,
+          delegate: data.delegate,
+          transfers: data.transfers.map((t) => ({ ...t, to: t.to.lookup })),
+        },
+      })
+    );
   }
 
-  async lock(from: PaladinVerifier, data: ZetoLockParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: zetoAbi,
-      function: "lock",
-      to: this.address,
-      from: from.lookup,
-      data,
-    });
-    return this.paladin.pollForReceipt(txID, POLL_TIMEOUT_MS);
+  lock(from: PaladinVerifier, data: ZetoLockParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: zetoAbi,
+        function: "lock",
+        to: this.address,
+        from: from.lookup,
+        data,
+      })
+    );
   }
 
-  async delegateLock(from: PaladinVerifier, data: ZetoDelegateLockParams) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.Public,
-      abi: zetoPublicAbi,
-      function: "delegateLock",
-      to: this.address,
-      from: from.lookup,
-      data: {
-        data: "0x",
-        utxos: data.utxos,
-        delegate: data.delegate,
-      },
-    });
-    return this.paladin.pollForReceipt(txID, POLL_TIMEOUT_MS);
+  delegateLock(from: PaladinVerifier, data: ZetoDelegateLockParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.Public,
+        abi: zetoPublicAbi,
+        function: "delegateLock",
+        to: this.address,
+        from: from.lookup,
+        data: {
+          data: "0x",
+          utxos: data.utxos,
+          delegate: data.delegate,
+        },
+      })
+    );
   }
 
-  async setERC20(from: PaladinVerifier, data: ZetoSetERC20Params) {
-    const txID = await this.paladin.sendTransaction({
-      type: TransactionType.PUBLIC,
-      abi: zetoAbi,
-      function: "setERC20",
-      to: this.address,
-      from: from.lookup,
-      data,
-    });
+  setERC20(from: PaladinVerifier, data: ZetoSetERC20Params) {
     this.erc20 = data.erc20;
-    return this.paladin.pollForReceipt(txID, POLL_TIMEOUT_MS);
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PUBLIC,
+        abi: zetoAbi,
+        function: "setERC20",
+        to: this.address,
+        from: from.lookup,
+        data,
+      })
+    );
   }
 
-  async deposit(from: PaladinVerifier, data: ZetoDepositParams) {
-    const receipt = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: zetoAbi,
-      function: "deposit",
-      to: this.address,
-      from: from.lookup,
-      data,
-    });
-    return this.paladin.pollForReceipt(receipt, POLL_TIMEOUT_MS);
+  deposit(from: PaladinVerifier, data: ZetoDepositParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: zetoAbi,
+        function: "deposit",
+        to: this.address,
+        from: from.lookup,
+        data,
+      })
+    );
   }
 
-  async withdraw(from: PaladinVerifier, data: ZetoWithdrawParams) {
-    const receipt = await this.paladin.sendTransaction({
-      type: TransactionType.PRIVATE,
-      abi: zetoAbi,
-      function: "withdraw",
-      to: this.address,
-      from: from.lookup,
-      data,
-    });
-    return this.paladin.pollForReceipt(receipt, POLL_TIMEOUT_MS);
+  withdraw(from: PaladinVerifier, data: ZetoWithdrawParams) {
+    return new TransactionWrapper(
+      this.paladin,
+      this.paladin.sendTransaction({
+        type: TransactionType.PRIVATE,
+        abi: zetoAbi,
+        function: "withdraw",
+        to: this.address,
+        from: from.lookup,
+        data,
+      })
+    );
   }
 
-  async balanceOf(from: PaladinVerifier, data: ZetoBalanceOfParams): Promise<ZetoBalanceOfResult> {
+  async balanceOf(
+    from: PaladinVerifier,
+    data: ZetoBalanceOfParams
+  ): Promise<ZetoBalanceOfResult> {
     return await this.paladin.call({
       type: TransactionType.PRIVATE,
       domain: "zeto",

--- a/sdk/typescript/src/domains/zeto.ts
+++ b/sdk/typescript/src/domains/zeto.ts
@@ -1,6 +1,6 @@
 import { TransactionType } from "../interfaces";
 import PaladinClient from "../paladin";
-import { TransactionWrapper } from "../transaction";
+import { TransactionFuture } from "../transaction";
 import { PaladinVerifier } from "../verifier";
 import * as zetoPrivateJSON from "./abis/IZetoFungible.json";
 import * as zetoPublicJSON from "./abis/Zeto_Anon.json";
@@ -75,7 +75,8 @@ export interface ZetoBalanceOfResult {
   overflow: boolean;
 }
 
-export class ZetoWrapper extends TransactionWrapper {
+// Represents an in-flight Zeto deployment
+export class ZetoFuture extends TransactionFuture {
   async waitForDeploy(waitMs?: number) {
     const receipt = await this.waitForReceipt(waitMs);
     return receipt?.contractAddress
@@ -92,7 +93,7 @@ export class ZetoFactory {
   }
 
   newZeto(from: PaladinVerifier, data: ZetoConstructorParams) {
-    return new ZetoWrapper(
+    return new ZetoFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -124,7 +125,7 @@ export class ZetoInstance {
     const params = {
       mints: data.mints.map((t) => ({ ...t, to: t.to.lookup })),
     };
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -138,7 +139,7 @@ export class ZetoInstance {
   }
 
   transfer(from: PaladinVerifier, data: ZetoTransferParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -154,7 +155,7 @@ export class ZetoInstance {
   }
 
   transferLocked(from: PaladinVerifier, data: ZetoTransferLockedParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -172,7 +173,7 @@ export class ZetoInstance {
   }
 
   prepareTransferLocked(from: PaladinVerifier, data: ZetoTransferLockedParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.prepareTransaction({
         type: TransactionType.PRIVATE,
@@ -190,7 +191,7 @@ export class ZetoInstance {
   }
 
   lock(from: PaladinVerifier, data: ZetoLockParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -204,7 +205,7 @@ export class ZetoInstance {
   }
 
   delegateLock(from: PaladinVerifier, data: ZetoDelegateLockParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.Public,
@@ -223,7 +224,7 @@ export class ZetoInstance {
 
   setERC20(from: PaladinVerifier, data: ZetoSetERC20Params) {
     this.erc20 = data.erc20;
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PUBLIC,
@@ -237,7 +238,7 @@ export class ZetoInstance {
   }
 
   deposit(from: PaladinVerifier, data: ZetoDepositParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,
@@ -251,7 +252,7 @@ export class ZetoInstance {
   }
 
   withdraw(from: PaladinVerifier, data: ZetoWithdrawParams) {
-    return new TransactionWrapper(
+    return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
         type: TransactionType.PRIVATE,

--- a/sdk/typescript/src/transaction.ts
+++ b/sdk/typescript/src/transaction.ts
@@ -1,6 +1,7 @@
 import PaladinClient from "./paladin";
 
-export class TransactionWrapper {
+// Represents an in-flight transaction
+export class TransactionFuture {
   constructor(
     protected paladin: PaladinClient,
     public readonly id: string | Promise<string>

--- a/sdk/typescript/src/transaction.ts
+++ b/sdk/typescript/src/transaction.ts
@@ -1,0 +1,16 @@
+import PaladinClient from "./paladin";
+
+export class TransactionWrapper {
+  constructor(
+    protected paladin: PaladinClient,
+    public readonly id: string | Promise<string>
+  ) {}
+
+  toString() {
+    return this.id;
+  }
+
+  async waitForReceipt(waitMs = 5000, full = false) {
+    return this.paladin.pollForReceipt(await this.id, waitMs, full);
+  }
+}


### PR DESCRIPTION
In general, the TypeScript SDK should never block on receiving a transaction receipt. The caller should receive the submitted transaction ID, and can look up the status asynchronously.

To support ease of use for development, returned transaction IDs have been wrapped in "future" objects that support blocking calls "waitForReceipt" and "waitForDeploy" as appropriate.

This is a breaking SDK change, but I believe the current approach is fundamentally wrong (and the migration is relatively easy using the new helpers).