### PR TITLE
Fix evm-registry label

### DIFF
--- a/doc-site/docs/getting-started/installation-advanced.md
+++ b/doc-site/docs/getting-started/installation-advanced.md
@@ -56,7 +56,7 @@ paladinNodes:
       - zeto
       - pente
     registries:
-      - evm-reg
+      - evm-registry
     transports:
       - name: grpc
         plugin:
@@ -250,7 +250,7 @@ paladinNodes:
     - zeto
     - pente
   registries:
-    - evm-reg
+    - evm-registry
   transports:
     - name: grpc
       plugin:

--- a/operator/charts/paladin-operator/tests/attach_test.yaml
+++ b/operator/charts/paladin-operator/tests/attach_test.yaml
@@ -36,7 +36,7 @@ tests:
             - zeto
             - pente
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -273,7 +273,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -349,7 +349,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -425,7 +425,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -514,7 +514,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -565,7 +565,7 @@ tests:
           domains:
             - zeto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -657,7 +657,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -746,7 +746,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -826,7 +826,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -919,7 +919,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -1042,7 +1042,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:

--- a/operator/charts/paladin-operator/tests/customnet_test.yaml
+++ b/operator/charts/paladin-operator/tests/customnet_test.yaml
@@ -27,7 +27,7 @@ tests:
             - zeto
             - pente
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -113,7 +113,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -184,7 +184,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -254,7 +254,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -324,7 +324,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -406,7 +406,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -457,7 +457,7 @@ tests:
           domains:
             - zeto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -538,7 +538,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -631,7 +631,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -754,7 +754,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -851,7 +851,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:

--- a/operator/charts/paladin-operator/tests/modes_test.yaml
+++ b/operator/charts/paladin-operator/tests/modes_test.yaml
@@ -228,7 +228,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -297,7 +297,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -361,7 +361,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -430,7 +430,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:
@@ -499,7 +499,7 @@ tests:
           domains:
             - noto
           registries:
-            - evm-reg
+            - evm-registry
           transports:
             - name: grpc
               plugin:

--- a/operator/charts/paladin-operator/values-customnet.yaml
+++ b/operator/charts/paladin-operator/values-customnet.yaml
@@ -53,7 +53,7 @@ paladinNodes:
     # ======== Registries ========
     # Registry names this node interacts with. Must match labels on registry CRs.
     registries:
-      - evm-reg
+      - evm-registry
 
     # ======== Transports ========
     transports:


### PR DESCRIPTION
The label was inconsistent which resulted in the deployed nodes having invalid registries