### PR TITLE
Restart event streams on block indexer reset

### DIFF
--- a/core/go/pkg/blockindexer/block_indexer.go
+++ b/core/go/pkg/blockindexer/block_indexer.go
@@ -487,7 +487,10 @@ func (bi *blockIndexer) dispatcher(ctx context.Context) {
 			for i, receiptError := range batch.receiptResults {
 				if receiptError != nil {
 					log.L(ctx).Errorf("Block indexer requires reset after failing to query receipts for block %s in batch of %d blocks: %s", batch.blocks[i].Hash, len(batch.blocks), receiptError)
-					go bi.startOrReset()
+					go func() {
+						bi.startOrReset()
+						bi.startEventStreams()
+					}()
 					return // We know we need to exit
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/LF-Decentralized-Trust-labs/paladin/issues/866 by adding in a startEventStreams call