### PR TITLE
Remove the duplicate instance of the L1/L2 chain setup guide

### DIFF
--- a/doc-site/mkdocs.yml
+++ b/doc-site/mkdocs.yml
@@ -117,7 +117,6 @@ nav:
       - Advanced Installation: getting-started/installation-advanced.md
       - Manual Installation: getting-started/installation-manual.md
     - User Interface: getting-started/user-interface.md
-    - L1 and L2 Chains: getting-started/l1-and-l2-chains.md
     - Troubleshooting: getting-started/troubleshooting.md
   - Tutorials:
     - Introduction: tutorials/index.md


### PR DESCRIPTION
We ended up with this guide being linked from 2 places. I think we decided it was going to be under `Guides` not `Getting started` so removing the latter.