### PR TITLE
Add timeouts to prevent test hangs in various plugin tests

### DIFF
--- a/core/go/internal/plugins/domains_test.go
+++ b/core/go/internal/plugins/domains_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"runtime/debug"
 	"testing"
+	"time"
 
 	"github.com/LF-Decentralized-Trust-labs/paladin/config/pkg/confutil"
 	"github.com/LF-Decentralized-Trust-labs/paladin/config/pkg/pldconf"
@@ -337,7 +338,13 @@ func TestDomainRequestsOK(t *testing.T) {
 	})
 	defer done()
 
-	domainAPI := <-waitForAPI
+	var domainAPI components.DomainManagerToDomain
+	select {
+	case domainAPI = <-waitForAPI:
+		// Received domain API
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for domain API - expected registration was not received")
+	}
 
 	cdr, err := domainAPI.ConfigureDomain(ctx, &prototk.ConfigureDomainRequest{
 		ChainId: int64(12345),
@@ -471,7 +478,13 @@ func TestDomainRequestsOK(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, `{"wrapped":"params"}`, wpgtr.Transaction.ParamsJson)
 
-	callbacks := <-waitForCallbacks
+	// Add timeout for callbacks
+	var callbacks plugintk.DomainCallbacks
+	select {
+	case callbacks = <-waitForCallbacks:
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for callbacks - expected callbacks were not received")
+	}
 
 	fas, err := callbacks.FindAvailableStates(ctx, &prototk.FindAvailableStatesRequest{
 		SchemaId: "schema1",
@@ -509,11 +522,11 @@ func TestDomainRequestsOK(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "node1", lnr.Name)
 
-	gsr, err := callbacks.GetStatesByID(ctx, &prototk.GetStatesByIDRequest{
+	gsr2, err := callbacks.GetStatesByID(ctx, &prototk.GetStatesByIDRequest{
 		SchemaId: "schema1",
 	})
 	require.NoError(t, err)
-	assert.Len(t, gsr.States, 1)
+	assert.Len(t, gsr2.States, 1)
 }
 
 func TestDomainRegisterFail(t *testing.T) {
@@ -548,7 +561,13 @@ func TestDomainRegisterFail(t *testing.T) {
 	})
 	defer done()
 
-	<-waitForError
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case <-waitForError:
+		// Error received successfully
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for error - expected error was not received")
+	}
 }
 
 func TestFromDomainRequestBadReq(t *testing.T) {
@@ -589,6 +608,11 @@ func TestFromDomainRequestBadReq(t *testing.T) {
 	})
 	defer done()
 
-	<-waitForResponse
-
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case <-waitForResponse:
+		// Response received successfully
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for response - expected response was not received")
+	}
 }

--- a/core/go/internal/plugins/plugin_base_test.go
+++ b/core/go/internal/plugins/plugin_base_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/LF-Decentralized-Trust-labs/paladin/config/pkg/confutil"
 	"github.com/LF-Decentralized-Trust-labs/paladin/config/pkg/pldconf"
@@ -181,8 +182,13 @@ func TestPluginRequestsError(t *testing.T) {
 	})
 	defer done()
 
-	<-waitForResponse
-
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case <-waitForResponse:
+		// Response received successfully
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for response - expected response was not received")
+	}
 }
 
 func TestSenderErrorHandling(t *testing.T) {
@@ -207,26 +213,29 @@ func TestSenderErrorHandling(t *testing.T) {
 		testDomainManager: tdm,
 	})
 
-	domainAPI := <-waitForRegister
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case domainAPI := <-waitForRegister:
+		// Stop
+		done()
 
-	// Stop
-	done()
-
-	// Check send loop sending on closed stream
-	bridge := domainAPI.(*domainBridge)
-	handler := bridge.toPlugin.(*pluginHandler[prototk.DomainMessage])
-	handler.senderDone = make(chan struct{})
-	handler.sendChl = make(chan plugintk.PluginMessage[prototk.DomainMessage])
-	cancellable, cancel := context.WithCancel(context.Background())
-	handler.ctx = cancellable
-	go func() {
+		// Check send loop sending on closed stream
+		bridge := domainAPI.(*domainBridge)
+		handler := bridge.toPlugin.(*pluginHandler[prototk.DomainMessage])
+		handler.senderDone = make(chan struct{})
+		handler.sendChl = make(chan plugintk.PluginMessage[prototk.DomainMessage])
+		cancellable, cancel := context.WithCancel(context.Background())
+		handler.ctx = cancellable
+		go func() {
+			handler.send(handler.wrapper.Wrap(&prototk.DomainMessage{}))
+			cancel() // cancel after first message pushed to sender
+		}()
+		handler.sender()
+		// Check does not block after context is closed
 		handler.send(handler.wrapper.Wrap(&prototk.DomainMessage{}))
-		cancel() // cancel after first message pushed to sender
-	}()
-	handler.sender()
-	// Check does not block after context is closed
-	handler.send(handler.wrapper.Wrap(&prototk.DomainMessage{}))
-
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for domain API - expected registration was not received")
+	}
 }
 
 func TestDomainRequestsBadResponse(t *testing.T) {
@@ -268,11 +277,14 @@ func TestDomainRequestsBadResponse(t *testing.T) {
 	})
 	defer done()
 
