### PR TITLE
Handle coordinator function signatures on private transaction resume

### DIFF
--- a/core/go/internal/sequencer/sequencer_lifecycle_test.go
+++ b/core/go/internal/sequencer/sequencer_lifecycle_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/mocks/metricsmocks"
 	"github.com/LFDT-Paladin/paladin/core/mocks/persistencemocks"
 	"github.com/LFDT-Paladin/paladin/core/pkg/blockindexer"
+	"github.com/LFDT-Paladin/paladin/core/pkg/persistence"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
@@ -177,6 +178,38 @@ func TestSequencer_GetTransportWriter(t *testing.T) {
 
 	transportWriter := seq.GetTransportWriter()
 	assert.Equal(t, mocks.transportWriter, transportWriter)
+}
+
+func TestSequencerManager_HandleTxResume_DeployShapedConstructorStringBlockedByDeps(t *testing.T) {
+	ctx := context.Background()
+	mocks := newSequencerLifecycleTestMocks(t)
+	sm := newSequencerManagerForTesting(t, mocks)
+
+	txID := uuid.New()
+	dbTX := persistencemocks.NewDBTX(t)
+	txi := &components.ValidatedTransaction{
+		ResolvedTransaction: components.ResolvedTransaction{
+			Transaction: &pldapi.Transaction{
+				ID: &txID,
+				TransactionBase: pldapi.TransactionBase{
+					Function: "constructor()",
+					To:       nil,
+				},
+			},
+		},
+	}
+
+	mocks.components.EXPECT().Persistence().Return(mocks.persistence).Once()
+	mocks.components.EXPECT().TxManager().Return(mocks.txManager).Once()
+	mocks.persistence.EXPECT().Transaction(mock.Anything, mock.Anything).RunAndReturn(
+		func(txCtx context.Context, fn func(context.Context, persistence.DBTX) error) error {
+			return fn(txCtx, dbTX)
+		},
+	).Once()
+	mocks.txManager.EXPECT().BlockedByDependencies(mock.Anything, dbTX, txi).Return(true, nil).Once()
+
+	err := sm.HandleTxResume(ctx, txi)
+	require.NoError(t, err)
 }
 
 func TestSequencerManager_LoadSequencer_NewSequencer(t *testing.T) {

--- a/core/go/internal/txmgr/transaction_query.go
+++ b/core/go/internal/txmgr/transaction_query.go
@@ -30,6 +30,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/query"
 	"github.com/google/uuid"
+	"github.com/hyperledger/firefly-signer/pkg/abi"
 	"gorm.io/gorm"
 )
 
@@ -378,7 +379,15 @@ func (tm *txManager) resolveABIReferencesAndCache(ctx context.Context, dbTX pers
 				return nil, i18n.WrapError(ctx, err, msgs.MsgTxMgrABIReferenceLookupFailed, tx.Transaction.ABIReference)
 			}
 		}
-		resolvedFunction, err := tm.pickFunction(ctx, a, tx.Transaction.Function, tx.Transaction.To)
+		// On create, a transaction which is calling a constructor will have provide an empty string for the function;
+		// however, what gets persisted is the signature of the constructor, i.e. the resolved function. This means
+		// that we must be able to go back from the constructor signature to the empty string ahead of resolving the
+		// function again
+		requiredFunction := tx.Transaction.Function
+		if tx.Transaction.To == nil && isConstructorSignature(a, requiredFunction) {
+			requiredFunction = ""
+		}
+		resolvedFunction, err := tm.pickFunction(ctx, a, requiredFunction, tx.Transaction.To)
 		if err != nil {
 			return nil, err
 		}
@@ -388,6 +397,22 @@ func (tm *txManager) resolveABIReferencesAndCache(ctx context.Context, dbTX pers
 		tm.txCache.Set(*tx.Transaction.ID, tx)
 	}
 	return txs, nil
