### PR TITLE
Never return ReadyForSequencing true when a transaction has reverted

### DIFF
--- a/core/go/internal/privatetxnmgr/transaction_flow.go
+++ b/core/go/internal/privatetxnmgr/transaction_flow.go
@@ -131,7 +131,7 @@ func (tf *transactionFlow) IsComplete(_ context.Context) bool {
 }
 
 func (tf *transactionFlow) ReadyForSequencing(ctx context.Context) bool {
-	return tf.transaction.PostAssembly != nil
+	return tf.transaction.PostAssembly != nil && tf.transaction.PostAssembly.AssemblyResult == prototk.AssembleTransactionResponse_OK
 }
 
 func (tf *transactionFlow) Dispatched(_ context.Context) bool {


### PR DESCRIPTION
I've seen an instance of the private TX manager getting stuck on a transaction, because it is attempting to prepare it even though it is not endorsed.

The reason it is not endorsed, is because it has reverted. But these lines show we still chose to try and add it to the graph for dispatchable transactions and dispatch it:

```
[2025-08-12T08:14:51.087Z] DEBUG Sequencer handling event *ptmgrtypes.TransactionAssembledEvent for transaction 1e34cf98-07ec-4fa2-aaff-e51abe738ad0 pid=21 role=pctm-loop-0x2a9e4508105fa962956bd2304847892850667ca3
[2025-08-12T08:14:51.087Z] ERROR Reverting transaction 1e34cf98-07ec-4fa2-aaff-e51abe738ad0: PD011814: Domain reverted transaction on assemble: PD200005: Insufficient funds (available=0) pid=21 role=pctm-loop-0x2a9e4508105fa962956bd2304847892850667ca3
[2025-08-12T08:14:51.087Z] ERROR finalize transaction 1e34cf98-07ec-4fa2-aaff-e51abe738ad0: PD011814: Domain reverted transaction on assemble: PD200005: Insufficient funds (available=0) pid=21 role=pctm-loop-0x2a9e4508105fa962956bd2304847892850667ca3
[2025-08-12T08:14:51.087Z] DEBUG transactionFlow:Action TransactionID='1e34cf98-07ec-4fa2-aaff-e51abe738ad0' Status='new' LatestEvent='TransactionAssembledEvent' LatestError='' : >> pid=21 role=pctm-loop-0x2a9e4508105fa962956bd2304847892850667ca3
[2025-08-12T08:14:51.087Z]  INFO transactionFlow:Action TransactionID='1e34cf98-07ec-4fa2-aaff-e51abe738ad0' Status='new' LatestEvent='TransactionAssembledEvent' LatestError='' : finalize already pending pid=21 role=pctm-loop-0x2a9e4508105fa962956bd2304847892850667ca3
[2025-08-12T08:14:51.087Z] DEBUG Adding transaction 1e34cf98-07ec-4fa2-aaff-e51abe738ad0 to graph pid=21 role=pctm-loop-0x2a9e4508105fa962956bd2304847892850667ca3

```

Which occurs in this block of code, based on `transactionProcessor.ReadyForSequencing(ctx)` returning true.

https://github.com/LF-Decentralized-Trust-labs/paladin/blob/4e2e07b9c780b48910b6913a4779f26274533c91/core/go/internal/privatetxnmgr/sequencer_event_loop.go#L121-L133