### PR TITLE
Fix IDs for transaction state machine logging

### DIFF
--- a/core/go/internal/sequencer/coordinator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine.go
@@ -379,7 +379,7 @@ var stateDefinitionsMap = StateDefinitions{
 
 func (t *CoordinatorTransaction) initializeStateMachine(initialState State) {
 	t.stateMachine = statemachine.NewStateMachine(initialState, stateDefinitionsMap,
-		fmt.Sprintf("coord-tx-%s", t.pt.Address.String()[0:8]),
+		fmt.Sprintf("coord-tx-%s", t.pt.ID.String()[0:8]),
 		statemachine.WithTransitionCallback(func(ctx context.Context, t *CoordinatorTransaction, from, to State, event common.Event) {
 			// Reset heartbeat counter on state change
 			t.heartbeatIntervalsSinceStateChange = 0

--- a/core/go/internal/sequencer/originator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine.go
@@ -458,7 +458,7 @@ var stateDefinitionsMap = StateDefinitions{
 
 func (t *OriginatorTransaction) initializeStateMachine(initialState State) {
 	t.stateMachine = statemachine.NewStateMachine(initialState, stateDefinitionsMap,
-		fmt.Sprintf("orig-tx-%s", t.pt.Address.String()[0:8]),
+		fmt.Sprintf("orig-tx-%s", t.pt.ID.String()[0:8]),
 		statemachine.WithTransitionCallback(func(ctx context.Context, t *OriginatorTransaction, from, to State, event common.Event) {
 			if t.queueEventForOriginator != nil {
 				t.queueEventForOriginator(ctx, &common.TransactionStateTransitionEvent[State]{


### PR DESCRIPTION
We have been logging the contract address like the coordinator/originator which means you can't distinguish between lines for individual transaction.