### PR TITLE
fix docs tags, set missing timeouts

### DIFF
--- a/doc-site/docs/guides/l1-and-l2-chains.md
+++ b/doc-site/docs/guides/l1-and-l2-chains.md
@@ -11,7 +11,7 @@ A public chain will have a long chain history. Paladin indexes the base ledger i
 chain this could take many days to index. Paladin only requires block history from the point at which Paladin tranasctions and contracts were deployed. To reduce the time to index the chain, use the `fromBlock` configuration
 option under the `blockIndexer` configuration section. For example:
 
-```
+```yaml
 blockIndexer:
     fromBlock: 9024200
 ```
@@ -34,7 +34,7 @@ Public chains can experience chain reorganizations, especially during periods of
 
 To set the required confirmations for a public chain, add the following to your configuration:
 
-```***
+```yaml
 blockIndexer:
   fromBlock: 9024200
   requiredConfirmations: 12
@@ -58,7 +58,7 @@ in order for them to be mined into blocks. Paladin provides several options for 
 
 You can configure fixed gas prices at the node level that will be used for all transactions unless overridden at the transaction level:
 
-```
+```yaml
 publicTxManager:
   gasPrice:
     fixedGasPrice:
@@ -80,7 +80,7 @@ Note: setting the fixed gas price values too high could result in paying more ga
 
 Paladin can automatically retrieve optimal gas prices using the `eth_feeHistory` RPC method, which provides historical fee data from the network. This approach adapts to network conditions and can be more cost-effective than fixed pricing.
 
-```
+```yaml
 publicTxManager:
   gasPrice:
     ethFeeHistory:
@@ -102,7 +102,7 @@ Configuration options:
 
 Paladin can retrieve gas prices from external gas oracle APIs, which can provide more accurate or specialized gas price data than the standard `eth_feeHistory` method. This is particularly useful for chains with limited RPC capabilities or when using specialized gas price services.
 
-```
+```yaml
 publicTxManager:
   gasPrice:
     gasOracleAPI:
@@ -139,7 +139,7 @@ The gas oracle API must:
 
 Gas oracle APIs can also be custom JSON/RPC methods provided by your base ledger node. This is useful when your node supports specialized gas price calculation methods that aren't part of the standard Ethereum JSON/RPC specification.
 
-```
+```yaml
 publicTxManager:
   gasPrice:
     gasOracleAPI:
@@ -169,7 +169,7 @@ Example API responses that work with the template above:
 **Hexadecimal format:**
 ```json
 {
-  "data": {
+  "result": {
     "maxFeePerGas": "0x2FAF080",
     "maxPriorityFeePerGas": "0x3B9ACA0"
   }
@@ -179,7 +179,7 @@ Example API responses that work with the template above:
 **Decimal format:**
 ```json
 {
-  "data": {
+  "result": {
     "maxFeePerGas": "50000000",
     "maxPriorityFeePerGas": "62500000"
   }
@@ -213,7 +213,7 @@ Transaction-level fixed gas pricing bypasses all automatic gas pricing logic and
 
 When a transaction is rejected for being underpriced, Paladin can automatically increase the gas price by a configurable percentage and resubmit the transaction. This mechanism applies to node-level fixed pricing, gas oracle API pricing, and dynamic pricing, but not to transaction-level fixed pricing.
 
-```
+```yaml
 publicTxManager:
   gasPrice:
     increasePercentage: 10
@@ -227,7 +227,7 @@ publicTxManager:
 
 To protect against excessive gas spending, you can configure maximum caps for both `maxFeePerGas` and `maxPriorityFeePerGas`. These caps apply universally to all gas pricing methods:
 
-```
+```yaml
 publicTxManager:
   gasPrice:
     maxFeePerGasCap: 0x5d21dba00  # 25 Gwei cap
@@ -264,7 +264,7 @@ The gas price cache stores the most recent gas price data and automatically refr
 
 Both `ethFeeHistory` and `gasOracleAPI` pricing methods support caching:
 
-```
+```yaml
 publicTxManager:
   gasPrice:
     ethFeeHistory:

--- a/examples/bond/src/helpers/bondsubscription.ts
+++ b/examples/bond/src/helpers/bondsubscription.ts
@@ -3,6 +3,7 @@ import PaladinClient, {
   PentePrivacyGroup,
   PentePrivateContract,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
+import { DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 import bondSubscription from "../abis/BondSubscription.json";
 
 const bondSubscriptionConstructor = bondSubscription.abi.find(
@@ -41,7 +42,7 @@ export const newBondSubscription = async (
       from: from.lookup,
       inputs: params,
     })
-    .waitForDeploy();
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   return address ? new BondSubscription(pente, address) : undefined;
 };
 

--- a/examples/bond/src/helpers/bondtracker.ts
+++ b/examples/bond/src/helpers/bondtracker.ts
@@ -3,6 +3,7 @@ import PaladinClient, {
   PentePrivacyGroup,
   PentePrivateContract,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
+import { DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 import bondTracker from "../abis/BondTracker.json";
 import { InvestorList } from "./investorlist";
 
@@ -30,7 +31,7 @@ export const newBondTracker = async (
       from: from.lookup,
       inputs: params,
     })
-    .waitForDeploy();
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   return address ? new BondTracker(pente, address) : undefined;
 };
 

--- a/examples/bond/src/index.ts
+++ b/examples/bond/src/index.ts
@@ -152,7 +152,7 @@ async function main(): Promise<boolean> {
         },
       },
     })
-    .waitForDeploy();
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(notoBond)) return false;
 
   // Deploy the atom factory on the base ledger

--- a/examples/event-listener/src/index.ts
+++ b/examples/event-listener/src/index.ts
@@ -48,7 +48,7 @@ async function main(): Promise<boolean> {
       evmVersion: "shanghai",
       externalCallsEnabled: true,
     })
-    .waitForDeploy();
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(memberPrivacyGroup)) return false;
 
   // Deploy a smart contract within the privacy group
@@ -59,7 +59,7 @@ async function main(): Promise<boolean> {
     from: verifierNode1.lookup,
   });
   const receipt = await deploy.waitForReceipt(DEFAULT_POLL_TIMEOUT);
-  const contractAddress = await deploy.waitForDeploy();
+  const contractAddress = await deploy.waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!receipt || !contractAddress) {
     logger.error("Failed to deploy the contract. No address returned.");
     return false;

--- a/examples/notarized-tokens/src/index.ts
+++ b/examples/notarized-tokens/src/index.ts
@@ -52,7 +52,7 @@ async function main(): Promise<boolean> {
       notary: verifierNode1,
       notaryMode: "basic",
     })
-    .waitForDeploy();
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!cashToken) {
     logger.error("Failed to deploy the Noto cash token!");
     return false;

--- a/examples/privacy-storage/src/helpers/storage.ts
+++ b/examples/privacy-storage/src/helpers/storage.ts
@@ -17,6 +17,7 @@ import PaladinClient, {
   PentePrivacyGroup,
   PentePrivateContract,
 } from "@lfdecentralizedtrust-labs/paladin-sdk";
+import { DEFAULT_POLL_TIMEOUT } from "paladin-example-common";
 import storage from "../abis/Storage.json";
 
 export const newPrivateStorage = async (
@@ -27,7 +28,7 @@ export const newPrivateStorage = async (
     abi: storage.abi,
     bytecode: storage.bytecode,
     from: from.lookup,
-  }).waitForDeploy();
+  }).waitForDeploy(DEFAULT_POLL_TIMEOUT);
   return address ? new PrivateStorage(pente, address) : undefined;
 };
 

--- a/examples/privacy-storage/src/index.ts
+++ b/examples/privacy-storage/src/index.ts
@@ -46,7 +46,7 @@ async function main(): Promise<boolean> {
     members: [verifierNode1, verifierNode2],
     evmVersion: "shanghai",
     externalCallsEnabled: true,
-  }).waitForDeploy();
+  }).waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(memberPrivacyGroup)) return false;
 
   logger.log(`Privacy group created, ID: ${memberPrivacyGroup?.group.id}`);
@@ -57,7 +57,7 @@ async function main(): Promise<boolean> {
     abi: storageJson.abi,
     bytecode: storageJson.bytecode,
     from: verifierNode1.lookup,
-  }).waitForDeploy();
+  }).waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!contractAddress) {
     logger.error("Failed to deploy the contract. No address returned.");
     return false;

--- a/examples/private-stablecoin/src/index.ts
+++ b/examples/private-stablecoin/src/index.ts
@@ -195,7 +195,7 @@ async function main(): Promise<boolean> {
     .newZeto(financialInstitution, {
       tokenName: "Zeto_AnonNullifierKyc",
     })
-    .waitForDeploy();
+    .waitForDeploy(DEFAULT_POLL_TIMEOUT);
   if (!checkDeploy(privateStablecoin)) return false;
   logger.log(
     `     ✓ Private stablecoin deployed at: ${privateStablecoin.address}`


### PR DESCRIPTION
`***` next to a code block tag stopped it from formatting correctly. While I was in there I added some yaml formatting so we get nice colours.

I missed some default timeouts for deploys in a number of the examples on a previous PR too.
