### PR TITLE
Create MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,7 +19,7 @@ Maintainers are assigned one or both of following scopes in this repository:
 | ----------------- | --------------- | ------------------------- | ----------------- | ----------------- | ---------------------------- | ------------------- | --------------------------------------- |
 | Anna McAllister   | annamcallister  | Paladin Maintainer        | annamcallister    | annamcallister    | anna.mcallister@kaleido.io   | Kaleido             | `paladin-committers`                    |
 | Andrew Richardson | awrichar        | Paladin & Zeto Maintainer | andrew.richardson | andrew.richardson | andrew.richardson@kaleido.io | Kaleido             | `paladin-committers`, `zeto-committers` |
-| Chengxuan Xing    | Chengxuan       | Zeto Maintainer           | chengxuan.xing    | xingchxuan        | chengxuan.xing@kaleido.io    | Kaleido             | `zeto-committers`                       |
+| Chengxuan Xing    | Chengxuan       | Zeto Maintainer           | chengxuanxing     | xingchxuan        | chengxuan.xing@kaleido.io    | Kaleido             | `zeto-committers`                       |
 | David Wertenteil  | dwertent        | Paladin Maintainer        | dwertent          | dwertent_33303    | david.wertenteil@kaleido.io  | Kaleido             | `paladin-committers`                    |
 | Jim Zhang         | jimthematrix    | Paladin & Zeto Maintainer | jimthematrix      | jimthematrix      | jim.zhang@kaleido.io         | Kaleido             | `paladin-committers`, `zeto-committers` |
 | Matthew Whitehead | matthew1001     | Paladin Maintainer        | matthew.whitehead | matthew.whitehead | matthew.whitehead@kaleido.io | Kaleido             | `paladin-committers`                    |


### PR DESCRIPTION
This is a required file for LFDT projects. I have used the LFDT sample maintainers file and added an initial set of maintainers.

Currently this is **not** the full list currently in the https://github.com/LFDT-Paladin/governance/blob/main/config.yaml config file. The intention is to provoke some discussion about who is a maintainer now that the two labs have become an incubating project.

I have proposed that we have a single list of maintainers for both Paladin and Zeto, but that the maintainers file identifies which of the 2 repos (or both) the user is a committer for. 

There is a PR for a minimal Zeto redirect maintainers file here: https://github.com/LFDT-Paladin/zeto/pull/169