### PR TITLE
sdk: ensure txId is properly encoded in Noto unlock

### DIFF
--- a/domains/noto/internal/noto/receipts.go
+++ b/domains/noto/internal/noto/receipts.go
@@ -80,7 +80,7 @@ func (n *Noto) BuildReceipt(ctx context.Context, req *prototk.BuildReceiptReques
 		// For prepareUnlock transactions, include the encoded "unlock" call that can be used to unlock the coins
 		unlock := interfaceBuild.ABI.Functions()["unlock"]
 		receipt.LockInfo.UnlockParams = &types.UnlockPublicParams{
-			TxId:          pldtypes.Bytes32UUIDFirst16(uuid.New()).HexString(),
+			TxId:          pldtypes.Bytes32UUIDFirst16(uuid.New()).String(),
 			LockedInputs:  endorsableStateIDs(n.filterSchema(req.ReadStates, []string{n.lockedCoinSchema.Id})),
 			LockedOutputs: endorsableStateIDs(n.filterSchema(req.InfoStates, []string{n.lockedCoinSchema.Id})),
 			Outputs:       endorsableStateIDs(n.filterSchema(req.InfoStates, []string{n.coinSchema.Id})),

--- a/sdk/typescript/src/domains/noto.ts
+++ b/sdk/typescript/src/domains/noto.ts
@@ -123,6 +123,7 @@ export interface NotoDelegateLockParams {
 }
 
 export interface NotoUnlockPublicParams {
+  txId: string;
   lockedInputs: string[];
   lockedOutputs: string[];
   outputs: string[];
@@ -242,10 +243,7 @@ export class NotoInstance {
     });
   }
 
-  approveTransfer(
-    from: PaladinVerifier,
-    data: NotoApproveTransferParams
-  ) {
+  approveTransfer(from: PaladinVerifier, data: NotoApproveTransferParams) {
     return new TransactionFuture(
       this.paladin,
       this.paladin.sendTransaction({
@@ -359,6 +357,7 @@ export class NotoInstance {
 
   encodeUnlock(data: NotoUnlockPublicParams) {
     return new ethers.Interface(notoJSON.abi).encodeFunctionData("unlock", [
+      data.txId,
       data.lockedInputs,
       data.lockedOutputs,
       data.outputs,


### PR DESCRIPTION
Fixes a slight misalignment in the SDK after https://github.com/LF-Decentralized-Trust-labs/paladin/pull/685.