+}
+
+func isConstructorSignature(pa *pldapi.StoredABI, requiredFunction string) bool {
+	if requiredFunction == "" {
+		return false
+	}
+	for _, e := range pa.ABI {
+		if e.Type != abi.Constructor {
+			continue
+		}
+		signature, _ := e.Signature()
+		if requiredFunction == signature {
+			return true
+		}
+	}
+	return false
 }
 
 func (tm *txManager) GetTransactionByIDFull(ctx context.Context, id uuid.UUID) (result *pldapi.TransactionFull, err error) {

--- a/core/go/internal/txmgr/transaction_query_test.go
+++ b/core/go/internal/txmgr/transaction_query_test.go
@@ -242,6 +242,66 @@ func TestResolveABIReferencesAndCacheBadFunc(t *testing.T) {
 	assert.Regexp(t, "PD012206", err)
 }
 
+func TestResolveABIReferencesAndCacheConstructorSignatureWithNilTo(t *testing.T) {
+	var abiHash = (pldtypes.Bytes32)(pldtypes.RandBytes(32))
+	ctx, txm, done := newTestTransactionManager(t, false,
+		mockEmptyReceiptListeners,
+		func(conf *pldconf.TxManagerConfig, mc *mockComponents) {
+			mc.db.ExpectQuery("SELECT.*abis").WillReturnRows(mc.db.NewRows([]string{"hash", "abi"}).AddRow(
+				abiHash.String(), `[{
+					"type":"constructor",
+					"inputs":[
+						{"name":"group","type":"tuple","components":[{"name":"salt","type":"bytes32"},{"name":"members","type":"string[]"}]},
+						{"name":"endorsementType","type":"string"},
+						{"name":"evmVersion","type":"string"},
+						{"name":"externalCallsEnabled","type":"bool"}
+					]
+				}]`,
+			))
+		})
+	defer done()
+
+	txID := uuid.New()
+	txs, err := txm.resolveABIReferencesAndCache(ctx, txm.p.NOTX(), []*components.ResolvedTransaction{
+		{Transaction: &pldapi.Transaction{
+			ID: &txID,
+			TransactionBase: pldapi.TransactionBase{
+				Function:     "((bytes32,string[]),string,string,bool)",
+				To:           nil,
+				ABIReference: confutil.P(abiHash),
+			},
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.NotNil(t, txs[0].Function)
+	assert.Equal(t, "((bytes32,string[]),string,string,bool)", txs[0].Function.Signature)
+}
+
+func TestResolveABIReferencesAndCacheFunctionWithNilToStillFails(t *testing.T) {
+	var abiHash = (pldtypes.Bytes32)(pldtypes.RandBytes(32))
+	ctx, txm, done := newTestTransactionManager(t, false,
+		mockEmptyReceiptListeners,
+		func(conf *pldconf.TxManagerConfig, mc *mockComponents) {
+			mc.db.ExpectQuery("SELECT.*abis").WillReturnRows(mc.db.NewRows([]string{"hash", "abi"}).AddRow(
+				abiHash.String(), `[]`,
+			))
+		})
+	defer done()
+
+	_, err := txm.resolveABIReferencesAndCache(ctx, txm.p.NOTX(), []*components.ResolvedTransaction{
+		{Transaction: &pldapi.Transaction{
+			ID: confutil.P(uuid.New()),
+			TransactionBase: pldapi.TransactionBase{
+				Function:     "doStuff()",
+				To:           nil,
+				ABIReference: confutil.P(abiHash),
+			},
+		}},
+	})
+	assert.Regexp(t, "PD012204", err)
+}
+
 func TestMapPersistedTXSequencingActivity(t *testing.T) {
 	_, txm, done := newTestTransactionManager(t, false, mockEmptyReceiptListeners)
 	defer done()


### PR DESCRIPTION
On create, a transaction which is calling a constructor will have provide an empty string for the function; however, what gets persisted is the signature of the constructor, i.e. the resolved function. This means that when resuming a transaction we must be able to go back from the constructor signature to the empty string ahead of resolving the function again.