-	domainAPI := <-waitForRegister
-
-	_, err := domainAPI.ConfigureDomain(ctx, &prototk.ConfigureDomainRequest{})
-	assert.Regexp(t, "PD011205", err)
-
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case domainAPI := <-waitForRegister:
+		_, err := domainAPI.ConfigureDomain(ctx, &prototk.ConfigureDomainRequest{})
+		assert.Regexp(t, "PD011205", err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for domain API - expected registration was not received")
+	}
 }
 
 func TestDomainRequestsErrorWithMessage(t *testing.T) {
@@ -310,11 +322,14 @@ func TestDomainRequestsErrorWithMessage(t *testing.T) {
 	})
 	defer done()
 
-	domainAPI := <-waitForRegister
-
-	_, err := domainAPI.ConfigureDomain(ctx, &prototk.ConfigureDomainRequest{})
-	assert.Regexp(t, "PD011206.*some error", err)
-
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case domainAPI := <-waitForRegister:
+		_, err := domainAPI.ConfigureDomain(ctx, &prototk.ConfigureDomainRequest{})
+		assert.Regexp(t, "PD011206.*some error", err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for domain API - expected registration was not received")
+	}
 }
 
 func TestDomainRequestsErrorNoMessage(t *testing.T) {
@@ -351,11 +366,14 @@ func TestDomainRequestsErrorNoMessage(t *testing.T) {
 	})
 	defer done()
 
-	domainAPI := <-waitForRegister
-
-	_, err := domainAPI.ConfigureDomain(ctx, &prototk.ConfigureDomainRequest{})
-	assert.Regexp(t, "PD011206.*ERROR_RESPONSE", err)
-
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case domainAPI := <-waitForRegister:
+		_, err := domainAPI.ConfigureDomain(ctx, &prototk.ConfigureDomainRequest{})
+		assert.Regexp(t, "PD011206.*ERROR_RESPONSE", err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for domain API - expected registration was not received")
+	}
 }
 
 func TestReceiveAfterTimeout(t *testing.T) {
@@ -388,19 +406,23 @@ func TestReceiveAfterTimeout(t *testing.T) {
 	})
 	defer done()
 
-	domainAPI := <-waitForRegister
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case domainAPI := <-waitForRegister:
+		go func() {
+			<-readyToGo
+			// Force a timeout by closing the inflight handler while the request is mid-flight
+			bridge := domainAPI.(*domainBridge)
+			handler := bridge.toPlugin.(*pluginHandler[prototk.DomainMessage])
+			handler.inflight.Close()
+			gone <- true
+		}()
 
-	go func() {
-		<-readyToGo
-		// Force a timeout by closing the inflight handler while the request is mid-flight
-		bridge := domainAPI.(*domainBridge)
-		handler := bridge.toPlugin.(*pluginHandler[prototk.DomainMessage])
-		handler.inflight.Close()
-		close(gone)
-	}()
-	_, err := domainAPI.ConfigureDomain(ctx, &prototk.ConfigureDomainRequest{})
-	assert.Regexp(t, "PD020100", err)
-
+		_, err := domainAPI.ConfigureDomain(ctx, &prototk.ConfigureDomainRequest{})
+		assert.Regexp(t, "PD011207", err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for domain API - expected registration was not received")
+	}
 }
 
 func TestDomainSendBeforeRegister(t *testing.T) {
@@ -433,7 +455,13 @@ func TestDomainSendBeforeRegister(t *testing.T) {
 	})
 	defer done()
 
-	<-waitForRegister
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case <-waitForRegister:
+		// Registration received successfully
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for registration - expected registration was not received")
+	}
 }
 
 func TestDomainSendDoubleRegister(t *testing.T) {
@@ -468,8 +496,13 @@ func TestDomainSendDoubleRegister(t *testing.T) {
 	})
 	defer done()
 
-	<-waitForRegister
-
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case <-waitForRegister:
+		// Registration received successfully
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for registration - expected registration was not received")
+	}
 }
 
 func TestDomainRegisterWrongID(t *testing.T) {
@@ -506,7 +539,13 @@ func TestDomainRegisterWrongID(t *testing.T) {
 	})
 	defer done()
 
