### PR TITLE
Submit domain transactions from configured identity

### DIFF
--- a/config/pkg/pldconf/domainmgr.go
+++ b/config/pkg/pldconf/domainmgr.go
@@ -30,13 +30,13 @@ type DomainManagerManagerConfig struct {
 }
 
 type DomainConfig struct {
-	Init                   DomainInitConfig `json:"init"`
-	Plugin                 PluginConfig     `json:"plugin"`
-	Config                 map[string]any   `json:"config"`
-	RegistryAddress        string           `json:"registryAddress"`
-	AllowSigning           bool             `json:"allowSigning"`
-	DefaultGasLimit        *uint64          `json:"defaultGasLimit"`
-	DefaultSigningIdentity string           `json:"defaultSigningIdentity"`
+	Init                 DomainInitConfig `json:"init"`
+	Plugin               PluginConfig     `json:"plugin"`
+	Config               map[string]any   `json:"config"`
+	RegistryAddress      string           `json:"registryAddress"`
+	AllowSigning         bool             `json:"allowSigning"`
+	DefaultGasLimit      *uint64          `json:"defaultGasLimit"`
+	FixedSigningIdentity string           `json:"fixedSigningIdentity"`
 }
 
 var ContractCacheDefaults = &CacheConfig{

--- a/config/pkg/pldconf/domainmgr.go
+++ b/config/pkg/pldconf/domainmgr.go
@@ -30,12 +30,13 @@ type DomainManagerManagerConfig struct {
 }
 
 type DomainConfig struct {
-	Init            DomainInitConfig `json:"init"`
-	Plugin          PluginConfig     `json:"plugin"`
-	Config          map[string]any   `json:"config"`
-	RegistryAddress string           `json:"registryAddress"`
-	AllowSigning    bool             `json:"allowSigning"`
-	DefaultGasLimit *uint64          `json:"defaultGasLimit"`
+	Init                   DomainInitConfig `json:"init"`
+	Plugin                 PluginConfig     `json:"plugin"`
+	Config                 map[string]any   `json:"config"`
+	RegistryAddress        string           `json:"registryAddress"`
+	AllowSigning           bool             `json:"allowSigning"`
+	DefaultGasLimit        *uint64          `json:"defaultGasLimit"`
+	DefaultSigningIdentity string           `json:"defaultSigningIdentity"`
 }
 
 var ContractCacheDefaults = &CacheConfig{

--- a/core/go/internal/components/domainmgr.go
+++ b/core/go/internal/components/domainmgr.go
@@ -54,6 +54,7 @@ type Domain interface {
 	RegistryAddress() *pldtypes.EthAddress
 	Configuration() *prototk.DomainConfig
 	CustomHashFunction() bool
+	DefaultSigningIdentity() string
 
 	// Specific to domains that support privacy groups (domain should return error if it does not).
 	// Validates the input properties, and turns it into the full genesis configuration for a group

--- a/core/go/internal/components/domainmgr.go
+++ b/core/go/internal/components/domainmgr.go
@@ -54,7 +54,7 @@ type Domain interface {
 	RegistryAddress() *pldtypes.EthAddress
 	Configuration() *prototk.DomainConfig
 	CustomHashFunction() bool
-	DefaultSigningIdentity() string
+	FixedSigningIdentity() string
 
 	// Specific to domains that support privacy groups (domain should return error if it does not).
 	// Validates the input properties, and turns it into the full genesis configuration for a group

--- a/core/go/internal/domainmgr/domain.go
+++ b/core/go/internal/domainmgr/domain.go
@@ -52,13 +52,13 @@ type domain struct {
 	ctx       context.Context
 	cancelCtx context.CancelFunc
 
-	conf                   *pldconf.DomainConfig
-	defaultGasLimit        pldtypes.HexUint64
-	dm                     *domainManager
-	name                   string
-	api                    components.DomainManagerToDomain
-	registryAddress        *pldtypes.EthAddress
-	defaultSigningIdentity string
+	conf                 *pldconf.DomainConfig
+	defaultGasLimit      pldtypes.HexUint64
+	dm                   *domainManager
+	name                 string
+	api                  components.DomainManagerToDomain
+	registryAddress      *pldtypes.EthAddress
+	fixedSigningIdentity string
 
 	stateLock          sync.Mutex
 	initialized        atomic.Bool
@@ -87,15 +87,15 @@ var DefaultDefaultGasLimit pldtypes.HexUint64 = 4000000 // high gas limit by def
 
 func (dm *domainManager) newDomain(name string, conf *pldconf.DomainConfig, toDomain components.DomainManagerToDomain) *domain {
 	d := &domain{
-		dm:                     dm,
-		conf:                   conf,
-		defaultGasLimit:        DefaultDefaultGasLimit,                     // can be set by config below
-		initRetry:              retry.NewRetryIndefinite(&conf.Init.Retry), // indefinite retry
-		name:                   name,
-		api:                    toDomain,
-		initDone:               make(chan struct{}),
-		registryAddress:        pldtypes.MustEthAddress(conf.RegistryAddress), // check earlier in startup
-		defaultSigningIdentity: conf.DefaultSigningIdentity,
+		dm:                   dm,
+		conf:                 conf,
+		defaultGasLimit:      DefaultDefaultGasLimit,                     // can be set by config below
+		initRetry:            retry.NewRetryIndefinite(&conf.Init.Retry), // indefinite retry
+		name:                 name,
+		api:                  toDomain,
+		initDone:             make(chan struct{}),
+		registryAddress:      pldtypes.MustEthAddress(conf.RegistryAddress), // check earlier in startup
+		fixedSigningIdentity: conf.FixedSigningIdentity,
 
 		schemasByID:        make(map[string]components.Schema),
 		schemasBySignature: make(map[string]components.Schema),
@@ -201,7 +201,7 @@ func (d *domain) init() {
 			RegistryContractAddress: d.RegistryAddress().String(),
 			ChainId:                 d.dm.ethClientFactory.ChainID(),
 			ConfigJson:              pldtypes.JSONString(d.conf.Config).String(),
-			DefaultSigningIdentity:  d.defaultSigningIdentity,
+			FixedSigningIdentity:    d.fixedSigningIdentity,
 		})
 		if err != nil {
 			return true, err
@@ -293,8 +293,8 @@ func (d *domain) Configuration() *prototk.DomainConfig {
 	return d.config
 }
 
-func (d *domain) DefaultSigningIdentity() string {
-	return d.defaultSigningIdentity
+func (d *domain) FixedSigningIdentity() string {
+	return d.fixedSigningIdentity
 }
 
 func toProtoStates(states []*pldapi.State) []*prototk.StoredState {

--- a/core/go/internal/privatetxnmgr/private_txn_mgr_test.go
+++ b/core/go/internal/privatetxnmgr/private_txn_mgr_test.go
@@ -2674,6 +2674,7 @@ func (m *dependencyMocks) mockDomain(domainAddress *pldtypes.EthAddress) {
 	m.stateStore.On("NewDomainContext", mock.Anything, m.domain, *domainAddress, mock.Anything).Return(m.domainContext).Maybe()
 	m.domainMgr.On("GetSmartContractByAddress", mock.Anything, mock.Anything, *domainAddress).Maybe().Return(m.domainSmartContract, nil)
 	m.domain.On("Configuration").Return(&prototk.DomainConfig{}).Maybe()
+	m.domain.On("DefaultSigningIdentity").Return("").Maybe()
 }
 
 // Some of the tests were getting quite verbose and was difficult to see the wood for the trees so moved a lot of the boilerplate into these utility functions

--- a/core/go/internal/privatetxnmgr/private_txn_mgr_test.go
+++ b/core/go/internal/privatetxnmgr/private_txn_mgr_test.go
@@ -2674,7 +2674,7 @@ func (m *dependencyMocks) mockDomain(domainAddress *pldtypes.EthAddress) {
 	m.stateStore.On("NewDomainContext", mock.Anything, m.domain, *domainAddress, mock.Anything).Return(m.domainContext).Maybe()
 	m.domainMgr.On("GetSmartContractByAddress", mock.Anything, mock.Anything, *domainAddress).Maybe().Return(m.domainSmartContract, nil)
 	m.domain.On("Configuration").Return(&prototk.DomainConfig{}).Maybe()
-	m.domain.On("DefaultSigningIdentity").Return("").Maybe()
+	m.domain.On("FixedSigningIdentity").Return("").Maybe()
 }
 
 // Some of the tests were getting quite verbose and was difficult to see the wood for the trees so moved a lot of the boilerplate into these utility functions

--- a/core/go/internal/privatetxnmgr/sequencer.go
+++ b/core/go/internal/privatetxnmgr/sequencer.go
@@ -180,7 +180,7 @@ func NewSequencer(
 
 	log.L(ctx).Debugf("NewSequencer for contract address %s created: %+v", newSequencer.contractAddress, newSequencer)
 
-	defaultSigner := domainAPI.Domain().DefaultSigningIdentity()
+	defaultSigner := domainAPI.Domain().FixedSigningIdentity()
 	if defaultSigner == "" {
 		// Randomly allocate a signer.
 		// TODO: rotation

--- a/core/go/internal/privatetxnmgr/sequencer.go
+++ b/core/go/internal/privatetxnmgr/sequencer.go
@@ -175,15 +175,18 @@ func NewSequencer(
 		environment: &sequencerEnvironment{
 			blockHeight: blockHeight,
 		},
-
-		// Randomly allocate a signer.
-		// TODO: rotation
-		defaultSigner:  fmt.Sprintf("domains.%s.submit.%s", contractAddress, uuid.New()),
 		newBlockEvents: make(chan int64, 10), //TODO do we want to make the buffer size configurable? Or should we put in non blocking mode? Does it matter if we miss a block?
-
 	}
 
 	log.L(ctx).Debugf("NewSequencer for contract address %s created: %+v", newSequencer.contractAddress, newSequencer)
+
+	defaultSigner := domainAPI.Domain().DefaultSigningIdentity()
+	if defaultSigner == "" {
+		// Randomly allocate a signer.
+		// TODO: rotation
+		defaultSigner = fmt.Sprintf("domains.%s.submit.%s", contractAddress, uuid.New())
+	}
+	newSequencer.defaultSigner = defaultSigner
 
 	coordinatorSelector, err := NewCoordinatorSelector(ctx, nodeName, domainAPI.ContractConfig(), *sequencerConfig)
 	if err != nil {

--- a/core/go/internal/privatetxnmgr/sequencer_test.go
+++ b/core/go/internal/privatetxnmgr/sequencer_test.go
@@ -84,7 +84,7 @@ func newSequencerForTesting(t *testing.T, ctx context.Context, domainAddress *pl
 	mocks.allComponents.On("TxManager").Return(mocks.txManager).Maybe()
 	mocks.allComponents.On("PublicTxManager").Return(mocks.pubTxManager).Maybe()
 	mocks.domainMgr.On("GetSmartContractByAddress", mock.Anything, mock.Anything, *domainAddress).Maybe().Return(mocks.domainSmartContract, nil)
-	mocks.domain.On("DefaultSigningIdentity").Return("").Maybe()
+	mocks.domain.On("FixedSigningIdentity").Return("").Maybe()
 	p, persistenceDone, err := persistence.NewUnitTestPersistence(ctx, "privatetxmgr")
 	require.NoError(t, err)
 	mocks.allComponents.On("Persistence").Return(p).Maybe()

--- a/core/go/internal/privatetxnmgr/sequencer_test.go
+++ b/core/go/internal/privatetxnmgr/sequencer_test.go
@@ -84,6 +84,7 @@ func newSequencerForTesting(t *testing.T, ctx context.Context, domainAddress *pl
 	mocks.allComponents.On("TxManager").Return(mocks.txManager).Maybe()
 	mocks.allComponents.On("PublicTxManager").Return(mocks.pubTxManager).Maybe()
 	mocks.domainMgr.On("GetSmartContractByAddress", mock.Anything, mock.Anything, *domainAddress).Maybe().Return(mocks.domainSmartContract, nil)
+	mocks.domain.On("DefaultSigningIdentity").Return("").Maybe()
 	p, persistenceDone, err := persistence.NewUnitTestPersistence(ctx, "privatetxmgr")
 	require.NoError(t, err)
 	mocks.allComponents.On("Persistence").Return(p).Maybe()

--- a/domains/noto/internal/noto/noto.go
+++ b/domains/noto/internal/noto/noto.go
@@ -100,14 +100,14 @@ var schemasJSON = mustParseSchemas(allSchemas)
 type Noto struct {
 	Callbacks plugintk.DomainCallbacks
 
-	name                   string
-	config                 types.DomainConfig
-	chainID                int64
-	defaultSigningIdentity string
-	coinSchema             *prototk.StateSchema
-	lockedCoinSchema       *prototk.StateSchema
-	dataSchema             *prototk.StateSchema
-	lockInfoSchema         *prototk.StateSchema
+	name                 string
+	config               types.DomainConfig
+	chainID              int64
+	fixedSigningIdentity string
+	coinSchema           *prototk.StateSchema
+	lockedCoinSchema     *prototk.StateSchema
+	dataSchema           *prototk.StateSchema
+	lockInfoSchema       *prototk.StateSchema
 }
 
 type NotoDeployParams struct {
@@ -299,7 +299,7 @@ func (n *Noto) ConfigureDomain(ctx context.Context, req *prototk.ConfigureDomain
 	n.name = req.Name
 	n.config = config
 	n.chainID = req.ChainId
-	n.defaultSigningIdentity = req.DefaultSigningIdentity
+	n.fixedSigningIdentity = req.FixedSigningIdentity
 
 	return &prototk.ConfigureDomainResponse{
 		DomainConfig: &prototk.DomainConfig{
@@ -410,7 +410,7 @@ func (n *Noto) PrepareDeploy(ctx context.Context, req *prototk.PrepareDeployRequ
 	var paramsJSON []byte
 	var deployDataJSON []byte
 
-	signer := n.defaultSigningIdentity
+	signer := n.fixedSigningIdentity
 	if signer == "" {
 		// Use a random key to deploy if no default signing identity is set
 		signer = fmt.Sprintf("%s.deploy.%s", n.name, uuid.New())

--- a/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteConfiguration.java
+++ b/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteConfiguration.java
@@ -65,7 +65,7 @@
  
      private String domainName;
      private long chainId;
-     private String defaultSigningIdentity;
+     private String fixedSigningIdentity;
  
      private String schemaId_AccountState_v24_10_0;
  
@@ -314,14 +314,14 @@
          return domainName;
      }
 
-     synchronized String getDefaultSigningIdentity() {
-         return defaultSigningIdentity;
+     synchronized String getFixedSigningIdentity() {
+         return fixedSigningIdentity;
      }
  
      synchronized void initFromConfig(ConfigureDomainRequest configReq) {
          this.domainName = configReq.getName();
          this.chainId = configReq.getChainId();
-         this.defaultSigningIdentity = configReq.getDefaultSigningIdentity();
+         this.fixedSigningIdentity = configReq.getFixedSigningIdentity();
      }
  
      List<String> allPenteSchemas() {

--- a/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteConfiguration.java
+++ b/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteConfiguration.java
@@ -65,6 +65,7 @@
  
      private String domainName;
      private long chainId;
+     private String defaultSigningIdentity;
  
      private String schemaId_AccountState_v24_10_0;
  
@@ -312,10 +313,15 @@
      synchronized String getDomainName() {
          return domainName;
      }
+
+     synchronized String getDefaultSigningIdentity() {
+         return defaultSigningIdentity;
+     }
  
      synchronized void initFromConfig(ConfigureDomainRequest configReq) {
          this.domainName = configReq.getName();
          this.chainId = configReq.getChainId();
+         this.defaultSigningIdentity = configReq.getDefaultSigningIdentity();
      }
  
      List<String> allPenteSchemas() {

--- a/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteDomain.java
+++ b/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteDomain.java
@@ -156,7 +156,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
                      resolvedVerifiers,
                      params.externalCallsEnabled()
              ).getBytes());
-             var signingIdentity = config.getDefaultSigningIdentity();
+             var signingIdentity = config.getFixedSigningIdentity();
              if (signingIdentity == "") {
                  signingIdentity = "%s.deploy.%s".formatted(config.getDomainName(), UUID.randomUUID().toString());
              }

--- a/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteDomain.java
+++ b/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteDomain.java
@@ -156,8 +156,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
                      resolvedVerifiers,
                      params.externalCallsEnabled()
              ).getBytes());
+             var signingIdentity = config.getDefaultSigningIdentity();
+             if (signingIdentity == "") {
+                 signingIdentity = "%s.deploy.%s".formatted(config.getDomainName(), UUID.randomUUID().toString());
+             }
              var response = PrepareDeployResponse.newBuilder().
-                     setSigner("%s.deploy.%s".formatted(config.getDomainName(), UUID.randomUUID().toString()));
+                     setSigner(signingIdentity);
              var newPrivacyGroupABIJson = config.getFactoryContractABI().getABIEntry("function", "newPrivacyGroup").toJSON(false);
              response.getTransactionBuilder().
                      setFunctionAbiJson(newPrivacyGroupABIJson).

--- a/operator/api/v1alpha1/paladindomain_types.go
+++ b/operator/api/v1alpha1/paladindomain_types.go
@@ -32,8 +32,8 @@ type PaladinDomainSpec struct {
 	// Required when Zero Knowledge Proof (ZKP) generation is being co-located with the Paladin core process
 	// for domains like Zeto.
 	AllowSigning bool `json:"allowSigning,omitempty"`
-	// The default signing identity to use for the domain - will resolve to a different signing key on each node
-	DefaultSigningIdentity string `json:"defaultSigningIdentity,omitempty"`
+	// The fixed signing identity to use for the domain - will resolve to a different signing key on each node
+	FixedSigningIdentity string `json:"fixedSigningIdentity,omitempty"`
 	// JSON configuration specific to the individual domain
 	ConfigJSON string `json:"configJSON"`
 }

--- a/operator/api/v1alpha1/paladindomain_types.go
+++ b/operator/api/v1alpha1/paladindomain_types.go
@@ -32,6 +32,8 @@ type PaladinDomainSpec struct {
 	// Required when Zero Knowledge Proof (ZKP) generation is being co-located with the Paladin core process
 	// for domains like Zeto.
 	AllowSigning bool `json:"allowSigning,omitempty"`
+	// The default signing identity to use for the domain - will resolve to a different signing key on each node
+	DefaultSigningIdentity string `json:"defaultSigningIdentity,omitempty"`
 	// JSON configuration specific to the individual domain
 	ConfigJSON string `json:"configJSON"`
 }

--- a/operator/charts/paladin-operator/values-customnet.yaml
+++ b/operator/charts/paladin-operator/values-customnet.yaml
@@ -131,8 +131,8 @@ paladinNodes:
 # Domains can be configured with a default signing identity
 domains:
   noto:
-    defaultSigningIdentity: ""
+    fixedSigningIdentity: ""
   pente:
-    defaultSigningIdentity: ""
+    fixedSigningIdentity: ""
   zeto:
-    defaultSigningIdentity: ""
+    fixedSigningIdentity: ""

--- a/operator/charts/paladin-operator/values-customnet.yaml
+++ b/operator/charts/paladin-operator/values-customnet.yaml
@@ -127,3 +127,12 @@ paladinNodes:
       registryAdminNode: bank  # The admin node that manages the registry
       registryAdminKey: registry.operator
       registry: evm-registry
+
+# Domains can be configured with a default signing identity
+domains:
+  noto:
+    defaultSigningIdentity: ""
+  pente:
+    defaultSigningIdentity: ""
+  zeto:
+    defaultSigningIdentity: ""

--- a/operator/charts/paladin-operator/values.yaml
+++ b/operator/charts/paladin-operator/values.yaml
@@ -145,3 +145,12 @@ besu:
   labels:
     app: besu
   baseNodePort: 31545
+
+# Domains can be configured with a default signing identity
+domains:
+  noto:
+    defaultSigningIdentity: ""
+  pente:
+    defaultSigningIdentity: ""
+  zeto:
+    defaultSigningIdentity: ""

--- a/operator/charts/paladin-operator/values.yaml
+++ b/operator/charts/paladin-operator/values.yaml
@@ -149,8 +149,8 @@ besu:
 # Domains can be configured with a default signing identity
 domains:
   noto:
-    defaultSigningIdentity: ""
+    fixedSigningIdentity: ""
   pente:
-    defaultSigningIdentity: ""
+    fixedSigningIdentity: ""
   zeto:
-    defaultSigningIdentity: ""
+    fixedSigningIdentity: ""

--- a/operator/config/crd/bases/core.paladin.io_paladindomains.yaml
+++ b/operator/config/crd/bases/core.paladin.io_paladindomains.yaml
@@ -63,9 +63,9 @@ spec:
               configJSON:
                 description: JSON configuration specific to the individual domain
                 type: string
-              defaultSigningIdentity:
-                description: The default signing identity to use for the domain -
-                  will resolve to a different signing key on each node
+              fixedSigningIdentity:
+                description: The fixed signing identity to use for the domain - will
+                  resolve to a different signing key on each node
                 type: string
               plugin:
                 description: Details of the plugin to load for the domain

--- a/operator/config/crd/bases/core.paladin.io_paladindomains.yaml
+++ b/operator/config/crd/bases/core.paladin.io_paladindomains.yaml
@@ -63,6 +63,10 @@ spec:
               configJSON:
                 description: JSON configuration specific to the individual domain
                 type: string
+              defaultSigningIdentity:
+                description: The default signing identity to use for the domain -
+                  will resolve to a different signing key on each node
+                type: string
               plugin:
                 description: Details of the plugin to load for the domain
                 properties:

--- a/operator/contractpkg/main.go
+++ b/operator/contractpkg/main.go
@@ -261,6 +261,8 @@ func template() error {
 			n := fmt.Sprintf(".Values.smartContractsReferences.%sFactory", domain.Name)
 			domain.Spec.RegistryAddress = fmt.Sprintf("{{ %s.address }}", n)
 			domain.Spec.SmartContractDeployment = fmt.Sprintf("{{ %s.deployment }}", n)
+
+			domain.Spec.DefaultSigningIdentity = fmt.Sprintf("{{ .Values.domains.%s.defaultSigningIdentity }}", domain.Name)
 			if content, err = yaml.Marshal(domain); err != nil {
 				return fmt.Errorf("error marshalling content: %v", err)
 			}

--- a/operator/contractpkg/main.go
+++ b/operator/contractpkg/main.go
@@ -262,7 +262,7 @@ func template() error {
 			domain.Spec.RegistryAddress = fmt.Sprintf("{{ %s.address }}", n)
 			domain.Spec.SmartContractDeployment = fmt.Sprintf("{{ %s.deployment }}", n)
 
-			domain.Spec.DefaultSigningIdentity = fmt.Sprintf("{{ .Values.domains.%s.defaultSigningIdentity }}", domain.Name)
+			domain.Spec.FixedSigningIdentity = fmt.Sprintf("{{ .Values.domains.%s.fixedSigningIdentity }}", domain.Name)
 			if content, err = yaml.Marshal(domain); err != nil {
 				return fmt.Errorf("error marshalling content: %v", err)
 			}

--- a/operator/internal/controller/paladin_controller.go
+++ b/operator/internal/controller/paladin_controller.go
@@ -1018,11 +1018,11 @@ func (r *PaladinReconciler) generatePaladinDomains(ctx context.Context, node *co
 		// or wholely defined by reference to the CR attached.
 		// We do not attempt to merge
 		pldConf.Domains[domain.Name] = &pldconf.DomainConfig{
-			Plugin:                 r.mapPluginConfig(domain.Spec.Plugin),
-			Config:                 domainConf,
-			RegistryAddress:        domain.Status.RegistryAddress,
-			AllowSigning:           domain.Spec.AllowSigning,
-			DefaultSigningIdentity: domain.Spec.DefaultSigningIdentity,
+			Plugin:               r.mapPluginConfig(domain.Spec.Plugin),
+			Config:               domainConf,
+			RegistryAddress:      domain.Status.RegistryAddress,
+			AllowSigning:         domain.Spec.AllowSigning,
+			FixedSigningIdentity: domain.Spec.FixedSigningIdentity,
 		}
 	}
 

--- a/operator/internal/controller/paladin_controller.go
+++ b/operator/internal/controller/paladin_controller.go
@@ -1018,10 +1018,11 @@ func (r *PaladinReconciler) generatePaladinDomains(ctx context.Context, node *co
 		// or wholely defined by reference to the CR attached.
 		// We do not attempt to merge
 		pldConf.Domains[domain.Name] = &pldconf.DomainConfig{
-			Plugin:          r.mapPluginConfig(domain.Spec.Plugin),
-			Config:          domainConf,
-			RegistryAddress: domain.Status.RegistryAddress,
-			AllowSigning:    domain.Spec.AllowSigning,
+			Plugin:                 r.mapPluginConfig(domain.Spec.Plugin),
+			Config:                 domainConf,
+			RegistryAddress:        domain.Status.RegistryAddress,
+			AllowSigning:           domain.Spec.AllowSigning,
+			DefaultSigningIdentity: domain.Spec.DefaultSigningIdentity,
 		}
 	}
 

--- a/toolkit/proto/protos/to_domain.proto
+++ b/toolkit/proto/protos/to_domain.proto
@@ -28,6 +28,7 @@ message ConfigureDomainRequest {
   string config_json= 2; // The block of config supplied in the configuration for the domain by the Paladin administrator (converted from YAML to JSON for domain)
   string registry_contract_address = 3;  // The address of the registry smart contract
   int64 chain_id = 4; // The chain_id of the underlying base ledger on which all smart contracts are deployed
+  string default_signing_identity = 5; // The identity to use for signing public transactions submitted to the underlying base ledger
 }
 
 message ConfigureDomainResponse {

--- a/toolkit/proto/protos/to_domain.proto
+++ b/toolkit/proto/protos/to_domain.proto
@@ -28,7 +28,7 @@ message ConfigureDomainRequest {
   string config_json= 2; // The block of config supplied in the configuration for the domain by the Paladin administrator (converted from YAML to JSON for domain)
   string registry_contract_address = 3;  // The address of the registry smart contract
   int64 chain_id = 4; // The chain_id of the underlying base ledger on which all smart contracts are deployed
-  string default_signing_identity = 5; // The identity to use for signing public transactions submitted to the underlying base ledger
+  string fixed_signing_identity = 5; // The identity to use for signing public transactions submitted to the underlying base ledger
 }
 
 message ConfigureDomainResponse {


### PR DESCRIPTION
Provide the option for a domain to be configured with a fixed identity. When this is set, all public transactions that result from domain actions that would normally use a randomly generated identity to sign a public transaction will use this fixed identity instead.

It can be configured this via the helm charts by adding the following section to the values file:
```yaml
domains:
  noto:
    fixedSigningIdentity: noto.default # or any identity you choose
  pente:
    fixedSigningIdentity: ...
  zeto:
   fixedSigningIdentity: ...
 ```
Noting that:
* The fixed signing identity will be resolve to a different signing address on each Paladin node (e.g. `noto.fixed@node1` will resolve to a different signing address than `noto.fixed@node2`)
* To know which addresses to fund ahead of using the domains you should resolve the fixed identities against all nodes e.g.
```bash
curl --location '127.0.0.1:31548' --header 'Content-Type: application/json' --data-raw '{
      "jsonrpc": "2.0",
      "id": "1",
      "method": "ptx_resolveVerifier",
      "params": ["noto.fixed@node1", "ecdsa:secp256k1", "eth_address"]
    }'
```
* You may choose to use the same fixed identity for all three domains to minimise how many addresses you need to fund
* Some public transactions are signed by an identity specified in the from field of the private transaction that created them (e.g. a Noto mint or transfer) - the behaviour of these cannot and has not changed. Resolving these identities and funding the resolved address before using them gives the cleanest experience here.