### PR TITLE
add back privateTxManager as deprecated in pldconf

### DIFF
--- a/common/go/pkg/pldmsgs/en_descriptions.go
+++ b/common/go/pkg/pldmsgs/en_descriptions.go
@@ -383,6 +383,7 @@ var (
 	PaladinConfigBlockIndexer     = pdm("PaladinConfig.blockIndexer", "Block indexer configuration")
 	PaladinConfigTempDir          = pdm("PaladinConfig.tempDir", "Temporary directory path")
 	PaladinConfigTxManager        = pdm("PaladinConfig.txManager", "Transaction manager configuration")
+	PaladinConfigPrivateTxManager = pdm("PaladinConfig.privateTxManager", "Private transaction manager configuration")
 	PaladinConfigSequencerManager = pdm("PaladinConfig.sequencerManager", "Sequencer manager configuration")
 	PaladinConfigPublicTxManager  = pdm("PaladinConfig.publicTxManager", "Public transaction manager configuration")
 	PaladinConfigIdentityResolver = pdm("PaladinConfig.identityResolver", "Identity resolver configuration")
@@ -704,11 +705,19 @@ var (
 	IdentityResolverConfigVerifierCache = pdm("IdentityResolverConfig.verifierCache", "Verifier cache configuration")
 
 	// PrivateTxManagerConfig field descriptions
-	PrivateTxManagerConfigWriter                         = pdm("PrivateTxManagerConfig.writer", "Writer configuration")
-	PrivateTxManagerConfigSequencer                      = pdm("PrivateTxManagerConfig.sequencer", "Sequencer configuration")
-	PrivateTxManagerConfigStateDistributer               = pdm("PrivateTxManagerConfig.stateDistributer", "State distributer configuration")
-	PrivateTxManagerConfigPreparedTransactionDistributer = pdm("PrivateTxManagerConfig.preparedTransactionDistributer", "Prepared transaction distributer configuration")
-	PrivateTxManagerConfigRequestTimeout                 = pdm("PrivateTxManagerConfig.requestTimeout", "Request timeout")
+	PrivateTxManagerConfigWriter                                       = pdm("PrivateTxManagerConfig.writer", "Writer configuration")
+	PrivateTxManagerConfigSequencer                                    = pdm("PrivateTxManagerConfig.sequencer", "Sequencer configuration")
+	PrivateTxManagerConfigStateDistributer                             = pdm("PrivateTxManagerConfig.stateDistributer", "State distributer configuration")
+	PrivateTxManagerConfigPreparedTransactionDistributer               = pdm("PrivateTxManagerConfig.preparedTransactionDistributer", "Prepared transaction distributer configuration")
+	PrivateTxManagerConfigRequestTimeout                               = pdm("PrivateTxManagerConfig.requestTimeout", "Request timeout")
+	PrivateTxManagerSequencerConfigAssembleRequestTimeout              = pdm("PrivateTxManagerSequencerConfig.assembleRequestTimeout", "Assemble request timeout")
+	PrivateTxManagerSequencerConfigEvaluationInterval                  = pdm("PrivateTxManagerSequencerConfig.evalInterval", "Evaluation interval")
+	PrivateTxManagerSequencerConfigMaxConcurrentProcess                = pdm("PrivateTxManagerSequencerConfig.maxConcurrentProcess", "Maximum concurrent processes")
+	PrivateTxManagerSequencerConfigMaxInflightTransactions             = pdm("PrivateTxManagerSequencerConfig.maxInflightTransactions", "Maximum inflight transactions")
+	PrivateTxManagerSequencerConfigMaxPendingEvents                    = pdm("PrivateTxManagerSequencerConfig.maxPendingEvents", "Maximum pending events")
+	PrivateTxManagerSequencerConfigPersistenceRetryTimeout             = pdm("PrivateTxManagerSequencerConfig.persistenceRetryTimeout", "Persistence retry timeout")
+	PrivateTxManagerSequencerConfigRoundRobinCoordinatorBlockRangeSize = pdm("PrivateTxManagerSequencerConfig.roundRobinCoordinatorBlockRangeSize", "Round robin coordinator block range size")
+	PrivateTxManagerSequencerConfigStaleTimeout                        = pdm("PrivateTxManagerSequencerConfig.staleTimeout", "Stale timeout")
 
 	// DistributerConfig field descriptions
 	DistributerConfigAcknowledgementWriter = pdm("DistributerConfig.acknowledgementWriter", "Acknowledgement writer configuration")

--- a/config/pkg/pldconf/config.go
+++ b/config/pkg/pldconf/config.go
@@ -33,6 +33,7 @@ type PaladinConfig struct {
 	BlockIndexer                 BlockIndexerConfig     `json:"blockIndexer"`
 	TempDir                      *string                `json:"tempDir"`
 	TxManager                    TxManagerConfig        `json:"txManager"`
+	PrivateTxManager             PrivateTxManagerConfig `json:"privateTxManager"` // deprecated
 	SequencerManager             SequencerConfig        `json:"sequencerManager"`
 	PublicTxManager              PublicTxManagerConfig  `json:"publicTxManager"`
 	IdentityResolver             IdentityResolverConfig `json:"identityResolver"`

--- a/config/pkg/pldconf/privatetxmgr.go
+++ b/config/pkg/pldconf/privatetxmgr.go
@@ -16,6 +16,7 @@ package pldconf
 
 import "github.com/LFDT-Paladin/paladin/config/pkg/confutil"
 
+// Deprecated, this is ignored in Paladin v1
 type PrivateTxManagerConfig struct {
 	Writer                         FlushWriterConfig               `json:"writer"`
 	Sequencer                      PrivateTxManagerSequencerConfig `json:"sequencer"`

--- a/doc-site/docs/administration/configuration.md
+++ b/doc-site/docs/administration/configuration.md
@@ -18,6 +18,7 @@
 | nodeName | Node name for transport identification | `string` | - |
 | peerInactivityTimeout | Timeout for peer inactivity detection | `string` | - |
 | peerReaperInterval | Interval for peer reaper cleanup | `string` | - |
+| privateTxManager | Private transaction manager configuration | [`PrivateTxManagerConfig`](#privatetxmanager) | - |
 | publicTxManager | Public transaction manager configuration | [`PublicTxManagerConfig`](#publictxmanager) | - |
 | registries | Map of registry configurations | [`map[string][RegistryConfig]`](#registries) | - |
 | registryManager | Registry manager configuration | [`RegistryManagerConfig`](#registrymanager) | - |
@@ -405,6 +406,83 @@
 | shutdownTimeout | Shutdown timeout | `string` | `"10s"` |
 | tls | TLS configuration | [`TLSConfig`](#metricsservertls) | - |
 | writeTimeout | Write timeout | `string` | - |
+
+## privateTxManager
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| preparedTransactionDistributer | Prepared transaction distributer configuration | [`DistributerConfig`](#privatetxmanagerpreparedtransactiondistributer) | - |
+| requestTimeout | Request timeout | `string` | - |
+| sequencer | Sequencer configuration | [`PrivateTxManagerSequencerConfig`](#privatetxmanagersequencer) | - |
+| stateDistributer | State distributer configuration | [`DistributerConfig`](#privatetxmanagerstatedistributer) | - |
+| writer | Writer configuration | [`FlushWriterConfig`](#privatetxmanagerwriter) | - |
+
+## privateTxManager.preparedTransactionDistributer
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| acknowledgementWriter | Acknowledgement writer configuration | [`FlushWriterConfig`](#privatetxmanagerpreparedtransactiondistributeracknowledgementwriter) | - |
+| receivedStateWriter | Received state writer configuration | [`FlushWriterConfig`](#privatetxmanagerpreparedtransactiondistributerreceivedstatewriter) | - |
+
+## privateTxManager.preparedTransactionDistributer.acknowledgementWriter
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| batchMaxSize | Maximum batch size | `int` | - |
+| batchTimeout | Timeout for batch operations | `string` | - |
+| workerCount | Number of worker threads | `int` | - |
+
+## privateTxManager.preparedTransactionDistributer.receivedStateWriter
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| batchMaxSize | Maximum batch size | `int` | - |
+| batchTimeout | Timeout for batch operations | `string` | - |
+| workerCount | Number of worker threads | `int` | - |
+
+## privateTxManager.sequencer
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| assembleRequestTimeout | Assemble request timeout | `string` | - |
+| evalInterval | Evaluation interval | `string` | - |
+| maxConcurrentProcess | Maximum concurrent processes | `int` | - |
+| maxInflightTransactions | Maximum inflight transactions | `int` | - |
+| maxPendingEvents | Maximum pending events | `int` | - |
+| persistenceRetryTimeout | Persistence retry timeout | `string` | - |
+| roundRobinCoordinatorBlockRangeSize | Round robin coordinator block range size | `int` | - |
+| staleTimeout | Stale timeout | `string` | - |
+
+## privateTxManager.stateDistributer
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| acknowledgementWriter | Acknowledgement writer configuration | [`FlushWriterConfig`](#privatetxmanagerstatedistributeracknowledgementwriter) | - |
+| receivedStateWriter | Received state writer configuration | [`FlushWriterConfig`](#privatetxmanagerstatedistributerreceivedstatewriter) | - |
+
+## privateTxManager.stateDistributer.acknowledgementWriter
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| batchMaxSize | Maximum batch size | `int` | - |
+| batchTimeout | Timeout for batch operations | `string` | - |
+| workerCount | Number of worker threads | `int` | - |
+
+## privateTxManager.stateDistributer.receivedStateWriter
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| batchMaxSize | Maximum batch size | `int` | - |
+| batchTimeout | Timeout for batch operations | `string` | - |
+| workerCount | Number of worker threads | `int` | - |
+
+## privateTxManager.writer
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| batchMaxSize | Maximum batch size | `int` | - |
+| batchTimeout | Timeout for batch operations | `string` | - |
+| workerCount | Number of worker threads | `int` | - |
 
 ## publicTxManager
 


### PR DESCRIPTION
Adding back the `pldconf` as deprecated, to help support non-v1 deployments during upgrade. This is good to have while v1 is still not fully released, and likely can be removed later. This config is a no-op now, but allows the v1 config package to be used to unmarshal config structures. 