### PR TITLE
Internal priority queues

### DIFF
--- a/common/go/pkg/pldmsgs/en_descriptions.go
+++ b/common/go/pkg/pldmsgs/en_descriptions.go
@@ -721,6 +721,7 @@ var (
 	SequencerConfigCoordinatorEventQueueSize         = pdm("SequencerConfig.coordinatorEventQueueSize", "Queue size for coordinator state machine events")
 	SequencerConfigCoordinatorPriorityEventQueueSize = pdm("SequencerConfig.coordinatorPriorityEventQueueSize", "Queue size for coordinator priority events")
 	SequencerConfigOriginatorEventQueueSize          = pdm("SequencerConfig.originatorEventQueueSize", "Queue size for originator state machine events")
+	SequencerConfigOriginatorPriorityEventQueueSize  = pdm("SequencerConfig.originatorPriorityEventQueueSize", "Queue size for originator priority events")
 	SequencerConfigClosingGracePeriod                = pdm("SequencerConfig.closingGracePeriod", "Grace period for closing operations")
 	SequencerConfigDelegateTimeout                   = pdm("SequencerConfig.delegateTimeout", "Timeout for re-delegating transactions")
 	SequencerConfigHeartbeatInterval                 = pdm("SequencerConfig.heartbeatInterval", "Heartbeat interval for coordinators")

--- a/config/pkg/pldconf/sequencermgr.go
+++ b/config/pkg/pldconf/sequencermgr.go
@@ -28,6 +28,7 @@ type SequencerConfig struct {
 	CoordinatorEventQueueSize         *int              `json:"coordinatorEventQueueSize"`
 	CoordinatorPriorityEventQueueSize *int              `json:"coordinatorPriorityEventQueueSize"`
 	OriginatorEventQueueSize          *int              `json:"originatorEventQueueSize"`
+	OriginatorPriorityEventQueueSize  *int              `json:"originatorPriorityEventQueueSize"`
 	ClosingGracePeriod                *int              `json:"closingGracePeriod"`
 	DelegateTimeout                   *string           `json:"delegateTimeout"`
 	HeartbeatInterval                 *string           `json:"heartbeatInterval"`
@@ -48,6 +49,7 @@ type SequencerMinimumConfig struct {
 	CoordinatorEventQueueSize         int
 	CoordinatorPriorityEventQueueSize int
 	OriginatorEventQueueSize          int
+	OriginatorPriorityEventQueueSize  int
 	ClosingGracePeriod                int
 	DelegateTimeout                   time.Duration
 	HeartbeatInterval                 time.Duration
@@ -69,8 +71,9 @@ var SequencerDefaults = SequencerConfig{
 	BlockHeightTolerance:              confutil.P(uint64(5)),
 	BlockRange:                        confutil.P(uint64(100)),
 	CoordinatorEventQueueSize:         confutil.P(100),
-	CoordinatorPriorityEventQueueSize: confutil.P(10),
+	CoordinatorPriorityEventQueueSize: confutil.P(500),
 	OriginatorEventQueueSize:          confutil.P(50),
+	OriginatorPriorityEventQueueSize:  confutil.P(500),
 	ClosingGracePeriod:                confutil.P(4),
 	DelegateTimeout:                   confutil.P("5s"),
 	HeartbeatInterval:                 confutil.P("10s"),
@@ -89,6 +92,7 @@ var SequencerMinimum = SequencerMinimumConfig{
 	CoordinatorEventQueueSize:         1,
 	CoordinatorPriorityEventQueueSize: 1,
 	OriginatorEventQueueSize:          1,
+	OriginatorPriorityEventQueueSize:  1,
 	ClosingGracePeriod:                1,
 	DelegateTimeout:                   100 * time.Millisecond,
 	HeartbeatInterval:                 1 * time.Second,

--- a/core/go/internal/sequencer/coordinator/coordinating.go
+++ b/core/go/internal/sequencer/coordinator/coordinating.go
@@ -70,7 +70,7 @@ func (c *coordinator) addToDelegatedTransactions(ctx context.Context, originator
 			hasChainedTransaction,
 			c.transportWriter,
 			c.clock,
-			c.QueueEvent,
+			c.queueEventInternal,
 			c.engineIntegration,
 			c.syncPoints,
 			c.requestTimeout,

--- a/core/go/internal/sequencer/coordinator/coordinator_test_utils.go
+++ b/core/go/internal/sequencer/coordinator/coordinator_test_utils.go
@@ -140,6 +140,10 @@ func copySequencerDefaultsForTest() *pldconf.SequencerConfig {
 		v := *def.OriginatorEventQueueSize
 		copy.OriginatorEventQueueSize = &v
 	}
+	if def.OriginatorPriorityEventQueueSize != nil {
+		v := *def.OriginatorPriorityEventQueueSize
+		copy.OriginatorPriorityEventQueueSize = &v
+	}
 	if def.ClosingGracePeriod != nil {
 		v := *def.ClosingGracePeriod
 		copy.ClosingGracePeriod = &v

--- a/core/go/internal/sequencer/originator/originating.go
+++ b/core/go/internal/sequencer/originator/originating.go
@@ -37,7 +37,7 @@ func (o *originator) createTransaction(ctx context.Context, txn *components.Priv
 	newTxn, err := transaction.NewTransaction(ctx,
 		txn,
 		o.transportWriter,
-		o.QueueEvent,
+		o.queueEventInternal,
 		o.engineIntegration,
 		o.metrics)
 	if err != nil {
@@ -156,7 +156,7 @@ func action_OriginatorTransactionStateTransition(ctx context.Context, o *origina
 	case transaction.State_Final:
 		o.removeTransaction(ctx, e.TransactionID)
 	case transaction.State_Confirmed, transaction.State_Reverted:
-		o.QueueEvent(ctx, &transaction.FinalizeEvent{
+		o.queueEventInternal(ctx, &transaction.FinalizeEvent{
 			BaseEvent:     common.BaseEvent{EventTime: e.GetEventTime()},
 			TransactionID: e.TransactionID,
 		})

--- a/core/go/internal/sequencer/originator/state_machine.go
+++ b/core/go/internal/sequencer/originator/state_machine.go
@@ -134,14 +134,15 @@ var stateDefinitionsMap = StateDefinitions{
 	},
 }
 
-func (o *originator) initializeStateMachineEventLoop(initialState State, eventQueueSize int) {
+func (o *originator) initializeStateMachineEventLoop(initialState State, eventQueueSize int, priorityEventQueueSize int) {
 	o.stateMachineEventLoop = statemachine.NewStateMachineEventLoop(statemachine.StateMachineEventLoopConfig[State, *originator]{
-		InitialState:   initialState,
-		Definitions:    stateDefinitionsMap,
-		Entity:         o,
-		EventQueueSize: eventQueueSize,
-		Name:           fmt.Sprintf("originator-%s", o.contractAddress.String()[0:8]),
-		PreProcess:     o.preProcessEvent,
+		InitialState:           initialState,
+		Definitions:            stateDefinitionsMap,
+		Entity:                 o,
+		EventQueueSize:         eventQueueSize,
+		PriorityEventQueueSize: priorityEventQueueSize,
+		Name:                   fmt.Sprintf("originator-%s", o.contractAddress.String()[0:8]),
+		PreProcess:             o.preProcessEvent,
 	})
 }
 

--- a/doc-site/docs/administration/configuration.md
+++ b/doc-site/docs/administration/configuration.md
@@ -788,13 +788,14 @@
 | blockRange | Block range size for sequencer operations | `uint64` | `100` |
 | closingGracePeriod | Grace period for closing operations | `int` | `4` |
 | coordinatorEventQueueSize | Queue size for coordinator state machine events | `int` | `100` |
-| coordinatorPriorityEventQueueSize | Queue size for coordinator priority events | `int` | `10` |
+| coordinatorPriorityEventQueueSize | Queue size for coordinator priority events | `int` | `500` |
 | delegateTimeout | Timeout for re-delegating transactions | `string` | `"5s"` |
 | heartbeatInterval | Heartbeat interval for coordinators | `string` | `"10s"` |
 | heartbeatThreshold | Heartbeat threshold | `int` | - |
 | maxDispatchAhead | Maximum number of transactions to dispatch ahead | `int` | `50` |
 | maxInflightTransactions | Maximum number of inflight transactions | `int` | `500` |
 | originatorEventQueueSize | Queue size for originator state machine events | `int` | `50` |
+| originatorPriorityEventQueueSize | Queue size for originator priority events | `int` | `500` |
 | requestTimeout | Timeout for sequencer requests | `string` | `"3s"` |
 | targetActiveCoordinators | Target number of active coordinators | `int` | `50` |
 | targetActiveSequencers | Target number of active sequencers | `int` | `50` |


### PR DESCRIPTION
Use the internal priority queue for queueing state transitions back from transactions to originator/coordinator and ensure that they are set by defualt to a size large enough not to cause deadlocks.

We have discussed that this is probably not the right pattern going forwards, and that relying on a queue size which has to increase with load, is a bad smell, but this PR provides an intermediate step before we can resolve this to make sure the system can function under load.