-	assert.Regexp(t, "UUID", <-waitForError)
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case err := <-waitForError:
+		assert.Regexp(t, "UUID", err.Error())
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for error - expected error was not received")
+	}
 }
 
 func TestDomainSendResponseWrongID(t *testing.T) {
@@ -576,12 +615,17 @@ func TestDomainSendResponseWrongID(t *testing.T) {
 	})
 	defer done()
 
-	domainAPI := <-waitForRegister
-	atr, err := domainAPI.AssembleTransaction(ctx, &prototk.AssembleTransactionRequest{
-		Transaction: &prototk.TransactionSpecification{
-			TransactionId: "tx2_prepare",
-		},
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, prototk.AssembleTransactionResponse_REVERT, atr.AssemblyResult)
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case domainAPI := <-waitForRegister:
+		atr, err := domainAPI.AssembleTransaction(ctx, &prototk.AssembleTransactionRequest{
+			Transaction: &prototk.TransactionSpecification{
+				TransactionId: "tx2_prepare",
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, prototk.AssembleTransactionResponse_REVERT, atr.AssemblyResult)
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for domain API - expected registration was not received")
+	}
 }

--- a/core/go/internal/plugins/signing_modules_test.go
+++ b/core/go/internal/plugins/signing_modules_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"runtime/debug"
 	"testing"
+	"time"
 
 	"github.com/LF-Decentralized-Trust-labs/paladin/config/pkg/pldconf"
 	"github.com/LF-Decentralized-Trust-labs/paladin/core/internal/components"
@@ -165,7 +166,13 @@ func TestSigningModuleRequestsOK(t *testing.T) {
 	})
 	defer done()
 
-	signingModuleAPI := <-waitForAPI
+	var signingModuleAPI components.KeyManagerToSigningModule
+	select {
+	case signingModuleAPI = <-waitForAPI:
+		// Received signing module API
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for signing module API - expected registration was not received")
+	}
 
 	_, err := signingModuleAPI.ConfigureSigningModule(ctx, &prototk.ConfigureSigningModuleRequest{})
 	require.NoError(t, err)
@@ -202,9 +209,14 @@ func TestSigningModuleRequestsOK(t *testing.T) {
 	signingModuleAPI.Initialized()
 	require.NoError(t, smpm.WaitForInit(ctx, prototk.PluginInfo_SIGNING_MODULE))
 
-	callbacks := <-waitForCallbacks
-
-	assert.NotNil(t, callbacks)
+	// Add timeout for callbacks
+	var callbacks plugintk.SigningModuleCallbacks
+	select {
+	case callbacks = <-waitForCallbacks:
+		assert.NotNil(t, callbacks)
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for callbacks - expected callbacks were not received")
+	}
 }
 
 func TestSigningModuleRegisterFail(t *testing.T) {
@@ -240,7 +252,13 @@ func TestSigningModuleRegisterFail(t *testing.T) {
 	})
 	defer done()
 
-	assert.Regexp(t, "pop", <-waitForError)
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case err := <-waitForError:
+		assert.Regexp(t, "pop", err.Error())
+	case <-time.After(20 * time.Second):
+		t.Fatal("Test timed out waiting for error - expected error was not received")
+	}
 }
 
 func TestFromSigningModuleRequestBadReq(t *testing.T) {
@@ -280,5 +298,11 @@ func TestFromSigningModuleRequestBadReq(t *testing.T) {
 	})
 	defer done()
 
-	<-waitForResponse
+	// Add timeout to prevent test from hanging indefinitely
+	select {
+	case <-waitForResponse:
+		// Response received successfully
+	case <-time.After(10 * time.Second):
+		t.Fatal("Test timed out waiting for response - expected response was not received")
+	}
 }


### PR DESCRIPTION
Updated multiple test cases to include timeouts for waiting on API responses, callbacks, and errors. This ensures that tests fail gracefully if expected events do not occur within a specified duration.
[Here](https://productionresultssa3.blob.core.windows.net/actions-results/25890fdb-ae24-471a-9f2a-f2700cee9edf/workflow-job-run-08ec2c91-885f-51ac-8b48-df92820d2cf8/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-08-14T20%3A07%3A38Z&sig=it8IJgvS5a1IgsisCM1QAUvq6Wuu05Uipf3rixcckaU%3D&ske=2025-08-15T06%3A48%3A17Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-08-14T18%3A48%3A17Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-08-14T19%3A57%3A33Z&sv=2025-05-05) is an example for a failing test.