### PR TITLE
Fix transaction dependency handling bugs and code quality issues

### DIFF
--- a/core/go/internal/msgs/en_errors.go
+++ b/core/go/internal/msgs/en_errors.go
@@ -437,6 +437,8 @@ var (
 	MsgTxMgrVerifierNotEthAddress                 = pde("PD012253", "Verifier '%s' is not an Ethereum address")
 	MsgTxMgrDependencyLookupFailed                = pde("PD012254", "Failed to lookup dependency transaction %s: %s")
 	MsgTxMgrResumeTXFailed                        = pde("PD012255", "Failed to resume transaction %s: %s")
+	MsgTxMgrDependencyFailed                      = pde("PD012256", "Dependency transaction %s failed")
+	MsgTxMgrFailDependentTXFailed                 = pde("PD012257", "Failed to propagate dependency failure to transaction %s: %s")
 
 	// FlushWriter module PD0123XX
 	MsgFlushWriterQuiescing      = pde("PD012300", "Writer shutting down")

--- a/core/go/internal/sequencer/coordinator/transaction/pooled.go
+++ b/core/go/internal/sequencer/coordinator/transaction/pooled.go
@@ -67,7 +67,7 @@ func (t *CoordinatorTransaction) hasUnknownDependencies(ctx context.Context) boo
 }
 
 // Initializes (or re-initializes) the transaction as it arrives in the pool
