### PR TITLE
Fix poll and process intermittent nil pointer exceptions

### DIFF
--- a/core/go/internal/publictxmgr/transaction_orchestrator.go
+++ b/core/go/internal/publictxmgr/transaction_orchestrator.go
@@ -459,6 +459,10 @@ func (oc *orchestrator) pollAndProcess(ctx context.Context) (polled int, total i
 
 		log.L(ctx).Debugf("Orchestrator poll and process: polled %d items, space: %d", len(additional), spaces)
 		for _, ptx := range additional {
+			if ptx.Binding == nil {
+				log.L(ctx).Warnf("Orchestrator poll and process: transaction %d has no binding", ptx.PublicTxnID)
+				continue
+			}
 			queueUpdated = true
 			it := NewInFlightTransactionStageController(oc.pubTxManager, oc, ptx, ptx.Binding.Transaction)
 			oc.inFlightTxs = append(oc.inFlightTxs, it)


### PR DESCRIPTION
I think this is the test failure which has been showing up for sometime where we haven't been able to actually see the failure.

Changes for notifications back into the sequencer required in flight transaction controllers to be created with the private transaction ID. In a real production system the binding this is retrieved from is always there, but there were a number of tests which created a public transaction without this binding. Whether the test failed or not depended on whether the the poll and process loop ran in the duration of the test.

I've updated the tests to create the binding as well. But I've also updated the loop to log a warning message rather than fail and crash the process if this condition ever occurs due to a regression elsewhere in the system in the future.