### PR TITLE
ensure transport plugins have started before sequencer starts

### DIFF
--- a/core/go/internal/componentmgr/manager.go
+++ b/core/go/internal/componentmgr/manager.go
@@ -444,6 +444,12 @@ func (cm *componentManager) CompleteStart() error {
 		err = cm.wrapIfErr(err, msgs.MsgComponentWaitPluginStartError)
 	}
 
+	// Wait for transport plugins to complete ConfigureTransport before starting sequencer
+	if err == nil {
+		err = cm.pluginManager.WaitForInit(cm.bgCtx, prototk.PluginInfo_TRANSPORT)
+		err = cm.wrapIfErr(err, msgs.MsgComponentWaitPluginStartError)
+	}
+
 	// then start the block indexer
 	if err == nil {
 		err = cm.startBlockIndexer()

--- a/core/go/internal/componentmgr/manager_test.go
+++ b/core/go/internal/componentmgr/manager_test.go
@@ -183,6 +183,7 @@ func TestStartOK(t *testing.T) {
 	mockPluginManager.On("Start").Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_SIGNING_MODULE).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_DOMAIN).Return(nil)
+	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_TRANSPORT).Return(nil)
 	mockPluginManager.On("Stop").Return()
 
 	mockKeyManager := componentsmocks.NewKeyManager(t)
@@ -312,6 +313,7 @@ func TestCompleteStart_MultipleAuthorizers(t *testing.T) {
 	mockPluginManager.On("Start").Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_SIGNING_MODULE).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_DOMAIN).Return(nil)
+	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_TRANSPORT).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_RPC_AUTH).Return(nil)
 	mockPluginManager.On("Stop").Return()
 
@@ -484,6 +486,7 @@ func TestCompleteStart_SingleAuthorizer(t *testing.T) {
 	mockPluginManager.On("Start").Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_SIGNING_MODULE).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_DOMAIN).Return(nil)
+	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_TRANSPORT).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_RPC_AUTH).Return(nil)
 	mockPluginManager.On("Stop").Return()
 
@@ -572,6 +575,7 @@ func TestCompleteStart_AuthorizerNotFound(t *testing.T) {
 	mockPluginManager.On("Start").Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_SIGNING_MODULE).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_DOMAIN).Return(nil)
+	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_TRANSPORT).Return(nil)
 	mockPluginManager.On("Stop").Return().Maybe()
 
 	mockBlockIndexer := blockindexermocks.NewBlockIndexer(t)
@@ -689,6 +693,7 @@ func TestCompleteStart_AuthorizerMissingFromArray(t *testing.T) {
 	mockPluginManager.On("Start").Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_SIGNING_MODULE).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_DOMAIN).Return(nil)
+	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_TRANSPORT).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_RPC_AUTH).Return(nil)
 	mockPluginManager.On("Stop").Return().Maybe()
 
@@ -818,6 +823,7 @@ func TestCompleteStart_AuthorizersArrayEmptyButConfigured(t *testing.T) {
 	mockPluginManager.On("Start").Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_SIGNING_MODULE).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_DOMAIN).Return(nil)
+	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_TRANSPORT).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_RPC_AUTH).Return(nil)
 	mockPluginManager.On("Stop").Return().Maybe()
 
@@ -955,6 +961,7 @@ func TestCompleteStart_MetricsServerNil(t *testing.T) {
 	mockPluginManager.On("Start").Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_SIGNING_MODULE).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_DOMAIN).Return(nil)
+	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_TRANSPORT).Return(nil)
 	mockPluginManager.On("Stop").Return()
 
 	mockBlockIndexer := blockindexermocks.NewBlockIndexer(t)
@@ -1057,6 +1064,7 @@ func TestCompleteStart_MetricsServerStartSuccess(t *testing.T) {
 	mockPluginManager.On("Start").Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_SIGNING_MODULE).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_DOMAIN).Return(nil)
+	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_TRANSPORT).Return(nil)
 	mockPluginManager.On("Stop").Return()
 
 	mockBlockIndexer := blockindexermocks.NewBlockIndexer(t)
@@ -1166,6 +1174,7 @@ func TestCompleteStart_MetricsServerStartError(t *testing.T) {
 	mockPluginManager.On("Start").Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_SIGNING_MODULE).Return(nil)
 	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_DOMAIN).Return(nil)
+	mockPluginManager.On("WaitForInit", mock.Anything, prototk.PluginInfo_TRANSPORT).Return(nil)
 	mockPluginManager.On("Stop").Return()
 
 	mockBlockIndexer := blockindexermocks.NewBlockIndexer(t)

