### PR TITLE
pente: treat IllegalArgumentException as a revert condition

### DIFF
--- a/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteDomain.java
+++ b/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteDomain.java
@@ -44,6 +44,8 @@
  import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
  public class PenteDomain extends DomainInstance {
      private static final Logger LOGGER = PaladinLogging.getLogger(PenteDomain.class);
 
@@ -212,7 +214,7 @@ import java.util.concurrent.ExecutionException;
          }
      }
 
-     private List<PenteConfiguration.TransactionExternalCall> parseExternalCalls(List<EVMRunner.JsonEVMLog> logs) throws Exception {
+     private List<PenteConfiguration.TransactionExternalCall> parseExternalCalls(List<EVMRunner.JsonEVMLog> logs) throws JsonProcessingException, InterruptedException, ExecutionException {
          var externalCalls = new ArrayList<PenteConfiguration.TransactionExternalCall>();
          for (var log : logs) {
              if (log.topics().getFirst().equals(config.getExternalCallTopic())) {
@@ -231,7 +233,7 @@ import java.util.concurrent.ExecutionException;
          return externalCalls;
      }
 
-     private String buildDomainData(PenteEVMTransaction.EVMExecutionResult execResult) throws Exception {
+     private String buildDomainData(PenteEVMTransaction.EVMExecutionResult execResult) throws JsonProcessingException, InterruptedException, ExecutionException {
          return new ObjectMapper().writeValueAsString(
                  new PenteConfiguration.DomainData(
                          new Address(execResult.contractAddress().toArray()),
@@ -289,6 +291,12 @@ import java.util.concurrent.ExecutionException;
                      setAssemblyResult(AssembleTransactionResponse.Result.REVERT).
                      setRevertReason(e.getMessage()).
                      build());
+         } catch (IllegalArgumentException e) {
+             LOGGER.error(new FormattedMessage("Illegal argument during assemble for TX {}", request.getTransaction().getTransactionId()), e);
+             return CompletableFuture.completedFuture(AssembleTransactionResponse.newBuilder().
+                     setAssemblyResult(AssembleTransactionResponse.Result.REVERT).
+                     setRevertReason(e.getMessage()).
+                     build());
          } catch (ExecutionException e) {
              if (e.getCause() instanceof ErrorResponseException && isPermanentFailure((ErrorResponseException) e.getCause())) {
                 // Any error response from a plugin during assembly is considered a revert.
@@ -300,8 +308,9 @@ import java.util.concurrent.ExecutionException;
                         build());
              }
              return CompletableFuture.failedFuture(e);
-         } catch (Exception e) {
-             return CompletableFuture.failedFuture(e);
+         } catch (IOException | InterruptedException | ClassNotFoundException e) {
+            // These exceptions will not revert, but will retry assembly
+            return CompletableFuture.failedFuture(e);
          }
      }
 
@@ -511,7 +520,7 @@ import java.util.concurrent.ExecutionException;
                                      .build());
 
                  } else {
-                     throw new Exception("Unknown signature: " + event.getSoliditySignature());
+                     throw new IllegalArgumentException("Unknown signature: " + event.getSoliditySignature());
                  }
              }
              return CompletableFuture.completedFuture(result.build());
@@ -615,7 +624,6 @@ import java.util.concurrent.ExecutionException;
      @Override
      protected CompletableFuture<ConfigurePrivacyGroupResponse> configurePrivacyGroup(ConfigurePrivacyGroupRequest request) {
          try {
-
              var resBuilder = ConfigurePrivacyGroupResponse.newBuilder();
 
              var inputConf = request.getInputConfigurationMap();
@@ -632,7 +640,6 @@ import java.util.concurrent.ExecutionException;
                  }
              }
              return CompletableFuture.completedFuture(resBuilder.build());
-
          } catch (Exception e) {
              return CompletableFuture.failedFuture(e);
          }


### PR DESCRIPTION
Also be very specific about the remaining exceptions that can cause retry (should only be those expected to be transient).

Avoid throwing Exception (always throw a more specific exception).