### PR TITLE
Handle nil contractAddr on transaction indexing

### DIFF
--- a/core/go/internal/privatetxnmgr/private_txn_mgr.go
+++ b/core/go/internal/privatetxnmgr/private_txn_mgr.go
@@ -971,9 +971,13 @@ func (p *privateTxManager) NotifyFailedPublicTx(ctx context.Context, dbTX persis
 	// TODO: We have processing we need to do here to resubmit
 	privateFailureReceipts := make([]*components.ReceiptInputWithOriginator, len(failures))
 	for i, tx := range failures {
+		contractAddr := ""
+		if tx.ContractAddress != nil {
+			contractAddr = tx.ContractAddress.String()
+		}
 		privateFailureReceipts[i] = &components.ReceiptInputWithOriginator{
 			Originator:            tx.Sender,
-			DomainContractAddress: tx.ContractAddress.String(),
+			DomainContractAddress: contractAddr,
 			ReceiptInput: components.ReceiptInput{
 				ReceiptType:   components.RT_FailedOnChainWithRevertData,
 				TransactionID: tx.TransactionID,


### PR DESCRIPTION
Issue after application of #795

```
[2025-08-14T00:02:25.961Z] ERROR Panic within database transaction: runtime error: invalid memory address or nil pointer dereference
goroutine 308 [running]:
runtime/debug.Stack()
    /usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/persistence.(*provider).Transaction.func1()
    /app/core/go/pkg/persistence/gorm.go:175 +0x85
panic({0x7fdc2ec45dc0?, 0x7fdc2f712620?})
    /usr/local/go/src/runtime/panic.go:792 +0x132
github.com/LF-Decentralized-Trust-labs/paladin/core/internal/privatetxnmgr.(*privateTxManager).NotifyFailedPublicTx(0xc0006cc3c0, {0x7fdc2ee70048, 0xc000a954d0}, {0x7fdc2ee784a0, 0xc000994500}, {0xc00070a378, 0x1, 0x7fdc6c1cbf30?})
    /app/core/go/internal/privatetxnmgr/private_txn_mgr.go:976 +0xb9
github.com/LF-Decentralized-Trust-labs/paladin/core/internal/txmgr.(*txManager).blockIndexerPreCommit(0xc0001c6000, {0x7fdc2ee70048, 0xc000a954d0}, {0x7fdc2ee784a0, 0xc000994500}, {0xc0006cc3c0?, 0x7fdc2ebb9a40?, 0x7fdc2ee5bdc0?}, {0xc000a89a80, 0x9, ...})
    /app/core/go/internal/txmgr/block_indexing.go:76 +0x70a
github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/blockindexer.(*blockIndexer).writeBatch.func1.1({0x7fdc2ee70048, 0xc000a954d0}, {0x7fdc2ee784a0, 0xc000994500})
    /app/core/go/pkg/blockindexer/block_indexer.go:617 +0x18d
github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/persistence.(*provider).Transaction.func2(0xc00078f830?)
    /app/core/go/pkg/persistence/gorm.go:197 +0xa2
gorm.io/gorm.(*DB).Transaction(0xc00078f830, 0xc0007a3800, {0x0?, 0x0?, 0x0?})
    /root/go/pkg/mod/gorm.io/gorm@v1.25.12/finisher_api.go:651 +0x21d
github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/persistence.(*provider).Transaction(0xc0004c69c0, {0x7fdc2ee70080, 0xc000295c20}, 0xc000de88c0)
    /app/core/go/pkg/persistence/gorm.go:195 +0x176
github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/blockindexer.(*blockIndexer).writeBatch.func1(0x5?)
    /app/core/go/pkg/blockindexer/block_indexer.go:614 +0x19e
github.com/LF-Decentralized-Trust-labs/paladin/sdk/go/pkg/retry.(*Retry).Do(0xc000265020, {0x7fdc2ee70080, 0xc000295c20}, 0xc0008c9c30)
    /app/sdk/go/pkg/retry/retry.go:66 +0x54
github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/blockindexer.(*blockIndexer).writeBatch(0xc000510140, {0x7fdc2ee70080, 0xc000295c20}, 0xc00081f290)
    /app/core/go/pkg/blockindexer/block_indexer.go:613 +0x55e
github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/blockindexer.(*blockIndexer).dispatcher(0xc000510140, {0x7fdc2ee70080, 0xc000295c20})
    /app/core/go/pkg/blockindexer/block_indexer.go:489 +0x733
created by github.com/LF-Decentralized-Trust-labs/paladin/core/pkg/blockindexer.(*blockIndexer).startup in goroutine 323
    /app/core/go/pkg/blockindexer/block_indexer.go:217 +0x1b6
 dbtx=RsNlUO1w pid=4466 role=block_indexer
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: PD010208: An unhandled error occurred within the database transaction: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7fdc2e5eb339]
```