### PR TITLE
Remove `AttestationType_GENERATE_PROOF`

### DIFF
--- a/core/go/internal/privatetxnmgr/assemble_and_sign.go
+++ b/core/go/internal/privatetxnmgr/assemble_and_sign.go
@@ -135,11 +135,6 @@ func (s *Sequencer) assembleAndSign(ctx context.Context, transactionID uuid.UUID
 		switch attRequest.AttestationType {
 		case prototk.AttestationType_ENDORSE:
 		case prototk.AttestationType_SIGN:
-		case prototk.AttestationType_GENERATE_PROOF:
-			errorMessage := "AttestationType_GENERATE_PROOF is not implemented yet"
-			log.L(ctx).Error(errorMessage)
-			return nil, i18n.NewError(ctx, msgs.MsgPrivateTxManagerInternalError, errorMessage)
-
 		default:
 			errorMessage := fmt.Sprintf("Unsupported attestation type: %s", attRequest.AttestationType)
 			log.L(ctx).Error(errorMessage)

--- a/toolkit/proto/protos/to_domain.proto
+++ b/toolkit/proto/protos/to_domain.proto
@@ -377,7 +377,6 @@ message EndorsableState {
 enum AttestationType {
   SIGN = 0; // Occurs before the transaction is considered fully assembled - gathers a signature against the state inputs+outputs of the transaction, including proof of knowledge of the private data. Use to authenticate an action, such as a transfer, that will be endorsed by other parties
   ENDORSE = 1; // A verification of the validity of the transaction that occurs with a full copy of all the data, by one or more parties.
-  GENERATE_PROOF = 2; // The generation of a cyprographic zero-knowledge proof (ZKP) using a full copy of all the data, that allows verification of the transaction by any party without that private data
 }
 
 message AttestationRequest {


### PR DESCRIPTION
Discussion with @jimthematrix suggests this attestation type isn't required, so for code cleanliness I've removed it. It couldn't have been used before now because it would always have returned "Not implemented". As such it could easily be added again in the future if it was needed.