### PR TITLE
Upgrade to trace for gRPC full logging

### DIFF
--- a/core/go/internal/plugins/plugin_base.go
+++ b/core/go/internal/plugins/plugin_base.go
@@ -311,8 +311,8 @@ func (ph *pluginHandler[M]) RequestReply(ctx context.Context, reqFn func(plugint
 	inflight := ph.inflight.AddInflight(ctx, reqID)
 	defer inflight.Cancel()
 	l.Infof("[%s] ==> %T", reqID, req.RequestToPlugin())
-	if log.IsDebugEnabled() {
-		l.Debugf("[%s] ==> %s", reqID, plugintk.PluginMessageToJSON(req))
+	if log.IsTraceEnabled() {
+		l.Tracef("[%s] ==> %s", reqID, plugintk.PluginMessageToJSON(req))
 	}
 
 	// Send the request
@@ -342,8 +342,8 @@ func (ph *pluginHandler[M]) RequestReply(ctx context.Context, reqFn func(plugint
 	}
 
 	l.Infof("[%s] <== [%s] %T [%s]", reqID, res.Header().MessageId, req.ResponseFromPlugin(), inflight.Age())
-	if log.IsDebugEnabled() {
-		l.Debugf("[%s] <== %s", reqID, plugintk.PluginMessageToJSON(res))
+	if log.IsTraceEnabled() {
+		l.Tracef("[%s] <== %s", reqID, plugintk.PluginMessageToJSON(res))
 	}
 	return nil
 }


### PR DESCRIPTION
The logs like this are extremely verbose for DEBUG level:

```
[2026-02-16T20:23:52.165Z] DEBUG d7d72e58-27a0-4225-aff7-d65609155750: ==> {"header":{"pluginId":"acff2e85-4c04-4cb7-b361-9a23feb46c9a", "messageId":"d7d72e58-27a0-4225-aff7-d65609155750", "messageType":"REQUEST_TO_PLUGIN"}, ....
```