### PR TITLE
Use correct noto tx id

### DIFF
--- a/domains/noto/internal/noto/events_test.go
+++ b/domains/noto/internal/noto/events_test.go
@@ -303,3 +303,43 @@ func TestHandleEventBatch_NotoUnlockBadData(t *testing.T) {
 	require.Len(t, res.SpentStates, 0)
 	require.Len(t, res.ConfirmedStates, 0)
 }
+
+func TestHandleEventBatch_NotoUnlockBadTransactionData(t *testing.T) {
+	n := &Noto{Callbacks: mockCallbacks}
+	ctx := context.Background()
+
+	_, err := n.ConfigureDomain(context.Background(), &prototk.ConfigureDomainRequest{
+		ConfigJson: `{}`,
+	})
+	require.NoError(t, err)
+
+	txId := pldtypes.RandBytes32()
+	lockId := pldtypes.RandBytes32()
+	event := &NotoUnlock_Event{
+		TxId:          txId,
+		LockId:        lockId,
+		LockedInputs:  []pldtypes.Bytes32{},
+		LockedOutputs: []pldtypes.Bytes32{},
+		Outputs:       []pldtypes.Bytes32{},
+		Signature:     pldtypes.MustParseHexBytes("0x1234"),
+		Data:          pldtypes.MustParseHexBytes("0x00010000"), // Bad transaction data
+	}
+	notoEventJson, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	req := &prototk.HandleEventBatchRequest{
+		Events: []*prototk.OnChainEvent{
+			{
+				SoliditySignature: eventSignatures[NotoUnlock],
+				DataJson:          string(notoEventJson),
+			}},
+		ContractInfo: &prototk.ContractInfo{
+			ContractConfigJson: mustParseJSON(&types.NotoParsedConfig{
+				Variant: types.NotoVariantDefault,
+			}),
+		},
+	}
+
+	_, err = n.HandleEventBatch(ctx, req)
+	require.ErrorContains(t, err, "FF22047")
+}

--- a/domains/noto/internal/noto/noto.go
+++ b/domains/noto/internal/noto/noto.go
@@ -215,6 +215,7 @@ type NotoDelegateLockParams struct {
 }
 
 type NotoTransfer_Event struct {
+	TxId      pldtypes.Bytes32   `json:"txId"`
 	Inputs    []pldtypes.Bytes32 `json:"inputs"`
 	Outputs   []pldtypes.Bytes32 `json:"outputs"`
 	Signature pldtypes.HexBytes  `json:"signature"`


### PR DESCRIPTION
Noto domain receipts have been missing states- this looks to be because transaction ID is not actually available in the data of a `NotoUnlock` event, so the code falls back generating a random ID (now logged at WARN level), which means the states and receipt cannot be correlated.