### PR TITLE
privatetxnmgr: use per-request channels rather than a global channel

### DIFF
--- a/core/go/internal/privatetxnmgr/assemble_coordinator_test.go
+++ b/core/go/internal/privatetxnmgr/assemble_coordinator_test.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2026 Kaleido, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package privatetxnmgr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Mock timer that can fire on demand
+type testCoordinatorTimer struct {
+	ch chan time.Time
+}
+
+func newTestTimer() *testCoordinatorTimer {
+	return &testCoordinatorTimer{ch: make(chan time.Time, 1)}
+}
+
+func (t *testCoordinatorTimer) C() <-chan time.Time {
+	return t.ch
+}
+
+func (t *testCoordinatorTimer) Stop() bool {
+	select {
+	case <-t.ch:
+		return false
+	default:
+	}
+	return true
+}
+
+func (t *testCoordinatorTimer) Fire() {
+	t.ch <- time.Now()
+}
+
+func newAssembleCoordinatorForTest(timeout time.Duration) *assembleCoordinator {
+	return &assembleCoordinator{
+		ctx:            context.Background(),
+		nodeName:       "node1",
+		requests:       make(chan *assembleRequest, 10),
+		stopProcess:    make(chan struct{}),
+		inflight:       make(map[string]chan struct{}),
+		requestTimeout: timeout,
+		timerFactory:   newDefaultTimer,
+	}
+}
+
+func inflightLen(ac *assembleCoordinator) int {
+	ac.inflightLock.Lock()
+	defer ac.inflightLock.Unlock()
+	return len(ac.inflight)
+}
+
+func hasInflight(ac *assembleCoordinator, requestID string) bool {
+	ac.inflightLock.Lock()
+	defer ac.inflightLock.Unlock()
+	_, exists := ac.inflight[requestID]
+	return exists
+}
+
+func TestAssembleCoordinatorCompleteUnknownIDIsNonBlocking(t *testing.T) {
+	ac := newAssembleCoordinatorForTest(20 * time.Minute)
+	ac.Complete("missing-request")
+}
+
+func TestAssembleCoordinatorCompleteOnlyUnblocksMatchingRequest(t *testing.T) {
+	ac := newAssembleCoordinatorForTest(20 * time.Minute)
+
+	doneA := ac.registerInflight("request-a")
+	_ = ac.registerInflight("request-b")
+
+	ac.Complete("request-b")
+	require.True(t, hasInflight(ac, "request-a"))
+
+	ac.Complete("request-a")
+	ac.waitForDone("request-a", doneA)
+	require.Equal(t, 0, inflightLen(ac))
+}
+
+func TestAssembleCoordinatorLateCompleteDoesNotInterfereWithNextRequest(t *testing.T) {
+	ac := newAssembleCoordinatorForTest(20 * time.Minute)
+	ac.registerInflight("request-old")
+	ac.removeInflight("request-old") // emulate late completion after request is already gone
+
+	doneCurrent := ac.registerInflight("request-current")
+
+	ac.Complete("request-old")
+	require.True(t, hasInflight(ac, "request-current"), "late completion should not affect current request")
+
+	ac.Complete("request-current")
+	ac.waitForDone("request-current", doneCurrent)
+	require.Equal(t, 0, inflightLen(ac))
+}
+
+func TestAssembleCoordinatorStopInterruptsWaitForDone(t *testing.T) {
+	ac := newAssembleCoordinatorForTest(20 * time.Minute)
+	doneCh := ac.registerInflight("request-stop")
+	ac.Stop()
+	ac.waitForDone("request-stop", doneCh)
+	require.Equal(t, 0, inflightLen(ac))
+}
+
+func TestAssembleCoordinatorWaitForDoneCleansInflightOnSuccessAndTimeout(t *testing.T) {
+	ac := newAssembleCoordinatorForTest(20 * time.Minute)
+
+	timeoutTimer := newTestTimer()
+	ac.timerFactory = func(_ time.Duration) coordinatorTimer { return timeoutTimer }
+
+	successCh := ac.registerInflight("request-success")
+	ac.Complete("request-success")
+	ac.waitForDone("request-success", successCh)
+	require.Equal(t, 0, inflightLen(ac))
+
+	timeoutCh := ac.registerInflight("request-timeout")
+	timeoutTimer.Fire()
+	ac.waitForDone("request-timeout", timeoutCh)
+	require.Equal(t, 0, inflightLen(ac))
+}

