### PR TITLE
Check that transaction has not been repooled while in dispatch queue

### DIFF
--- a/core/go/internal/sequencer/coordinator/dispatch_loop.go
+++ b/core/go/internal/sequencer/coordinator/dispatch_loop.go
@@ -47,6 +47,18 @@ func (c *coordinator) dispatchLoop(ctx context.Context) {
 				}
 			}
 
+			// A transaction might have been queued while ready, then moved back to pooled
+			// before the dispatch loop processed it. Skip stale queue entries.
+			if tx.GetCurrentState() != transaction.State_Ready_For_Dispatch {
+				log.L(ctx).Debugf(
+					"skipping stale transaction %s from dispatch queue. current state: %s",
+					tx.GetID().String(),
+					tx.GetCurrentState(),
+				)
+				c.inFlightMutex.L.Unlock()
+				continue
+			}
+
 			// Dispatch and then asynchronously update the state machine to State_Dispatched
 			log.L(ctx).Debugf("submitting transaction %s for dispatch", tx.GetID().String())
 			c.readyForDispatch(ctx, tx)

--- a/core/go/internal/sequencer/coordinator/dispatch_loop_test.go
+++ b/core/go/internal/sequencer/coordinator/dispatch_loop_test.go
@@ -73,3 +73,58 @@ func TestDispatchLoop_StopAtSelect(t *testing.T) {
 	// Stop without ever queueing a tx; loop is blocked on select between dispatchQueue and stopDispatchLoop
 	c.Stop()
 }
+
+func TestDispatchLoop_SkipsStaleQueuedTransaction(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
+	config := builder.GetSequencerConfig()
+	config.MaxDispatchAhead = confutil.P(1)
+	builder.OverrideSequencerConfig(config)
+	c, _ := builder.Build(ctx)
+	defer c.Stop()
+
+	dispatchedTxIDs := make(chan string, 2)
+	c.readyForDispatch = func(_ context.Context, tx *transaction.CoordinatorTransaction) {
+		dispatchedTxIDs <- tx.GetID().String()
+	}
+
+	// Pre-populate in-flight to force the dispatch loop to wait after pulling from queue.
+	inFlightTxn := transaction.NewTransactionBuilderForTesting(t, transaction.State_Dispatched).Build()
+	c.inFlightMutex.L.Lock()
+	c.inFlightTxns[inFlightTxn.GetID()] = inFlightTxn
+	c.inFlightMutex.L.Unlock()
+
+	staleTxn := transaction.NewTransactionBuilderForTesting(t, transaction.State_Ready_For_Dispatch).Build()
+	validTxn := transaction.NewTransactionBuilderForTesting(t, transaction.State_Ready_For_Dispatch).Build()
+	c.transactionsByID[staleTxn.GetID()] = staleTxn
+	c.transactionsByID[validTxn.GetID()] = validTxn
+
+	err := action_TransactionStateTransition(ctx, c, &common.TransactionStateTransitionEvent[transaction.State]{
+		TransactionID: staleTxn.GetID(),
+		To:            transaction.State_Ready_For_Dispatch,
+	})
+	require.NoError(t, err)
+	err = action_TransactionStateTransition(ctx, c, &common.TransactionStateTransitionEvent[transaction.State]{
+		TransactionID: validTxn.GetID(),
+		To:            transaction.State_Ready_For_Dispatch,
+	})
+	require.NoError(t, err)
+
+	// Simulate dependency repool while queued for dispatch.
+	err = staleTxn.HandleEvent(ctx, &transaction.DependencyRepooledEvent{
+		BaseCoordinatorEvent: transaction.BaseCoordinatorEvent{
+			TransactionID: staleTxn.GetID(),
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, transaction.State_Pooled, staleTxn.GetCurrentState())
+
+	// Release the dispatch loop and allow it to process the stale queue entry.
+	c.inFlightMutex.L.Lock()
+	delete(c.inFlightTxns, inFlightTxn.GetID())
+	c.inFlightMutex.Signal()
+	c.inFlightMutex.L.Unlock()
+
+	txID := <-dispatchedTxIDs
+	require.Equal(t, validTxn.GetID().String(), txID, "expected only the valid queued transaction to dispatch")
+}


### PR DESCRIPTION
There is a timing window where a transaction is in the dispatch queue but a transaction it depends on has reverted on the base ledger so we have repooled the transaction. This causes a reset of the transaction meaning that it can't be dispatched. The dispatch loop was still picking it up though, including sending a dispatched event to the originator, which meant the originator transaction transitioned to a state where it wouldn't listen to any more assemble requests, meaning the transaction was stuck. 

It isn't possible to removed a transaction from the dispatch queue, so the best we can do is reject it in the loop if it isn't in READY_TO_DISPATCH state