### PR TITLE
Fix withdraw handling of nullifier tokens

### DIFF
--- a/domains/integration-test/zeto_fungible_test.go
+++ b/domains/integration-test/zeto_fungible_test.go
@@ -249,13 +249,13 @@ func (s *fungibleTestSuiteHelper) testZeto(t *testing.T, tokenName string, useBa
 	log.L(ctx).Info("*************************************")
 	zeto.Withdraw(ctx, 100).SignAndSend(controllerName, true).Wait()
 
+	balanceOfResult = zeto.BalanceOf(ctx, controllerName).SignAndCall(controllerName).Wait()
+	assert.Equal(t, "5", balanceOfResult["totalBalance"].(string), "Balance of controller should be 5")
+
 	if tokenName != constants.TOKEN_ANON {
 		// for now the lock and transferLocked only works properly for the ANON token
 		return
 	}
-
-	balanceOfResult = zeto.BalanceOf(ctx, controllerName).SignAndCall(controllerName).Wait()
-	assert.Equal(t, "5", balanceOfResult["totalBalance"].(string), "Balance of controller should be 5")
 
 	log.L(ctx).Info("*************************************")
 	log.L(ctx).Infof("Lock some UTXOs and delegate the lock to recipient1")

--- a/domains/zeto/internal/zeto/fungible/handler_withdraw.go
+++ b/domains/zeto/internal/zeto/fungible/handler_withdraw.go
@@ -132,7 +132,7 @@ func (h *withdrawHandler) Assemble(ctx context.Context, tx *types.ParsedTransact
 	}
 
 	remainder := big.NewInt(0).Sub(inputStates.total, amount.Int())
-	outputCoin, outputState, err := h.prepareOutput(ctx, pldtypes.MustParseHexUint256(remainder.Text(10)), resolvedSender)
+	outputCoin, outputState, err := h.prepareOutput(ctx, useNullifiers, pldtypes.MustParseHexUint256(remainder.Text(10)), resolvedSender)
 	if err != nil {
 		return nil, i18n.NewError(ctx, msgs.MsgErrorPrepTxOutputs, err)
 	}
@@ -251,7 +251,7 @@ func (h *withdrawHandler) prepareInputs(ctx context.Context, useNullifiers bool,
 	return buildInputsForExpectedTotal(ctx, h.callbacks, h.stateSchemas.CoinSchema, useNullifiers, stateQueryContext, senderKey, expectedTotal, false)
 }
 
-func (h *withdrawHandler) prepareOutput(ctx context.Context, amount *pldtypes.HexUint256, resolvedRecipient *pb.ResolvedVerifier) (*types.ZetoCoin, *pb.NewState, error) {
+func (h *withdrawHandler) prepareOutput(ctx context.Context, useNullifiers bool, amount *pldtypes.HexUint256, resolvedRecipient *pb.ResolvedVerifier) (*types.ZetoCoin, *pb.NewState, error) {
 	recipientKey, err := common.LoadBabyJubKey([]byte(resolvedRecipient.Verifier))
 	if err != nil {
 		return nil, nil, i18n.NewError(ctx, msgs.MsgErrorLoadOwnerPubKey, err)
@@ -265,7 +265,7 @@ func (h *withdrawHandler) prepareOutput(ctx context.Context, amount *pldtypes.He
 		Amount: amount,
 	}
 
-	newState, err := makeNewState(ctx, h.stateSchemas.CoinSchema, false, newCoin, h.name, resolvedRecipient.Lookup)
+	newState, err := makeNewState(ctx, h.stateSchemas.CoinSchema, useNullifiers, newCoin, h.name, resolvedRecipient.Lookup)
 	if err != nil {
 		return nil, nil, i18n.NewError(ctx, msgs.MsgErrorCreateNewState, err)
 	}


### PR DESCRIPTION
The nullifiers were missing for the UTXOs created by the withdraw transactions, impacting the lookup of available tokens.