--- a/toolkit/go/go.sum
+++ b/toolkit/go/go.sum
@@ -88,6 +88,7 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hyperledger/firefly-common v1.5.6 h1:z1QsMSkyQ6t6deNhMI68OZV3QidutOE3zU3buqC5M5o=
+github.com/hyperledger/firefly-common v1.5.6/go.mod h1:1Xawm5PUhxT7k+CL/Kr3i1LE3cTTzoQwZMLimvlW8rs=
 github.com/hyperledger/firefly-signer v1.1.21 h1:r7cTOw6e/6AtiXLf84wZy6Z7zppzlc191HokW2hv4N4=
 github.com/hyperledger/firefly-signer v1.1.21/go.mod h1:axrlSQeKrd124UdHF5L3MkTjb5DeTcbJxJNCZ3JmcWM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=


### PR DESCRIPTION
The assemble coordinator is currently prone to leak requests and stall when tracking multiple requests in flight. Switch to a map of requests so that each one can track completion/timeout individually.

---

Built with Cursor Plan
Model = GPT-5.3 Codex

## Goal

Move from a single shared `commit chan string` to per-request completion channels, keyed by `requestID`, to eliminate cross-request interference and blocking risks in completion signaling.

## Implementation Plan

1. Introduce inflight request state in `[/Users/andrew/workspace/paladin/core/go/internal/privatetxnmgr/assemble_coordinator.go](/Users/andrew/workspace/paladin/core/go/internal/privatetxnmgr/assemble_coordinator.go)`:
  - Add `inflight map[string]chan struct{}` and a mutex (`sync.Mutex`).
  - Create helper methods:
    - `registerInflight(requestID string) chan struct{}`
    - `completeInflight(requestID string) (found bool)`
    - `removeInflight(requestID string)`
2. Replace global commit signaling:
  - Remove `commit chan string` from coordinator state.
  - In `Start()`, register inflight immediately before `processLocal/processRemote`.
  - In `Complete(requestID)`, lookup+close only the matching done channel; never block.
3. Rework wait logic:
  - Change `waitForDone(requestID, doneCh)` to wait on:
    - `<-doneCh`
    - `<-timeoutTimer.C`
    - `<-ac.stopProcess`
    - `<-ac.ctx.Done()`
  - Add `defer` timer stop/drain cleanup.
  - Ensure inflight entry is removed on every exit path.
4. Handle late/unknown completions safely:
  - If `Complete()` receives a request ID not in `inflight`, log as late/unknown and return.
  - This avoids blocking and removes dependence on channel buffer sizing.
5. Keep behavior scope tight:
  - Do not alter transaction-flow semantics in this pass beyond completion signaling reliability.
  - Keep timeout-to-failure-event work as a follow-up task if needed.

## Test Plan

- Add/extend tests under `core/go/internal/privatetxnmgr` to cover:
  - `Complete()` for unknown request ID is non-blocking and harmless.
  - Matching `Complete()` unblocks only the waiting request.
  - Late `Complete()` after timeout does not interfere with next request.
  - `Stop()` while waiting exits promptly (without waiting full request timeout).
  - Timer cleanup path is exercised on success and timeout.

## Scope

- Primary files:
  - `[/Users/andrew/workspace/paladin/core/go/internal/privatetxnmgr/assemble_coordinator.go](/Users/andrew/workspace/paladin/core/go/internal/privatetxnmgr/assemble_coordinator.go)`
  - `[/Users/andrew/workspace/paladin/core/go/internal/privatetxnmgr/assemble_coordinator_test.go](/Users/andrew/workspace/paladin/core/go/internal/privatetxnmgr/assemble_coordinator_test.go)` (new or extended)