### PR TITLE
Example polling timeouts

### DIFF
--- a/core/go/build.gradle
+++ b/core/go/build.gradle
@@ -348,7 +348,7 @@ task unitTestPostgres(type: UnitTests, dependsOn: [
     mustRunAfter 'unitTestSQLite' // these tests cannot run concurrently
 }
 
-task componentTestPostgres(type: ComponentTest, dependsOn: [
+task componentTestSQLite(type: ComponentTest, dependsOn: [
         makeMocks,
         ':testinfra:startTestInfra',
         setupCoverage,
@@ -360,14 +360,14 @@ task componentTestPostgres(type: ComponentTest, dependsOn: [
 
 }
 
-task componentTestWithGasPostgres(type: GasComponentTest, dependsOn: [
+task componentTestWithGasSQLite(type: GasComponentTest, dependsOn: [
         makeMocks,
         ':testinfra:startTestInfra',
         setupCoverage,
         goGet,
         copyContracts, // Ensure this task depends on copying the test contracts
     ]) {
-    mustRunAfter 'componentTestPostgres' // these tests cannot run concurrently
+    mustRunAfter 'componentTestSQLite' // these tests cannot run concurrently
     environment 'BESU_PORT', '8555' // Use gas-priced Besu port
 }
 
@@ -375,8 +375,8 @@ task buildCoverageTxt(type: Exec, dependsOn: [
         protoc,
         unitTestSQLite,
         unitTestPostgres,
-        componentTestPostgres,
-        componentTestWithGasPostgres
+        componentTestSQLite,
+        componentTestWithGasSQLite
     ]) {
     inputs.files(fileTree(project.mkdir('coverage')) {
         include "covcounters.*"

--- a/doc-site/docs/guides/l1-and-l2-chains.md
+++ b/doc-site/docs/guides/l1-and-l2-chains.md
@@ -325,21 +325,9 @@ The gas price cache provides the most benefit when:
 
 ## Examples
 
-The examples deploy contracts and invoke transactions before waiting for receipts to confirm they have succeesfully been mined. The default wait time in the Paladin Node SDK is 5 seconds. For many
-public chains this will need increasing to a suitable value, based on the block period of the chain. The following is an example of a modification to a `waitForReceipt()` call:
+The examples deploy contracts and invoke transactions before waiting for receipts to confirm they have succeesfully been mined. The default wait time in the Paladin examples is 30 seconds. This should be sufficient for most public chains, but it can be increased by modifying (`DEFAULT_POLL_TIMEOUT` in the examples config file)[https://github.com/LF-Decentralized-Trust-labs/paladin/blob/main/examples/common/src/config.ts].
 
-```
-const cashToken = await notoFactory
-    .newNoto(verifierNode1, {
-      name: "NOTO",
-      symbol: "NOTO",
-      notary: verifierNode1,
-      notaryMode: "basic",
-    })
-    .waitForDeploy(20000);  // Allow 20 seconds for the contract deploy to complete
-```
-
-Note: the example code won't wait the full 20 seconds if the contract deploy completes early, so setting a large value won't increase the example run time unncessarily.
+Note: the example code won't wait the full polling period if the contract deploy completes early, so setting a large value won't increase the example run time unncessarily.
 
 ## Funding signing addresses with gas tokens e.g. ETH
 
@@ -349,7 +337,3 @@ preventing transactions on the base ledger from being correlated with each other
 A Paladin node can be configured to use predetermined signing keys, for example by using a pre-configured HD wallet mnemonic from which all signing keys are derived.
 
 It is necessary to ensure the addresses used by Paladin have sufficient gas tokens to fund transactions.
-
-### Automatic funding of addresses
-
-TBC

--- a/examples/bond/src/index.ts
+++ b/examples/bond/src/index.ts
@@ -19,7 +19,13 @@ import PaladinClient, {
   PenteFactory,
   TransactionType,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
-import { checkDeploy, checkReceipt, DEFAULT_POLL_TIMEOUT, LONG_POLL_TIMEOUT } from "paladin-example-common";
+import {
+  checkDeploy,
+  checkReceipt,
+  DEFAULT_POLL_TIMEOUT,
+  LONG_POLL_TIMEOUT,
+  POLL_INTERVAL,
+} from "paladin-example-common";
 import atomJson from "./abis/Atom.json";
 import atomFactoryJson from "./abis/AtomFactory.json";
 import bondTrackerPublicJson from "./abis/BondTrackerPublic.json";
@@ -412,22 +418,22 @@ async function main(): Promise<boolean> {
   let finalBondBalanceCustodian: NotoBalanceOfResult | undefined;
   const startTime = Date.now();
   while (true) {
-  // Get final balances after the bond distribution
-  finalCashBalanceInvestor = await notoCash
-    .using(paladin3)
-    .balanceOf(investor, { account: investor.lookup });
+    // Get final balances after the bond distribution
+    finalCashBalanceInvestor = await notoCash
+      .using(paladin3)
+      .balanceOf(investor, { account: investor.lookup });
 
-  finalBondBalanceInvestor = await notoBond
-    .using(paladin3)
-    .balanceOf(investor, { account: investor.lookup });
+    finalBondBalanceInvestor = await notoBond
+      .using(paladin3)
+      .balanceOf(investor, { account: investor.lookup });
 
-  finalCashBalanceCustodian = await notoCash
-    .using(paladin2)
-    .balanceOf(bondCustodian, { account: bondCustodian.lookup });
+    finalCashBalanceCustodian = await notoCash
+      .using(paladin2)
+      .balanceOf(bondCustodian, { account: bondCustodian.lookup });
 
     finalBondBalanceCustodian = await notoBond
-    .using(paladin2)
-    .balanceOf(bondCustodian, { account: bondCustodian.lookup });
+      .using(paladin2)
+      .balanceOf(bondCustodian, { account: bondCustodian.lookup });
 
     if (finalCashBalanceInvestor?.totalBalance !== "0" &&
       finalBondBalanceInvestor?.totalBalance !== "0" &&
@@ -440,6 +446,8 @@ async function main(): Promise<boolean> {
       logger.error(`Failed to get final balances after ${LONG_POLL_TIMEOUT / 1000} seconds`);
       return false;
     }
+
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
   }
 
       // Save contract data to file for later use

--- a/examples/bond/src/index.ts
+++ b/examples/bond/src/index.ts
@@ -19,7 +19,7 @@ import PaladinClient, {
   PenteFactory,
   TransactionType,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
-import { checkDeploy, checkReceipt } from "paladin-example-common";
+import { checkDeploy, checkReceipt, DEFAULT_POLL_TIMEOUT, LONG_POLL_TIMEOUT } from "paladin-example-common";
 import atomJson from "./abis/Atom.json";
 import atomFactoryJson from "./abis/AtomFactory.json";
 import bondTrackerPublicJson from "./abis/BondTrackerPublic.json";
@@ -60,7 +60,7 @@ async function main(): Promise<boolean> {
       notary: cashIssuer,
       notaryMode: "basic",
     })
-    .waitForDeploy();
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(notoCash)) return false;
 
   // Issue some cash
@@ -71,7 +71,7 @@ async function main(): Promise<boolean> {
       amount: 100000,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   let balanceInvestor = await notoCash.balanceOf(cashIssuer, {
@@ -90,7 +90,7 @@ async function main(): Promise<boolean> {
       evmVersion: "shanghai",
       externalCallsEnabled: true,
     })
-    .waitForDeploy();
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(issuerCustodianGroup)) return false;
 
   // Deploy the public bond tracker on the base ledger (controlled by the privacy group)
@@ -111,7 +111,7 @@ async function main(): Promise<boolean> {
       faceValue_: 1,
     },
   });
-  receipt = await paladin1.pollForReceipt(txID, 10000);
+  receipt = await paladin1.pollForReceipt(txID, DEFAULT_POLL_TIMEOUT);
   if (receipt?.contractAddress === undefined) {
     logger.error("Failed!");
     return false;
@@ -158,7 +158,7 @@ async function main(): Promise<boolean> {
     from: bondIssuer.lookup,
     data: {},
   });
-  receipt = await paladin1.pollForReceipt(txID, 10000);
+  receipt = await paladin1.pollForReceipt(txID, DEFAULT_POLL_TIMEOUT);
   if (receipt?.contractAddress === undefined) {
     logger.error("Failed!");
     return false;
@@ -174,7 +174,7 @@ async function main(): Promise<boolean> {
       amount: 1000,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
   let balanceCustodian = await notoBond.balanceOf(bondIssuer, {
     account: bondCustodian.lookup,
@@ -191,7 +191,7 @@ async function main(): Promise<boolean> {
       discountPrice: 1,
       minimumDenomination: 1,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Add allowed investors
@@ -199,7 +199,7 @@ async function main(): Promise<boolean> {
   receipt = await investorList
     .using(paladin2)
     .addInvestor(bondCustodian, { addr: await investor.address() })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Create a Pente privacy group between the bond investor and bond custodian
@@ -211,7 +211,7 @@ async function main(): Promise<boolean> {
       evmVersion: "shanghai",
       externalCallsEnabled: true,
     })
-    .waitForDeploy();
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (investorCustodianGroup === undefined) {
     logger.error("Failed!");
     return false;
@@ -240,7 +240,7 @@ async function main(): Promise<boolean> {
       amount: 100,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
   receipt = await paladin3.ptx.getTransactionReceiptFull(receipt.id);
   let domainReceipt = receipt?.domainReceipt as INotoDomainReceipt | undefined;
@@ -266,7 +266,7 @@ async function main(): Promise<boolean> {
       recipients: [{ to: bondCustodian, amount: 100 }],
       data: "0x",
     })
-    .waitForReceipt(5000, true);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT, true);
   if (!checkReceipt(receipt)) return false;
   domainReceipt = receipt?.domainReceipt as INotoDomainReceipt | undefined;
   const cashUnlockParams = domainReceipt?.lockInfo?.unlockParams;
@@ -284,7 +284,7 @@ async function main(): Promise<boolean> {
       amount: 100,
       data: "0x",
     })
-    .waitForReceipt(5000, true);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT, true);
   if (!checkReceipt(receipt)) return false;
   domainReceipt = receipt?.domainReceipt as INotoDomainReceipt | undefined;
   const bondLockId = domainReceipt?.lockInfo?.lockId;
@@ -309,7 +309,7 @@ async function main(): Promise<boolean> {
       recipients: [{ to: investor, amount: 100 }],
       data: "0x",
     })
-    .waitForReceipt(5000, true);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT, true);
   if (!checkReceipt(receipt)) return false;
   domainReceipt = receipt?.domainReceipt as INotoDomainReceipt | undefined;
   const assetUnlockParams = domainReceipt?.lockInfo?.unlockParams;
@@ -327,7 +327,7 @@ async function main(): Promise<boolean> {
       to: notoCash.address,
       encodedCall: cashUnlockCall,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Pass the prepared bond transfer to the subscription contract
@@ -338,7 +338,7 @@ async function main(): Promise<boolean> {
       to: notoBond.address,
       encodedCall: assetUnlockCall,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Prepare bond distribution (initializes atomic swap of payment and bond units)
@@ -346,7 +346,7 @@ async function main(): Promise<boolean> {
   receipt = await bondSubscription
     .using(paladin2)
     .distribute(bondCustodian)
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Extract the address of the created Atom
@@ -375,7 +375,7 @@ async function main(): Promise<boolean> {
       delegate: atomAddress,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Approve the bond transfer
@@ -388,7 +388,7 @@ async function main(): Promise<boolean> {
       delegate: atomAddress,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Execute the atomic transfer
@@ -401,7 +401,7 @@ async function main(): Promise<boolean> {
     to: atomAddress,
     data: {},
   });
-  receipt = await paladin2.pollForReceipt(txID, 10000);
+  receipt = await paladin2.pollForReceipt(txID, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
 
@@ -435,10 +435,9 @@ async function main(): Promise<boolean> {
       finalBondBalanceCustodian?.totalBalance !== "0") {
       break;
     }
-    await new Promise(resolve => setTimeout(resolve, 1000));
 
-    if (Date.now() - startTime > 60000) {
-      logger.error("Failed to get final balances after 60 seconds");
+    if (Date.now() - startTime > LONG_POLL_TIMEOUT) {
+      logger.error(`Failed to get final balances after ${LONG_POLL_TIMEOUT / 1000} seconds`);
       return false;
     }
   }

--- a/examples/common/src/config.ts
+++ b/examples/common/src/config.ts
@@ -6,6 +6,7 @@ import path from "path";
 
 export const DEFAULT_POLL_TIMEOUT = 30000;
 export const LONG_POLL_TIMEOUT = 120000;
+export const POLL_INTERVAL = 1000;
 
 /**
  * Defines the connectivity information for a single network node in JSON format.

--- a/examples/common/src/config.ts
+++ b/examples/common/src/config.ts
@@ -3,6 +3,10 @@ import https from "https";
 import fs from "fs";
 import path from "path";
 
+
+export const DEFAULT_POLL_TIMEOUT = 30000;
+export const LONG_POLL_TIMEOUT = 120000;
+
 /**
  * Defines the connectivity information for a single network node in JSON format.
  */

--- a/examples/event-listener/src/index.ts
+++ b/examples/event-listener/src/index.ts
@@ -19,7 +19,7 @@ import PaladinClient, {
   TransactionType,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
 import { nanoid } from "nanoid";
-import { checkDeploy } from "paladin-example-common";
+import { checkDeploy, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 import helloWorldJson from "./abis/HelloWorld.json";
 import * as fs from 'fs';
 import * as path from 'path';
@@ -58,7 +58,7 @@ async function main(): Promise<boolean> {
     bytecode: helloWorldJson.bytecode,
     from: verifierNode1.lookup,
   });
-  const receipt = await deploy.waitForReceipt(10000);
+  const receipt = await deploy.waitForReceipt(DEFAULT_POLL_TIMEOUT);
   const contractAddress = await deploy.waitForDeploy();
   if (!receipt || !contractAddress) {
     logger.error("Failed to deploy the contract. No address returned.");
@@ -204,14 +204,13 @@ async function main(): Promise<boolean> {
   // Wait for event data to be properly captured
   logger.log("Waiting for event data to be captured...");
   const startTime = Date.now();
-  const maxWaitTime = 60000; // Reduced to 30 seconds
   
   while (!receivedEventData || !receivedReceiptId) {
     await new Promise((resolve) => setTimeout(resolve, 500)); // Reduced polling interval
     
-    // If maxWaitTime passed from the beginning of the loop then fail the test
-    if (Date.now() - startTime > maxWaitTime) {
-      logger.error(`Failed to capture event data after ${maxWaitTime/1000} seconds`);
+    // If DEFAULT_POLL_TIMEOUT passed from the beginning of the loop then fail the test
+    if (Date.now() - startTime > DEFAULT_POLL_TIMEOUT) {
+      logger.error(`Failed to capture event data after ${DEFAULT_POLL_TIMEOUT/1000} seconds`);
       logger.error(`received: ${received}, receivedEventData: ${!!receivedEventData}, receivedReceiptId: ${!!receivedReceiptId}`);
       return false;
     }

--- a/examples/event-listener/src/tests/data-persistence.ts
+++ b/examples/event-listener/src/tests/data-persistence.ts
@@ -13,14 +13,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import PaladinClient, {
-  PaladinVerifier,
   PenteFactory,
   TransactionType,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
 import * as fs from 'fs';
 import * as path from 'path';
 import helloWorldJson from "../abis/HelloWorld.json";
-import { nodeConnections } from "paladin-example-common";
+import { nodeConnections, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 
 const logger = console;
 
@@ -319,11 +318,8 @@ async function main(): Promise<boolean> {
 
     logger.log(`STEP 8: Test transaction sent with ID: ${txId}`);
 
-    // Wait a moment for the transaction to be processed
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
     // Try to get the transaction receipt
-    const receipt = await paladin.pollForReceipt(txId, 10000);
+    const receipt = await paladin.pollForReceipt(txId, DEFAULT_POLL_TIMEOUT);
     if (!receipt) {
       logger.error("STEP 8: Failed to get test transaction receipt!");
       return false;

--- a/examples/helloworld/src/index.ts
+++ b/examples/helloworld/src/index.ts
@@ -18,7 +18,7 @@ import PaladinClient, {
 import helloWorldJson from "./abis/HelloWorld.json";
 import * as fs from 'fs';
 import * as path from 'path';
-import { nodeConnections } from "paladin-example-common";
+import { nodeConnections, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 
 const logger = console;
 
@@ -46,7 +46,7 @@ async function main(): Promise<boolean> {
   });
 
   // Wait for the deployment receipt
-  const deploymentReceipt = await paladin.pollForReceipt(deploymentTxID, 10000, true);
+  const deploymentReceipt = await paladin.pollForReceipt(deploymentTxID, DEFAULT_POLL_TIMEOUT, true);
   if (!deploymentReceipt?.contractAddress) {
     logger.error("STEP 1: Deployment failed!");
     return false;
@@ -74,7 +74,7 @@ async function main(): Promise<boolean> {
   }
 
   // Wait for the function call receipt
-  const functionReceipt = await paladin.pollForReceipt(sayHelloTxID, 10000, true);
+  const functionReceipt = await paladin.pollForReceipt(sayHelloTxID, DEFAULT_POLL_TIMEOUT, true);
   if (!functionReceipt?.transactionHash) {
     logger.error("STEP 2: Receipt retrieval failed!");
     return false;

--- a/examples/helloworld/src/tests/data-persistence.ts
+++ b/examples/helloworld/src/tests/data-persistence.ts
@@ -16,7 +16,7 @@ import PaladinClient from "@lfdecentralizedtrust-labs/paladin-sdk";
 import helloWorldJson from "../abis/HelloWorld.json";
 import * as fs from 'fs';
 import * as path from 'path';
-import { nodeConnections } from "paladin-example-common";
+import { DEFAULT_POLL_TIMEOUT, nodeConnections } from "paladin-example-common";
 
 const logger = console;
 
@@ -171,7 +171,7 @@ async function main(): Promise<boolean> {
       }
 
       // Wait for the function call receipt
-      const functionReceipt = await paladin.pollForReceipt(sayHelloTxID, 10000, true);
+      const functionReceipt = await paladin.pollForReceipt(sayHelloTxID, DEFAULT_POLL_TIMEOUT, true);
       if (!functionReceipt?.transactionHash) {
         logger.error("STEP 6: Receipt retrieval failed!");
         return false;

--- a/examples/notarized-tokens/src/index.ts
+++ b/examples/notarized-tokens/src/index.ts
@@ -18,7 +18,7 @@ import PaladinClient, {
 import * as fs from 'fs';
 import * as path from 'path';
 import { ContractData } from "./tests/data-persistence";
-import { nodeConnections } from "paladin-example-common";
+import { nodeConnections, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 import assert from "assert";
 
 const logger = console;
@@ -69,7 +69,7 @@ async function main(): Promise<boolean> {
       amount: mintAmount,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!mintReceipt) {
     logger.error("Failed to mint cash tokens!");
     return false;
@@ -111,7 +111,7 @@ async function main(): Promise<boolean> {
       amount: transferToNode2Amount,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!transferToNode2) {
     logger.error("Failed to transfer cash to Node2!");
     return false;
@@ -148,7 +148,7 @@ async function main(): Promise<boolean> {
       amount: transferToNode3Amount,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!transferToNode3) {
     logger.error("Failed to transfer cash to Node3!");
     return false;

--- a/examples/notarized-tokens/src/tests/data-persistence.ts
+++ b/examples/notarized-tokens/src/tests/data-persistence.ts
@@ -17,7 +17,7 @@ import PaladinClient, {
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
 import * as fs from 'fs';
 import * as path from 'path';
-import { nodeConnections } from "paladin-example-common";
+import { nodeConnections, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 
 const logger = console;
 
@@ -193,7 +193,7 @@ async function main(): Promise<boolean> {
         amount: testTransferAmount,
         data: "0x",
       })
-      .waitForReceipt(10000);
+      .waitForReceipt(DEFAULT_POLL_TIMEOUT);
 
     if (!testTransferReceipt?.transactionHash) {
       logger.error("STEP 4: Test transfer failed!");

--- a/examples/privacy-storage/src/index.ts
+++ b/examples/privacy-storage/src/index.ts
@@ -15,7 +15,7 @@
 import PaladinClient, {
   PenteFactory,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
-import { checkDeploy } from "paladin-example-common";
+import { checkDeploy, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 import storageJson from "./abis/Storage.json";
 import { PrivateStorage } from "./helpers/storage";
 import * as fs from 'fs';
@@ -78,7 +78,7 @@ async function main(): Promise<boolean> {
     from: verifierNode1.lookup,
     function: "store",
     data: { num: valueToStore },
-  }).waitForReceipt(10000);
+  }).waitForReceipt(DEFAULT_POLL_TIMEOUT);
   
   // Validate store transaction was successful
   if (!storeReceipt?.success) {

--- a/examples/privacy-storage/src/tests/data-persistence.ts
+++ b/examples/privacy-storage/src/tests/data-persistence.ts
@@ -15,8 +15,7 @@
 import PaladinClient, {
   PenteFactory,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
-import { checkDeploy } from "paladin-example-common";
-import storageJson from "../abis/Storage.json";
+import { DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 import { PrivateStorage } from "../helpers/storage";
 import * as fs from 'fs';
 import * as path from 'path';
@@ -195,7 +194,7 @@ async function main(): Promise<boolean> {
       from: verifierNode1.lookup,
       function: "store",
       data: { num: newValueToStore },
-    }).waitForReceipt(10000);
+    }).waitForReceipt(DEFAULT_POLL_TIMEOUT);
 
     if (!storeReceipt?.transactionHash) {
       logger.error("STEP 7: Function call failed!");
@@ -255,7 +254,7 @@ async function main(): Promise<boolean> {
       from: verifierNode1.lookup,
       function: "store",
       data: { num: contractData.storedValue },
-    }).waitForReceipt(10000);
+    }).waitForReceipt(DEFAULT_POLL_TIMEOUT);
 
     if (!restoreReceipt?.transactionHash) {
       logger.error("STEP 8: Function call failed!");

--- a/examples/private-stablecoin/src/index.ts
+++ b/examples/private-stablecoin/src/index.ts
@@ -19,7 +19,7 @@ import PaladinClient, {
   algorithmZetoSnarkBJJ,
   IDEN3_PUBKEY_BABYJUBJUB_COMPRESSED_0X,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
-import { checkDeploy, checkReceipt } from "paladin-example-common";
+import { checkDeploy, checkReceipt, DEFAULT_POLL_TIMEOUT, LONG_POLL_TIMEOUT } from "paladin-example-common";
 import erc20Abi from "./zeto-abis/SampleERC20.json";
 import kycAbi from "./zeto-abis/IZetoKyc.json";
 import { buildBabyjub } from "circomlibjs";
@@ -78,7 +78,7 @@ async function deployERC20(
     abi: erc20Abi.abi,
     bytecode: erc20Abi.bytecode,
   });
-  const result = await paladin.pollForReceipt(txId, 10000);
+  const result = await paladin.pollForReceipt(txId, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(result)) {
     throw new Error("Failed to deploy ERC20 token");
   }
@@ -103,7 +103,7 @@ async function mintERC20(
     function: "mint",
     abi: erc20Abi.abi,
   });
-  const result = await paladin.pollForReceipt(txId, 10000);
+  const result = await paladin.pollForReceipt(txId, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(result)) {
     throw new Error("Failed to mint ERC20 tokens");
   }
@@ -124,7 +124,7 @@ async function approveERC20(
     from: from.lookup,
     data: { value: amount, spender },
   });
-  const result = await paladin.pollForReceipt(txId, 10000);
+  const result = await paladin.pollForReceipt(txId, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(result)) {
     throw new Error("Failed to approve ERC20 transfer");
   }
@@ -218,7 +218,7 @@ async function main(): Promise<boolean> {
     .setERC20(financialInstitution, {
       erc20: publicStablecoinAddress,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(setERC20Receipt)) return false;
   logger.log("     ✓ ERC20 connected to Zeto contract\n");
 
@@ -241,7 +241,7 @@ async function main(): Promise<boolean> {
     function: "register",
     abi: kycAbi.abi,
   });
-  let kycReceipt = await paladin1.pollForReceipt(kycTxId, 10000);
+  let kycReceipt = await paladin1.pollForReceipt(kycTxId, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(kycReceipt)) return false;
   logger.log("     ✓ Financial Institution registered for KYC");
 
@@ -259,7 +259,7 @@ async function main(): Promise<boolean> {
     function: "register",
     abi: kycAbi.abi,
   });
-  kycReceipt = await paladin1.pollForReceipt(kycTxId, 10000);
+  kycReceipt = await paladin1.pollForReceipt(kycTxId, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(kycReceipt)) return false;
   logger.log("     ✓ Client A registered for KYC");
 
@@ -277,7 +277,7 @@ async function main(): Promise<boolean> {
     function: "register",
     abi: kycAbi.abi,
   });
-  kycReceipt = await paladin1.pollForReceipt(kycTxId, 10000);
+  kycReceipt = await paladin1.pollForReceipt(kycTxId, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(kycReceipt)) return false;
   logger.log("     ✓ Client B registered for KYC\n");
 
@@ -341,7 +341,7 @@ async function main(): Promise<boolean> {
     .deposit(clientA, {
       amount: 75000,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(depositReceipt)) return false;
   logger.log(
     "     ✓ Deposit successful - public tokens converted to private tokens"
@@ -380,7 +380,7 @@ async function main(): Promise<boolean> {
         },
       ],
     })
-    .waitForReceipt(30000); // Wait up to 30 seconds for transfer to give less powerful laptops time to generate ZK proof
+    .waitForReceipt(LONG_POLL_TIMEOUT); // Wait longer for transfer to give less powerful laptops time to generate ZK proof
   if (!checkReceipt(transferReceipt)) return false;
   logger.log("     ✓ Private transfer successful");
   logger.log("     ✓ Transfer amount and parties remain private");
@@ -414,7 +414,7 @@ async function main(): Promise<boolean> {
     .withdraw(clientB, {
       amount: 15000, // Withdraw 15,000 tokens
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(withdrawReceipt)) return false;
   logger.log(
     "     ✓ Withdrawal successful - private tokens converted back to public"

--- a/examples/public-storage/src/index.ts
+++ b/examples/public-storage/src/index.ts
@@ -18,7 +18,7 @@ import PaladinClient, {
 import storageJson from "./abis/Storage.json";
 import * as fs from 'fs';
 import * as path from 'path';
-import { nodeConnections } from "paladin-example-common";
+import { nodeConnections, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 
 const logger = console;
 
@@ -44,7 +44,7 @@ async function main(): Promise<boolean> {
   });
 
   // Wait for deployment receipt
-  const deploymentReceipt = await paladin.pollForReceipt(deploymentTxID, 10000);
+  const deploymentReceipt = await paladin.pollForReceipt(deploymentTxID, DEFAULT_POLL_TIMEOUT);
   if (!deploymentReceipt?.contractAddress) {
     logger.error("Deployment failed!");
     return false;
@@ -71,7 +71,7 @@ async function main(): Promise<boolean> {
   });
 
   // Wait for the store transaction receipt
-  const storeReceipt = await paladin.pollForReceipt(storeTxID, 10000);
+  const storeReceipt = await paladin.pollForReceipt(storeTxID, DEFAULT_POLL_TIMEOUT);
   if (!storeReceipt?.transactionHash) {
     logger.error("Failed to store value in the contract!");
     return false;

--- a/examples/public-storage/src/tests/data-persistence.ts
+++ b/examples/public-storage/src/tests/data-persistence.ts
@@ -16,7 +16,7 @@ import PaladinClient from "@lfdecentralizedtrust-labs/paladin-sdk";
 import storageJson from "../abis/Storage.json";
 import * as fs from 'fs';
 import * as path from 'path';
-import { nodeConnections } from "paladin-example-common";
+import { nodeConnections, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 
 const logger = console;
 
@@ -167,7 +167,7 @@ async function main(): Promise<boolean> {
     }
 
     // Wait for the store transaction receipt
-    const storeReceipt = await paladin.pollForReceipt(storeTxID, 10000);
+    const storeReceipt = await paladin.pollForReceipt(storeTxID, DEFAULT_POLL_TIMEOUT);
     if (!storeReceipt?.transactionHash) {
       logger.error("STEP 4: Receipt retrieval failed!");
       return false;
@@ -223,7 +223,7 @@ async function main(): Promise<boolean> {
     }
 
     // Wait for the restore transaction receipt
-    const restoreReceipt = await paladin.pollForReceipt(restoreTxID, 10000);
+    const restoreReceipt = await paladin.pollForReceipt(restoreTxID, DEFAULT_POLL_TIMEOUT);
     if (!restoreReceipt?.transactionHash) {
       logger.error("STEP 5: Receipt retrieval failed!");
       return false;

--- a/examples/swap/src/helpers/atom.ts
+++ b/examples/swap/src/helpers/atom.ts
@@ -18,6 +18,7 @@ import PaladinClient, {
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
 import atomJson from "../abis/Atom.json";
 import atomFactoryJson from "../abis/AtomFactory.json";
+import { DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 
 export interface AtomOperation {
   contractAddress: string;
@@ -36,7 +37,7 @@ export const newAtomFactory = async (
     from: from.lookup,
     data: {},
   });
-  const receipt = await paladin.pollForReceipt(txID, 10000);
+  const receipt = await paladin.pollForReceipt(txID, DEFAULT_POLL_TIMEOUT);
   return receipt?.contractAddress
     ? new AtomFactory(paladin, receipt.contractAddress)
     : undefined;
@@ -61,7 +62,7 @@ export class AtomFactory {
       to: this.address,
       data: { operations },
     });
-    const receipt = await this.paladin.pollForReceipt(txID, 10000);
+    const receipt = await this.paladin.pollForReceipt(txID, DEFAULT_POLL_TIMEOUT);
     if (receipt) {
       const events = await this.paladin.bidx.decodeTransactionEvents(
         receipt.transactionHash,
@@ -97,6 +98,6 @@ export class Atom {
       to: this.address,
       data: {},
     });
-    return this.paladin.pollForReceipt(txID, 10000);
+    return this.paladin.pollForReceipt(txID, DEFAULT_POLL_TIMEOUT);
   }
 }

--- a/examples/swap/src/helpers/erc20tracker.ts
+++ b/examples/swap/src/helpers/erc20tracker.ts
@@ -18,6 +18,7 @@ import PaladinClient, {
   PentePrivateContract,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
 import erc20Tracker from "../abis/NotoTrackerERC20.json";
+import { DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 
 export interface ERC20TrackerConstructorParams {
   name: string;
@@ -34,7 +35,7 @@ export const newERC20Tracker = async (
     bytecode: erc20Tracker.bytecode,
     from: from.lookup,
     inputs: params,
-  }).waitForDeploy(10000);
+  }).waitForDeploy(DEFAULT_POLL_TIMEOUT);
   return address ? new BondTracker(pente, address) : undefined;
 };
 

--- a/examples/swap/src/index.ts
+++ b/examples/swap/src/index.ts
@@ -21,7 +21,13 @@ import PaladinClient, {
   ZetoFactory,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
 import { ethers } from "ethers";
-import { checkDeploy, checkReceipt, DEFAULT_POLL_TIMEOUT, LONG_POLL_TIMEOUT } from "paladin-example-common";
+import {
+  checkDeploy,
+  checkReceipt,
+  DEFAULT_POLL_TIMEOUT,
+  LONG_POLL_TIMEOUT,
+  POLL_INTERVAL,
+} from "paladin-example-common";
 import { newAtomFactory } from "./helpers/atom";
 import { newERC20Tracker } from "./helpers/erc20tracker";
 import * as fs from 'fs';
@@ -346,6 +352,8 @@ async function main(): Promise<boolean> {
       logger.error(`Failed to get final balances after ${LONG_POLL_TIMEOUT / 1000} seconds`);
       return false;
     }
+
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
   }
 
   // Save contract data to file for later use

--- a/examples/swap/src/index.ts
+++ b/examples/swap/src/index.ts
@@ -21,7 +21,7 @@ import PaladinClient, {
   ZetoFactory,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
 import { ethers } from "ethers";
-import { checkDeploy, checkReceipt } from "paladin-example-common";
+import { checkDeploy, checkReceipt, DEFAULT_POLL_TIMEOUT, LONG_POLL_TIMEOUT } from "paladin-example-common";
 import { newAtomFactory } from "./helpers/atom";
 import { newERC20Tracker } from "./helpers/erc20tracker";
 import * as fs from 'fs';
@@ -96,7 +96,7 @@ async function main(): Promise<boolean> {
     .newZeto(cashIssuer, {
       tokenName: "Zeto_Anon",
     })
-    .waitForDeploy(10000);
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(zetoCash)) return false;
 
   // Create a Pente privacy group for the asset issuer only
@@ -108,7 +108,7 @@ async function main(): Promise<boolean> {
       evmVersion: "shanghai",
       externalCallsEnabled: true,
     })
-    .waitForDeploy(10000);
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(issuerGroup)) return false;
 
   // Deploy private tracker to the issuer privacy group
@@ -136,7 +136,7 @@ async function main(): Promise<boolean> {
         },
       },
     })
-    .waitForDeploy(10000);
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(notoAsset)) return false;
 
   // Issue asset
@@ -147,7 +147,7 @@ async function main(): Promise<boolean> {
       amount: issuedAssetAmount,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Issue cash
@@ -162,7 +162,7 @@ async function main(): Promise<boolean> {
         },
       ],
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Lock the asset for the swap
@@ -173,7 +173,7 @@ async function main(): Promise<boolean> {
       amount: assetAmount,
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
   receipt = await paladin2.ptx.getTransactionReceiptFull(receipt.id);
 
@@ -194,7 +194,7 @@ async function main(): Promise<boolean> {
       recipients: [{ to: investor2, amount: assetAmount }],
       data: "0x",
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
   receipt = await paladin2.ptx.getTransactionReceiptFull(receipt.id);
 
@@ -215,15 +215,14 @@ async function main(): Promise<boolean> {
       amount: cashAmount,
       delegate: investor2Address,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
   
   // Poll for the lock operation to be fully settled
   logger.log("Waiting for lock operation to settle...");
   let lockedStateId: string | undefined;
   const pollStartTime = Date.now();
-  const pollTimeout = 120000; // 2 minutes
-  while (Date.now() - pollStartTime < pollTimeout) {
+  while (Date.now() - pollStartTime < LONG_POLL_TIMEOUT) {
     const lockedStates = await paladin3.ptx.getStateReceipt(receipt.id);
     const confirmedLockedState = lockedStates?.confirmed?.find(
       (state) => state.data["locked"]
@@ -236,7 +235,7 @@ async function main(): Promise<boolean> {
   }
 
   if (lockedStateId === undefined) {
-    logger.error(`Timed out after ${pollTimeout / 1000}s waiting for locked state in state receipt`);
+    logger.error(`Timed out after ${LONG_POLL_TIMEOUT / 1000}s waiting for locked state in state receipt`);
     return false;
   }
   logger.log(`Locked state ID: ${lockedStateId}`);
@@ -256,7 +255,7 @@ async function main(): Promise<boolean> {
   }).id;
   
   logger.log(`Prepared transaction ID: ${txID}`);
-  const preparedCashTransfer = await paladin3.pollForPreparedTransaction(txID, pollTimeout); // 2 minutes
+  const preparedCashTransfer = await paladin3.pollForPreparedTransaction(txID, LONG_POLL_TIMEOUT);
   if (!preparedCashTransfer) {
     logger.error(`Failed to get prepared transaction for ID: ${txID}`);
     return false;
@@ -296,7 +295,7 @@ async function main(): Promise<boolean> {
       delegate: atom.address,
       data: "0x",
     })
-    .waitForReceipt(pollTimeout);
+    .waitForReceipt(LONG_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // Approve cash transfer operation
@@ -307,7 +306,7 @@ async function main(): Promise<boolean> {
       utxos: [lockedStateId],
       delegate: atom.address,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
 
   // execute the swap
@@ -342,10 +341,9 @@ async function main(): Promise<boolean> {
       logger.log("All balances are non-zero, proceeding...");
       break;
     }
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    // if 60 second passed from the beginning of the loop than fail the test
-    if (Date.now() - startTime > 60000) {
-      logger.error("Failed to get final balances after 60 seconds");
+    // if LONG_POLL_TIMEOUT ms passed from the beginning of the loop than fail the test
+    if (Date.now() - startTime > LONG_POLL_TIMEOUT) {
+      logger.error(`Failed to get final balances after ${LONG_POLL_TIMEOUT / 1000} seconds`);
       return false;
     }
   }

--- a/examples/zeto/src/index.ts
+++ b/examples/zeto/src/index.ts
@@ -22,7 +22,7 @@ import erc20Abi from "./zeto-abis/SampleERC20.json";
 import * as fs from 'fs';
 import * as path from 'path';
 import { ContractData } from "./tests/data-persistence";
-import { nodeConnections } from "paladin-example-common";
+import { nodeConnections, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 
 const logger = console;
 
@@ -58,7 +58,7 @@ async function main(): Promise<boolean> {
     .newZeto(cbdcIssuer, {
       tokenName: "Zeto_AnonNullifier",
     })
-    .waitForDeploy(10000);
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(zetoCBDC1)) return false;
 
   // Issue some cash
@@ -78,7 +78,7 @@ async function main(): Promise<boolean> {
         },
       ],
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
   let bank1Balance = await zetoCBDC1
     .using(paladin1)
@@ -111,7 +111,7 @@ async function main(): Promise<boolean> {
         },
       ],
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
   
   // Add a small delay to ensure state is settled
@@ -139,7 +139,7 @@ async function main(): Promise<boolean> {
     .newZeto(cbdcIssuer, {
       tokenName: "Zeto_AnonNullifier",
     })
-    .waitForDeploy(10000);
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(zetoCBDC2)) return false;
 
   logger.log("- Deploying ERC20 token to manage the CBDC supply publicly...");
@@ -151,7 +151,7 @@ async function main(): Promise<boolean> {
     .setERC20(cbdcIssuer, {
       erc20: erc20Address as string,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(result2)) return false;
 
   logger.log("- Issuing CBDC to bank1 with public minting in ERC20...");
@@ -167,7 +167,7 @@ async function main(): Promise<boolean> {
     .deposit(bank1, {
       amount: depositAmount,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(result4)) return false;
   const bank1BalanceAfterDeposit = await zetoCBDC2
     .using(paladin1)
@@ -191,7 +191,7 @@ async function main(): Promise<boolean> {
         },
       ],
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(receipt)) return false;
   
   // Add a small delay to ensure state is settled
@@ -216,7 +216,7 @@ async function main(): Promise<boolean> {
     .withdraw(bank1, {
       amount: withdrawAmount,
     })
-    .waitForReceipt(10000);
+    .waitForReceipt(DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(result5)) return false;
 
   // Add a small delay to ensure state is settled
@@ -306,7 +306,7 @@ async function deployERC20(
     abi: erc20Abi.abi,
     bytecode: erc20Abi.bytecode,
   });
-  const result1 = await paladin.pollForReceipt(txId1, 120000); // 2 minutes
+  const result1 = await paladin.pollForReceipt(txId1, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(result1)) {
     throw new Error("Failed to deploy ERC20 token");
   }
@@ -332,7 +332,7 @@ async function mintERC20(
     function: "mint",
     abi: erc20Abi.abi,
   });
-  const result3 = await paladin.pollForReceipt(txId2, 120000);
+  const result3 = await paladin.pollForReceipt(txId2, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(result3)) {
     throw new Error("Failed to mint ERC20 tokens to bank1");
   }
@@ -354,7 +354,7 @@ async function approveERC20(
     from: from.lookup,
     data: { value: amount, spender },
   });
-  const result1 = await paladin.pollForReceipt(txID1, 120000);
+  const result1 = await paladin.pollForReceipt(txID1, DEFAULT_POLL_TIMEOUT);
   if (!checkReceipt(result1)) {
     throw new Error("Failed to approve transfer");
   }

--- a/examples/zeto/src/tests/data-persistence.ts
+++ b/examples/zeto/src/tests/data-persistence.ts
@@ -13,12 +13,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import PaladinClient, {
-  PaladinVerifier,
   ZetoFactory,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
 import * as fs from 'fs';
 import * as path from 'path';
-import { nodeConnections } from "paladin-example-common";
+import { nodeConnections, DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 
 const logger = console;
 
@@ -244,7 +243,7 @@ async function main(): Promise<boolean> {
           },
         ],
       })
-      .waitForReceipt(10000);
+      .waitForReceipt(DEFAULT_POLL_TIMEOUT);
 
     if (!testTransferReceipt?.transactionHash) {
       logger.error("STEP 5: Test transfer failed!");


### PR DESCRIPTION
Define a default and long poll timeout plus a poll interval for the examples and use these constants across the tests.

The default I have bumped from 5/10 secs to 30 secs to resolve https://github.com/LF-Decentralized-Trust-labs/paladin/issues/806.

The long I have set at 120 secs, which is largely what was in use across the tests.

Where other time periods were used I have generally bumped them up, for the simplicity of only having 2 types of timeout.

I have put a couple of erc20 public transaction deploys/mints back to the default from 120 secs. I think these were raised for debug but if these genuinely need 120 seconds then we need to be investigating what is going wrong, not just increasing the timeout.

I've cleaned up a couple of unused imports too, and reordered the wait in a loop so that the error message is more accurate.