--- a/transports/grpc/internal/grpctransport/grpc_transport.go
+++ b/transports/grpc/internal/grpctransport/grpc_transport.go
@@ -241,6 +241,10 @@ func (t *grpcTransport) ActivatePeer(ctx context.Context, req *prototk.ActivateP
 	t.connLock.Lock()
 	defer t.connLock.Unlock()
 
+	if t.peerVerifier == nil {
+		return nil, i18n.NewError(ctx, msgs.MsgTransportNotConfigured)
+	}
+
 	existing := t.outboundConnections[req.NodeName]
 	if existing != nil {
 		// Replace an existing connection - unexpected as Paladin shouldn't do this

--- a/transports/grpc/internal/msgs/en_errors.go
+++ b/transports/grpc/internal/msgs/en_errors.go
@@ -48,4 +48,5 @@ var (
 	MsgInvalidTransportDetails              = pde("PD030014", "Invalid transport details for node '%s'")
 	MsgConnectionFailed                     = pde("PD030015", "GRPC connection failed for endpoint '%s'")
 	MsgNodeNotActive                        = pde("PD030016", "Send for node that is not active '%s'")
+	MsgTransportNotConfigured              = pde("PD030017", "transport not configured: activate peer only after ConfigureTransport has succeeded")
 )


### PR DESCRIPTION
Fixes a timing window in start up that allowed for a nil pointer exception in the coordination tests. I doubt this occur outside a test but we still don't want it to be a cause of intermittent test failures.
```
2026-02-11T17:44:59.5089735Z panic: runtime error: invalid memory address or nil pointer dereference
2026-02-11T17:44:59.5091116Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x10e539a]
2026-02-11T17:44:59.5095474Z 
2026-02-11T17:44:59.5095722Z goroutine 31641 [running]:
2026-02-11T17:44:59.5097137Z github.com/LFDT-Paladin/paladin/transports/grpc/internal/grpctransport.(*tlsVerifier).Clone(...)
2026-02-11T17:44:59.5098530Z 	/home/runner/work/paladin/paladin/transports/grpc/internal/grpctransport/tls_verifier.go:106
2026-02-11T17:44:59.5100365Z github.com/LFDT-Paladin/paladin/transports/grpc/internal/grpctransport.(*grpcTransport).newConnection(0xc0035c8160, {0x18fdf18, 0xc00466eb40}, {0xc00381e560, 0x5}, {0xc0050d2380, 0x372})
2026-02-11T17:44:59.5102224Z 	/home/runner/work/paladin/paladin/transports/grpc/internal/grpctransport/outbound_conn.go:59 +0x23a
2026-02-11T17:44:59.5104132Z github.com/LFDT-Paladin/paladin/transports/grpc/internal/grpctransport.(*grpcTransport).ActivatePeer(0xc0035c8160, {0x18fdf50?, 0xc002447d10?}, 0xc00387e000)
2026-02-11T17:44:59.5105855Z 	/home/runner/work/paladin/paladin/transports/grpc/internal/grpctransport/grpc_transport.go:251 +0x205
2026-02-11T17:44:59.5107975Z github.com/LFDT-Paladin/paladin/toolkit/pkg/plugintk.(*transportHandler).RequestToPlugin(0xc003f58060, {0x18fdf50, 0xc002447d10}, {0x19068d0?, 0xc00307d670?})
2026-02-11T17:44:59.5109722Z 	/home/runner/work/paladin/paladin/toolkit/go/pkg/plugintk/plugin_type_transport.go:136 +0x394
2026-02-11T17:44:59.5112598Z github.com/LFDT-Paladin/paladin/toolkit/pkg/plugintk.(*pluginRun[...]).handleRequestToPlugin(0x191d820, {0x19068d0, 0xc00307d670})
2026-02-11T17:44:59.5114207Z 	/home/runner/work/paladin/paladin/toolkit/go/pkg/plugintk/instance.go:232 +0x176
2026-02-11T17:44:59.5115457Z created by github.com/LFDT-Paladin/paladin/toolkit/pkg/plugintk.(*pluginRun[...]).serve in goroutine 31491
2026-02-11T17:44:59.5117283Z 	/home/runner/work/paladin/paladin/toolkit/go/pkg/plugintk/instance.go:192 +0x353
2026-02-11T17:44:59.5119548Z FAIL	github.com/LFDT-Paladin/paladin/core/noderuntests/coordinationtest	108.971s
2026-02-11T17:44:59.5120280Z FAIL
2026-02-11T17:44:59.6064394Z 
2026-02-11T17:44:59.6065547Z Task ':core:go:coordinationTestPostgres' failed. Dumping Docker logs from ':testinfra:startTestInfra'.
2026-02-11T17:44:59.9065073Z Docker logs dumped to /home/runner/work/paladin/paladin/core/go/build/docker-compose.log
2026-02-11T17:44:59.9065528Z 
2026-02-11T17:44:59.9065703Z > Task :core:go:coordinationTestPostgres FAILED
```