-func (t *CoordinatorTransaction) initializeForNewAssemply(ctx context.Context) error {
+func (t *CoordinatorTransaction) initializeForNewAssembly(ctx context.Context) error {
 	if t.pt.PreAssembly == nil {
 		msg := fmt.Sprintf("cannot calculate dependencies for transaction %s without a PreAssembly", t.pt.ID)
 		log.L(ctx).Error(msg)
@@ -145,7 +145,7 @@ func action_recordRevert(ctx context.Context, txn *CoordinatorTransaction, _ com
 }
 
 func action_initializeDependencies(ctx context.Context, txn *CoordinatorTransaction, _ common.Event) error {
-	return txn.initializeForNewAssemply(ctx)
+	return txn.initializeForNewAssembly(ctx)
 }
 
 func guard_HasUnassembledDependencies(ctx context.Context, txn *CoordinatorTransaction) bool {

--- a/core/go/internal/sequencer/coordinator/transaction/ready_for_dispatch_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/ready_for_dispatch_test.go
@@ -59,7 +59,7 @@ func Test_updateSigningIdentity_NoPostAssembly(t *testing.T) {
 	txn.pt.Signer = ""
 	txn.dynamicSigningIdentity = true
 
-	txn.updateSigningIdentity()
+	txn.updateSigningIdentity(context.Background())
 
 	assert.Empty(t, txn.pt.Signer)
 	assert.True(t, txn.dynamicSigningIdentity)
@@ -74,7 +74,7 @@ func Test_updateSigningIdentity_NoEndorsements(t *testing.T) {
 	txn.pt.Signer = ""
 	txn.dynamicSigningIdentity = true
 
-	txn.updateSigningIdentity()
+	txn.updateSigningIdentity(context.Background())
 
 	assert.Empty(t, txn.pt.Signer)
 	assert.True(t, txn.dynamicSigningIdentity)
@@ -99,7 +99,7 @@ func Test_updateSigningIdentity_EndorsementWithConstraint(t *testing.T) {
 	txn.pt.Signer = ""
 	txn.dynamicSigningIdentity = true
 
-	txn.updateSigningIdentity()
+	txn.updateSigningIdentity(context.Background())
 
 	assert.Equal(t, verifierLookup, txn.pt.Signer)
 	assert.False(t, txn.dynamicSigningIdentity)
@@ -121,7 +121,7 @@ func Test_updateSigningIdentity_EndorsementWithoutConstraint(t *testing.T) {
 	txn.pt.Signer = ""
 	txn.dynamicSigningIdentity = true
 
-	txn.updateSigningIdentity()
+	txn.updateSigningIdentity(context.Background())
 
 	assert.Empty(t, txn.pt.Signer)
 	assert.True(t, txn.dynamicSigningIdentity)
@@ -146,7 +146,7 @@ func Test_updateSigningIdentity_NonCoordinatorSubmitter(t *testing.T) {
 	txn.pt.Signer = ""
 	txn.dynamicSigningIdentity = true
 
-	txn.updateSigningIdentity()
+	txn.updateSigningIdentity(context.Background())
 
 	assert.Empty(t, txn.pt.Signer)
 	assert.True(t, txn.dynamicSigningIdentity)
@@ -156,49 +156,49 @@ func Test_dependentsMustWait_FixedSigningIdentity_Confirmed(t *testing.T) {
 	txn, _ := newTransactionForUnitTesting(t, nil)
 	txn.stateMachine.CurrentState = State_Confirmed
 
-	assert.False(t, txn.dependentsMustWait(false))
+	assert.False(t, txn.dependentsMustWait(context.Background(), false))
 }
 
 func Test_dependentsMustWait_FixedSigningIdentity_Submitted(t *testing.T) {
 	txn, _ := newTransactionForUnitTesting(t, nil)
 	txn.stateMachine.CurrentState = State_Submitted
 
-	assert.False(t, txn.dependentsMustWait(false))
+	assert.False(t, txn.dependentsMustWait(context.Background(), false))
 }
 
 func Test_dependentsMustWait_FixedSigningIdentity_Dispatched(t *testing.T) {
 	txn, _ := newTransactionForUnitTesting(t, nil)
 	txn.stateMachine.CurrentState = State_Dispatched
 
-	assert.False(t, txn.dependentsMustWait(false))
+	assert.False(t, txn.dependentsMustWait(context.Background(), false))
 }
 
 func Test_dependentsMustWait_FixedSigningIdentity_ReadyForDispatch(t *testing.T) {
 	txn, _ := newTransactionForUnitTesting(t, nil)
 	txn.stateMachine.CurrentState = State_Ready_For_Dispatch
 
-	assert.False(t, txn.dependentsMustWait(false))
+	assert.False(t, txn.dependentsMustWait(context.Background(), false))
 }
 
 func Test_dependentsMustWait_FixedSigningIdentity_NotReady(t *testing.T) {
 	txn, _ := newTransactionForUnitTesting(t, nil)
 	txn.stateMachine.CurrentState = State_Assembling
 
-	assert.True(t, txn.dependentsMustWait(false))
+	assert.True(t, txn.dependentsMustWait(context.Background(), false))
 }
 
 func Test_dependentsMustWait_DynamicSigningIdentity_Confirmed(t *testing.T) {
 	txn, _ := newTransactionForUnitTesting(t, nil)
 	txn.stateMachine.CurrentState = State_Confirmed
 
-	assert.False(t, txn.dependentsMustWait(true))
+	assert.False(t, txn.dependentsMustWait(context.Background(), true))
 }
 
 func Test_dependentsMustWait_DynamicSigningIdentity_NotReady(t *testing.T) {
 	txn, _ := newTransactionForUnitTesting(t, nil)
 	txn.stateMachine.CurrentState = State_Ready_For_Dispatch
 
-	assert.True(t, txn.dependentsMustWait(true))
+	assert.True(t, txn.dependentsMustWait(context.Background(), true))
 }
 
 func Test_hasDependenciesNotReady_NoDependencies(t *testing.T) {

--- a/core/go/internal/txmgr/dependency_listener_test.go
+++ b/core/go/internal/txmgr/dependency_listener_test.go
@@ -80,6 +80,8 @@ func TestBlockedByDependencies_DependencyWithFailedReceipt_ReturnsTrue(t *testin
 				sqlmock.NewRows([]string{"transaction", "sequence", "indexed", "domain", "success", "tx_hash", "block_number", "tx_index", "log_index", "source", "failure_message", "revert_data", "contract_address"}).
 					AddRow(depID, 1, "2024-01-01T00:00:00Z", "", false, nil, nil, nil, nil, nil, "failed", nil, nil),
 			)
+			// failDependentTransaction will attempt a new DB transaction to propagate the failure
+			mc.db.ExpectBegin().WillReturnError(fmt.Errorf("mock: propagation not under test"))
 		})
 	defer done()
 


### PR DESCRIPTION
### Summary

- Fix `BlockedByDependencies` to proactively propagate failure when a dependency transaction has already failed, instead of permanently blocking the dependent transaction
- Add recursion guard in `notifyDependentTransactions` to prevent unbounded failure propagation with circular dependencies
- Fix swapped log variables, inconsistent context usage, untranslated error strings, `context.Background()` usage in logging, and a function name typo

### Details

**Bug: Failed dependencies silently block dependents forever** (`dependency_listener.go`)

`BlockedByDependencies` treated "dependency receipt missing" (still in progress) and "dependency receipt present but failed" identically — both returned `(true, nil)`, causing the dependent to wait. But a failed dependency will never succeed, so the dependent was permanently stuck. Now the two cases are distinguished: missing receipt blocks as before, but a failed receipt triggers `failDependentTransaction` which proactively creates a failure receipt for the dependent.

**Bug: Circular dependency recursion** (`dependency_listener.go`)

`notifyDependentTransactions` propagates failure by calling `FinalizeTransactions`, which adds a pre-commit that calls `notifyDependentTransactions` again. With circular dependencies (A→B→A), this recursed without bound. Now we check if the dependent already has a receipt before propagating failure, breaking the cycle.

**Fix: Swapped log arguments** (`dependency_listener.go`)

The post-commit log `"Dependency %s successful, resuming TX %s", dep, receipt.TransactionID` had the arguments reversed — `dep` is the *dependent* being resumed, and `receipt.TransactionID` is the *dependency* that succeeded.

**Fix: Inconsistent context** (`dependency_listener.go`)

`notifyDependentTransactions` used `tm.bgCtx` for some DB calls instead of the caller-provided `ctx`, losing per-transaction logging/tracing context.

**Fix: Untranslated error string** (`dependency_listener.go`, `en_errors.go`)

The hardcoded `"Transaction dependency failed"` is now the i18n message `MsgTxMgrDependencyFailed` (`PD012256`), including the failed dependency TX ID for diagnostics.

**Fix: `context.Background()` in logging** (`ready_for_dispatch.go`)

`updateSigningIdentity` and `dependentsMustWait` used `context.Background()` for all `log.L()` calls, discarding caller context. Both now accept and propagate `ctx`.

**Fix: Typo `initializeForNewAssemply`** (`pooled.go`)

Renamed to `initializeForNewAssembly`.
 