### PR TITLE
Implement Automatic SDK Revert to Prevent Git Changes in Examples

### DIFF
--- a/examples/bond/build.gradle
+++ b/examples/bond/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     buildCommon project(path: ':examples:common', configuration: 'buildCommon')
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -47,7 +47,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -58,8 +58,7 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-
-task copyABI(type: Exec, dependsOn: install) {
+task npm_copyABI(type: Exec, dependsOn: npm_install) {
     executable 'npm'
     args 'run'
     args 'abi'
@@ -69,7 +68,7 @@ task copyABI(type: Exec, dependsOn: install) {
     outputs.dir('src/abis')
 }
 
-task build(type: Exec, dependsOn: [install, copyABI]) {
+task npm_build(type: Exec, dependsOn: [npm_install, npm_copyABI]) {
     executable 'npm'
     args 'run'
     args 'build'
@@ -78,7 +77,27 @@ task build(type: Exec, dependsOn: [install, copyABI]) {
     outputs.dir('build')
 }
 
-task start(type: Exec, dependsOn: [build]) {
+// Task to revert SDK to published version
+task revert_sdk(type: Exec, dependsOn: ':examples:common:revert_sdk') {
+    executable 'npm'
+    args 'install' 
+    args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+    inputs.files(configurations.buildSDK)
+    inputs.files(configurations.buildCommon)
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
+    
+    description = 'Revert SDK to published version to prevent git changes'
+}
+
+// Main build task that includes cleanup
+task build(dependsOn: [npm_build]) {
+    finalizedBy revert_sdk
+}
+
+task npm_start(type: Exec, dependsOn: [npm_build]) {
     dependsOn ':operator:e2e'
 
     executable 'npm'
@@ -86,7 +105,8 @@ task start(type: Exec, dependsOn: [build]) {
     args 'start'
 }
 
-task e2e(type: Exec, dependsOn: [start]) {
+task e2e(type: Exec, dependsOn: [npm_start]) {
+    finalizedBy revert_sdk
 
     executable 'npm'
     args 'run'

--- a/examples/bond/package-lock.json
+++ b/examples/bond/package-lock.json
@@ -19,33 +19,10 @@
         "typescript": "^5.6.3"
       }
     },
-    "../../sdk/typescript": {
-      "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "ethers": "^6.13.4",
-        "uuid": "^11.0.2",
-        "ws": "^8.18.1"
-      },
-      "devDependencies": {
-        "@types/node": "^22.9.0",
-        "@types/ws": "^8.18.0",
-        "copy-file": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "^7.4.3",
-        "typescript": "^5.6.3"
-      }
-    },
     "../common": {
       "name": "paladin-example-common",
       "version": "0.0.1",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@lfdecentralizedtrust-labs/paladin-sdk": "^0.9.0"
-      },
       "devDependencies": {
         "@types/node": "^22.8.7",
         "copy-file": "^11.0.0",
@@ -402,9 +379,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",

--- a/examples/common/build.gradle
+++ b/examples/common/build.gradle
@@ -25,12 +25,12 @@ configurations {
         canBeResolved = false
     }
 }
-
+ 
 dependencies {
     buildSDK project(path: ':sdk:typescript', configuration: 'buildSDK')
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -41,7 +41,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -51,13 +51,34 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-task build(type: Exec, dependsOn: install) {
+// Task to revert SDK to published version
+task revert_sdk(type: Exec) {
+    executable 'npm'
+    args 'install' 
+    args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+    inputs.files(configurations.buildSDK)
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
+    
+    description = 'Revert SDK to published version to prevent git changes'
+}
+
+task npm_build(type: Exec, dependsOn: npm_install) {
     executable 'npm'
     args 'run'
     args 'build'
 
     inputs.files('*.ts')
     outputs.dir('build')
+}
+
+task build(dependsOn: [npm_build]) {
+    finalizedBy revert_sdk
+}
+
+task build_without_cleanup(dependsOn: [npm_build]) {
 }
 
 task clean(type: Delete) {
@@ -67,5 +88,5 @@ task clean(type: Delete) {
 }
 
 dependencies {
-    buildCommon files(build)
+    buildCommon files(build_without_cleanup)
 }

--- a/examples/common/package-lock.json
+++ b/examples/common/package-lock.json
@@ -19,26 +19,6 @@
         "typescript": "^5.6.3"
       }
     },
-    "../../sdk/typescript": {
-      "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "ethers": "^6.13.4",
-        "uuid": "^11.0.2",
-        "ws": "^8.18.1"
-      },
-      "devDependencies": {
-        "@types/node": "^22.9.0",
-        "@types/ws": "^8.18.0",
-        "copy-file": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "^7.4.3",
-        "typescript": "^5.6.3"
-      }
-    },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
@@ -346,9 +326,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",

--- a/examples/event-listener/build.gradle
+++ b/examples/event-listener/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     buildCommon project(path: ':examples:common', configuration: 'buildCommon')
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -47,7 +47,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -58,7 +58,7 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-task copyABI(type: Exec, dependsOn: install) {
+task npm_copyABI(type: Exec, dependsOn: npm_install) {
     executable 'npm'
     args 'run'
     args 'abi'
@@ -68,7 +68,7 @@ task copyABI(type: Exec, dependsOn: install) {
     outputs.dir('src/abis')
 }
 
-task build(type: Exec, dependsOn: [install, copyABI]) {
+task npm_build(type: Exec, dependsOn: [npm_install, npm_copyABI]) {
     executable 'npm'
     args 'run'
     args 'build'
@@ -77,7 +77,30 @@ task build(type: Exec, dependsOn: [install, copyABI]) {
     outputs.dir('build')
 }
 
-task start(type: Exec, dependsOn: [build]) {
+// Task to revert SDK to published version
+task revert_sdk( dependsOn: ':examples:common:revert_sdk') {
+// task revert_sdk(type: Exec, dependsOn: ':examples:common:revert_sdk') {
+    // this example does not support the latest SDK
+    /*
+        executable 'npm'
+        args 'install' 
+        args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+        inputs.files(configurations.buildSDK)
+        inputs.files(configurations.buildCommon)
+        inputs.files('package.json')
+        outputs.files('package-lock.json')
+        outputs.dir('node_modules')
+        description = 'Revert SDK to published version to prevent git changes'
+    */
+}
+
+// Main build task that includes cleanup
+task build(dependsOn: [npm_build]) {
+    finalizedBy revert_sdk
+}
+
+task npm_start(type: Exec, dependsOn: [npm_build]) {
     dependsOn ':operator:e2e'
 
     executable 'npm'
@@ -85,7 +108,8 @@ task start(type: Exec, dependsOn: [build]) {
     args 'start'
 }
 
-task e2e(type: Exec, dependsOn: [start]) {
+task e2e(type: Exec, dependsOn: [npm_start]) {
+    finalizedBy revert_sdk
 
     executable 'npm'
     args 'run'

--- a/examples/helloworld/build.gradle
+++ b/examples/helloworld/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     buildSDK project(path: ':sdk:typescript', configuration: 'buildSDK')
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -41,7 +41,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -51,7 +51,7 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-task copyABI(type: Exec, dependsOn: install) {
+task npm_copyABI(type: Exec, dependsOn: npm_install) {
     executable 'npm'
     args 'run'
     args 'abi'
@@ -61,7 +61,7 @@ task copyABI(type: Exec, dependsOn: install) {
     outputs.dir('src/abis')
 }
 
-task build(type: Exec, dependsOn: [install, copyABI]) {
+task npm_build(type: Exec, dependsOn: [npm_install, npm_copyABI]) {
     executable 'npm'
     args 'run'
     args 'build'
@@ -70,7 +70,26 @@ task build(type: Exec, dependsOn: [install, copyABI]) {
     outputs.dir('build')
 }
 
-task start(type: Exec, dependsOn: [build]) {
+// Task to revert SDK to published version
+task revert_sdk(type: Exec, dependsOn: ':examples:common:revert_sdk') {
+    executable 'npm'
+    args 'install' 
+    args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+    inputs.files(configurations.buildSDK)
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
+    
+    description = 'Revert SDK to published version to prevent git changes'
+}
+
+// Main build task that includes cleanup
+task build(dependsOn: [npm_build]) {
+    finalizedBy revert_sdk
+}
+
+task npm_start(type: Exec, dependsOn: [npm_build]) {
     dependsOn ':operator:e2e'
     
     executable 'npm'
@@ -78,7 +97,8 @@ task start(type: Exec, dependsOn: [build]) {
     args 'start'
 }
 
-task e2e(type: Exec, dependsOn: [start]) {
+task e2e(type: Exec, dependsOn: [npm_start]) {
+    finalizedBy revert_sdk
 
     executable 'npm'
     args 'run'

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -18,26 +18,6 @@
         "typescript": "^5.6.3"
       }
     },
-    "../../sdk/typescript": {
-      "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "ethers": "^6.13.4",
-        "uuid": "^11.0.2",
-        "ws": "^8.18.1"
-      },
-      "devDependencies": {
-        "@types/node": "^22.9.0",
-        "@types/ws": "^8.18.0",
-        "copy-file": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "^7.4.3",
-        "typescript": "^5.6.3"
-      }
-    },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
@@ -407,9 +387,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",

--- a/examples/notarized-tokens/build.gradle
+++ b/examples/notarized-tokens/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     buildSDK project(path: ':sdk:typescript', configuration: 'buildSDK')
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -40,7 +40,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -50,7 +50,7 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-task build(type: Exec, dependsOn: install) {
+task npm_build(type: Exec, dependsOn: [npm_install]) {
     executable 'npm'
     args 'run'
     args 'build'
@@ -59,15 +59,38 @@ task build(type: Exec, dependsOn: install) {
     outputs.dir('build')
 }
 
-task start(type: Exec, dependsOn: [build]) {
-    dependsOn ':operator:deploy'
+// Task to revert SDK to published version
+task revert_sdk(type: Exec) {
+    executable 'npm'
+    args 'install' 
+    args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+    inputs.files(configurations.buildSDK)
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
+    
+    description = 'Revert SDK to published version to prevent git changes'
+}
+
+// Main build task that includes cleanup
+task build(dependsOn: [npm_build]) {
+    finalizedBy revert_sdk
+}
+
+task buildWithoutCleanup(type: Exec, dependsOn: [npm_build]) {
+}
+
+task npm_start(type: Exec, dependsOn: [npm_build]) {
+    dependsOn ':operator:e2e'
 
     executable 'npm'
     args 'run'
     args 'start'
 }
 
-task e2e(type: Exec, dependsOn: [start]) {
+task e2e(type: Exec, dependsOn: [npm_start]) {
+    finalizedBy revert_sdk
 
     executable 'npm'
     args 'run'

--- a/examples/notarized-tokens/package-lock.json
+++ b/examples/notarized-tokens/package-lock.json
@@ -17,26 +17,6 @@
         "typescript": "^5.6.3"
       }
     },
-    "../../sdk/typescript": {
-      "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "ethers": "^6.13.4",
-        "uuid": "^11.0.2",
-        "ws": "^8.18.1"
-      },
-      "devDependencies": {
-        "@types/node": "^22.9.0",
-        "@types/ws": "^8.18.0",
-        "copy-file": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "^7.4.3",
-        "typescript": "^5.6.3"
-      }
-    },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
@@ -369,9 +349,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",

--- a/examples/privacy-storage/build.gradle
+++ b/examples/privacy-storage/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     buildCommon project(path: ':examples:common', configuration: 'buildCommon')
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -47,7 +47,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -58,7 +58,7 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-task copyABI(type: Exec, dependsOn: install) {
+task npm_copyABI(type: Exec, dependsOn: npm_install) {
     executable 'npm'
     args 'run'
     args 'abi'
@@ -68,7 +68,7 @@ task copyABI(type: Exec, dependsOn: install) {
     outputs.dir('src/abis')
 }
 
-task build(type: Exec, dependsOn: [install, copyABI]) {
+task npm_build(type: Exec, dependsOn: [npm_copyABI]) {
     executable 'npm'
     args 'run'
     args 'build'
@@ -77,7 +77,26 @@ task build(type: Exec, dependsOn: [install, copyABI]) {
     outputs.dir('build')
 }
 
-task start(type: Exec, dependsOn: [build]) {
+// Task to revert SDK to published version
+task revert_sdk(type: Exec, dependsOn: ':examples:common:revert_sdk') {
+    executable 'npm'
+    args 'install' 
+    args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+    inputs.files(configurations.buildCommon)
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
+    
+    description = 'Revert SDK to published version to prevent git changes'
+}
+
+// Main build task that includes cleanup
+task build(dependsOn: [npm_build]) {
+    finalizedBy revert_sdk
+}
+
+task npm_start(type: Exec, dependsOn: [npm_build]) {
     dependsOn ':operator:e2e'
 
     executable 'npm'
@@ -85,7 +104,8 @@ task start(type: Exec, dependsOn: [build]) {
     args 'start'
 }
 
-task e2e(type: Exec, dependsOn: [start]) {
+task e2e(type: Exec, dependsOn: [npm_start]) {
+    finalizedBy revert_sdk
 
     executable 'npm'
     args 'run'

--- a/examples/privacy-storage/package-lock.json
+++ b/examples/privacy-storage/package-lock.json
@@ -19,26 +19,6 @@
         "typescript": "^5.6.3"
       }
     },
-    "../../sdk/typescript": {
-      "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "ethers": "^6.13.4",
-        "uuid": "^11.0.2",
-        "ws": "^8.18.1"
-      },
-      "devDependencies": {
-        "@types/node": "^22.9.0",
-        "@types/ws": "^8.18.0",
-        "copy-file": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "^7.4.3",
-        "typescript": "^5.6.3"
-      }
-    },
     "../common": {
       "name": "paladin-example-common",
       "version": "0.0.1",
@@ -423,9 +403,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",

--- a/examples/private-stablecoin/build.gradle
+++ b/examples/private-stablecoin/build.gradle
@@ -42,7 +42,7 @@ task copyContracts(type: Copy, dependsOn: [":domains:zeto:extractZetoArtifacts"]
     includeEmptyDirs = false
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -54,7 +54,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -65,7 +65,7 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-task build(type: Exec, dependsOn: [install, copyContracts]) {
+task npm_build(type: Exec, dependsOn: [npm_install, copyContracts]) {
     executable 'npm'
     args 'run'
     args 'build'
@@ -74,7 +74,32 @@ task build(type: Exec, dependsOn: [install, copyContracts]) {
     outputs.dir('build')
 }
 
-task start(type: Exec, dependsOn: [build]) {
+// Task to revert SDK to published version
+// task revert_sdk(type: Exec, dependsOn: ':examples:common:revert_sdk') {
+task revert_sdk(dependsOn: ':examples:common:revert_sdk') {
+    // this example does not support the latest SDK
+    /*
+    executable 'npm'
+    args 'install' 
+    args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+    inputs.files(configurations.buildSDK)
+    inputs.files(configurations.buildCommon)
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
+    
+    description = 'Revert SDK to published version to prevent git changes'
+    */
+}
+
+// Main build task that includes cleanup
+task build(dependsOn: [npm_build]) {
+    // this example does not support the latest SDK
+    finalizedBy revert_sdk
+}
+
+task npm_start(type: Exec, dependsOn: [npm_build]) {
     dependsOn ':operator:e2e'
 
     executable 'npm'
@@ -82,7 +107,8 @@ task start(type: Exec, dependsOn: [build]) {
     args 'start'
 }
 
-task e2e(type: Exec, dependsOn: [start]) {
+task e2e(type: Exec, dependsOn: [npm_start]) {
+    finalizedBy revert_sdk
 
     executable 'npm'
     args 'run'

--- a/examples/public-storage/build.gradle
+++ b/examples/public-storage/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     buildSDK project(path: ':sdk:typescript', configuration: 'buildSDK')
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -41,7 +41,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -51,7 +51,7 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-task copyABI(type: Exec, dependsOn: install) {
+task npm_copyABI(type: Exec, dependsOn: npm_install) {
     executable 'npm'
     args 'run'
     args 'abi'
@@ -61,7 +61,7 @@ task copyABI(type: Exec, dependsOn: install) {
     outputs.dir('src/abis')
 }
 
-task build(type: Exec, dependsOn: [install, copyABI]) {
+task npm_build(type: Exec, dependsOn: [npm_install, npm_copyABI]) {
     executable 'npm'
     args 'run'
     args 'build'
@@ -70,7 +70,29 @@ task build(type: Exec, dependsOn: [install, copyABI]) {
     outputs.dir('build')
 }
 
-task start(type: Exec, dependsOn: [build]) {
+// Task to revert SDK to published version
+task revert_sdk(type: Exec, dependsOn: ':examples:common:revert_sdk') {
+    executable 'npm'
+    args 'install' 
+    args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+    inputs.files(configurations.buildSDK)
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
+    
+    description = 'Revert SDK to published version to prevent git changes'
+}
+
+// Main build task that includes cleanup
+task build(dependsOn: [npm_build]) {
+    finalizedBy revert_sdk
+}
+
+task buildWithoutCleanup(type: Exec, dependsOn: [npm_build]) {
+}
+
+task npm_start(type: Exec, dependsOn: [npm_build]) {
     dependsOn ':operator:e2e'
 
     executable 'npm'
@@ -78,7 +100,8 @@ task start(type: Exec, dependsOn: [build]) {
     args 'start'
 }
 
-task e2e(type: Exec, dependsOn: [start]) {
+task e2e(type: Exec, dependsOn: [npm_start]) {
+    finalizedBy revert_sdk
 
     executable 'npm'
     args 'run'

--- a/examples/public-storage/package-lock.json
+++ b/examples/public-storage/package-lock.json
@@ -18,26 +18,6 @@
         "typescript": "^5.6.3"
       }
     },
-    "../../sdk/typescript": {
-      "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "ethers": "^6.13.4",
-        "uuid": "^11.0.2",
-        "ws": "^8.18.1"
-      },
-      "devDependencies": {
-        "@types/node": "^22.9.0",
-        "@types/ws": "^8.18.0",
-        "copy-file": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "^7.4.3",
-        "typescript": "^5.6.3"
-      }
-    },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
@@ -407,9 +387,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",

--- a/examples/swap/build.gradle
+++ b/examples/swap/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     buildCommon project(path: ':examples:common', configuration: 'buildCommon')
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -47,7 +47,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -58,7 +58,7 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-task copyABI(type: Exec, dependsOn: install) {
+task npm_copyABI(type: Exec, dependsOn: npm_install) {
     executable 'npm'
     args 'run'
     args 'abi'
@@ -68,7 +68,7 @@ task copyABI(type: Exec, dependsOn: install) {
     outputs.dir('src/abis')
 }
 
-task build(type: Exec, dependsOn: [install, copyABI]) {
+task npm_build(type: Exec, dependsOn: [npm_install, npm_copyABI]) {
     executable 'npm'
     args 'run'
     args 'build'
@@ -77,7 +77,27 @@ task build(type: Exec, dependsOn: [install, copyABI]) {
     outputs.dir('build')
 }
 
-task start(type: Exec, dependsOn: [build]) {
+// Task to revert SDK to published version
+task revert_sdk(type: Exec, dependsOn: ':examples:common:revert_sdk') {
+    executable 'npm'
+    args 'install' 
+    args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+    inputs.files(configurations.buildSDK)
+    inputs.files(configurations.buildCommon)
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
+    
+    description = 'Revert SDK to published version to prevent git changes'
+}
+
+// Main build task that includes cleanup
+task build(dependsOn: [npm_build]) {
+    finalizedBy revert_sdk
+}
+
+task npm_start(type: Exec, dependsOn: [npm_build]) {
     dependsOn ':operator:e2e'
 
     executable 'npm'
@@ -85,7 +105,8 @@ task start(type: Exec, dependsOn: [build]) {
     args 'start'
 }
 
-task e2e(type: Exec, dependsOn: [start]) {
+task e2e(type: Exec, dependsOn: [npm_start]) {
+    finalizedBy revert_sdk
 
     executable 'npm'
     args 'run'

--- a/examples/swap/package-lock.json
+++ b/examples/swap/package-lock.json
@@ -20,26 +20,6 @@
         "typescript": "^5.6.3"
       }
     },
-    "../../sdk/typescript": {
-      "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "ethers": "^6.13.4",
-        "uuid": "^11.0.2",
-        "ws": "^8.18.1"
-      },
-      "devDependencies": {
-        "@types/node": "^22.9.0",
-        "@types/ws": "^8.18.0",
-        "copy-file": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "^7.4.3",
-        "typescript": "^5.6.3"
-      }
-    },
     "../common": {
       "name": "paladin-example-common",
       "version": "0.0.1",
@@ -397,9 +377,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",

--- a/examples/zeto/build.gradle
+++ b/examples/zeto/build.gradle
@@ -41,7 +41,7 @@ task copyContracts(type: Copy, dependsOn: [":domains:zeto:extractZetoArtifacts"]
     includeEmptyDirs = false
 }
 
-task install_sdk(type: Exec) {
+task npm_install_sdk(type: Exec) {
     executable 'npm'
     args 'install' 
     args 'file:../../sdk/typescript' // use local sdk
@@ -53,7 +53,7 @@ task install_sdk(type: Exec) {
     outputs.dir('node_modules')
 }
 
-task install(type: Exec, dependsOn: install_sdk) {
+task npm_install(type: Exec, dependsOn: npm_install_sdk) {
     executable 'npm'
     args 'install' 
 
@@ -64,7 +64,7 @@ task install(type: Exec, dependsOn: install_sdk) {
     outputs.dir('node_modules')
 }
 
-task build(type: Exec, dependsOn: [install, copyContracts]) {
+task npm_build(type: Exec, dependsOn: [npm_install, copyContracts]) {
     executable 'npm'
     args 'run'
     args 'build'
@@ -73,15 +73,39 @@ task build(type: Exec, dependsOn: [install, copyContracts]) {
     outputs.dir('build')
 }
 
-task start(type: Exec, dependsOn: [build]) {
-    // dependsOn ':operator:e2e'
+// Task to revert SDK to published version
+task revert_sdk(type: Exec, dependsOn: ':examples:common:revert_sdk') {
+    executable 'npm'
+    args 'install' 
+    args '@lfdecentralizedtrust-labs/paladin-sdk@latest'
+
+    inputs.files(configurations.buildSDK)
+    inputs.files(configurations.buildCommon)
+    inputs.files('package.json')
+    outputs.files('package-lock.json')
+    outputs.dir('node_modules')
+    
+    description = 'Revert SDK to published version to prevent git changes'
+}
+
+// Main build task that includes cleanup
+task build(dependsOn: [npm_build]) {
+    finalizedBy revert_sdk
+}
+
+task buildWithoutCleanup(type: Exec, dependsOn: [npm_build]) {
+}
+
+task npm_start(type: Exec, dependsOn: [npm_build]) {
+    dependsOn ':operator:e2e'
 
     executable 'npm'
     args 'run'
     args 'start'
 }
 
-task e2e(type: Exec, dependsOn: [start]) {
+task e2e(type: Exec, dependsOn: [npm_start]) {
+    finalizedBy revert_sdk
 
     executable 'npm'
     args 'run'

--- a/examples/zeto/package-lock.json
+++ b/examples/zeto/package-lock.json
@@ -21,26 +21,6 @@
         "typescript": "^5.6.3"
       }
     },
-    "../../sdk/typescript": {
-      "name": "@lfdecentralizedtrust-labs/paladin-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "ethers": "^6.13.4",
-        "uuid": "^11.0.2",
-        "ws": "^8.18.1"
-      },
-      "devDependencies": {
-        "@types/node": "^22.9.0",
-        "@types/ws": "^8.18.0",
-        "copy-file": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "^7.4.3",
-        "typescript": "^5.6.3"
-      }
-    },
     "../common": {
       "name": "paladin-example-common",
       "version": "0.0.1",
@@ -482,9 +462,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
### Overview
Prevents unwanted git changes to `package.json` files after building examples by automatically reverting local SDK dependencies to published versions.
