### PR TITLE
Delete socket on start up if next over from previous process

### DIFF
--- a/core/go/internal/plugins/plugin_manager.go
+++ b/core/go/internal/plugins/plugin_manager.go
@@ -17,6 +17,7 @@ package plugins
 import (
 	"context"
 	"fmt"
+	iofs "io/fs"
 	"net"
 	"os"
 	"strings"
@@ -49,6 +50,7 @@ type pluginManager struct {
 	mux      sync.Mutex
 	listener net.Listener
 	server   *grpc.Server
+	fs       pluginManagerFileSystem
 
 	loaderID        uuid.UUID
 	grpcTarget      string
@@ -78,6 +80,22 @@ type pluginManager struct {
 	serverDone           chan error
 }
 
+// Wrapper around os.Lstat and os.Remove to allow for testing error cases
+type pluginManagerFileSystem interface {
+	Lstat(name string) (iofs.FileInfo, error)
+	Remove(name string) error
+}
+
+type osPluginManagerFileSystem struct{}
+
+func (osPluginManagerFileSystem) Lstat(name string) (iofs.FileInfo, error) {
+	return os.Lstat(name)
+}
+
+func (osPluginManagerFileSystem) Remove(name string) error {
+	return os.Remove(name)
+}
+
 func NewPluginManager(bgCtx context.Context,
 	grpcTarget string, // default is a UDS path, can use tcp:127.0.0.1:12345 strings too (or tcp4:/tcp6:)
 	loaderID uuid.UUID,
@@ -85,6 +103,7 @@ func NewPluginManager(bgCtx context.Context,
 
 	pc := &pluginManager{
 		bgCtx: log.WithComponent(bgCtx, log.Component("pluginmanager")),
+		fs:    osPluginManagerFileSystem{},
 
 		grpcTarget:      grpcTarget,
 		loaderID:        loaderID,
@@ -163,9 +182,10 @@ func (pm *pluginManager) PostInit(c components.AllComponents) error {
 func (pm *pluginManager) Start() (err error) {
 	ctx := pm.bgCtx
 	log.L(ctx).Infof("server starting on %s:%s", pm.network, pm.address)
-	if stat, statErr := os.Lstat(pm.address); statErr == nil {
+
+	if stat, statErr := pm.fs.Lstat(pm.address); statErr == nil {
 		if !stat.IsDir() {
-			if err := os.Remove(pm.address); err != nil && !os.IsNotExist(err) {
+			if err := pm.fs.Remove(pm.address); err != nil && !os.IsNotExist(err) {
 				log.L(ctx).Error("failed to remove stale listener path: ", err)
 				return err
 			}

--- a/core/go/internal/plugins/plugin_manager_test.go
+++ b/core/go/internal/plugins/plugin_manager_test.go
@@ -16,6 +16,7 @@ package plugins
 
 import (
 	"context"
+	iofs "io/fs"
 	"os"
 	"strings"
 	"testing"
@@ -160,6 +161,69 @@ func TestInitPluginManagerBadSocket(t *testing.T) {
 
 	err = pc.Start()
 	assert.Regexp(t, "bind", err)
+}
+
+type testPluginManagerFileSystem struct {
+	lstatFunc  func(name string) (iofs.FileInfo, error)
+	removeFunc func(name string) error
+}
+
+func (tfs *testPluginManagerFileSystem) Lstat(name string) (iofs.FileInfo, error) {
+	return tfs.lstatFunc(name)
+}
+
+func (tfs *testPluginManagerFileSystem) Remove(name string) error {
+	return tfs.removeFunc(name)
+}
+
+func TestInitPluginManagerSocketLstatError(t *testing.T) {
+	pc := NewPluginManager(context.Background(),
+		tempUDS(t),
+		uuid.New(), &pldconf.PluginManagerInlineConfig{},
+	)
+	err := pc.PostInit((&testManagers{}).componentsmocks(t))
+	require.NoError(t, err)
+
+	expectedErr := os.ErrPermission
+	pm := pc.(*pluginManager)
+	pm.fs = &testPluginManagerFileSystem{
+		lstatFunc: func(name string) (iofs.FileInfo, error) {
+			return nil, expectedErr
+		},
+		removeFunc: func(name string) error {
+			t.Fatalf("remove should not be called when lstat fails")
+			return nil
+		},
+	}
+
+	err = pm.Start()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestInitPluginManagerRemoveStaleSocketError(t *testing.T) {
+	pc := NewPluginManager(context.Background(),
+		tempUDS(t),
+		uuid.New(), &pldconf.PluginManagerInlineConfig{},
+	)
+	err := pc.PostInit((&testManagers{}).componentsmocks(t))
+	require.NoError(t, err)
+
+	expectedErr := os.ErrPermission
+	pm := pc.(*pluginManager)
+	require.NoError(t, os.WriteFile(pm.address, []byte("stale"), 0o600))
+	pm.fs = &testPluginManagerFileSystem{
+		lstatFunc: func(name string) (iofs.FileInfo, error) {
+			return os.Lstat(name)
+		},
+		removeFunc: func(name string) error {
+			return expectedErr
+		},
+	}
+
+	err = pm.Start()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
 }
 
 func TestInitPluginManagerStaleSocketFile(t *testing.T) {


### PR DESCRIPTION
Fixes a bug where if a socket was left over from a previous process, Paladin fails to start. In KinD this manifested as a crash loop back off which could only be fixed by restarting the pod (as opposed to just the container which got the system into this state).