### PR TITLE
Remove fake clock

### DIFF
--- a/core/go/internal/sequencer/common/clock.go
+++ b/core/go/internal/sequencer/common/clock.go
@@ -23,24 +23,18 @@ import (
 type Clock interface {
 	//wrapper of time.Now()
 	//primarily to allow artificial clocks to be injected for testing
-	Now() Time
-	HasExpired(Time, Duration) bool
-	Duration(milliseconds int) Duration
-	ScheduleTimer(context.Context, Duration, func()) (cancel func())
-}
-
-type Duration interface {
-}
-
-type Time interface {
+	Now() time.Time
+	HasExpired(time.Time, time.Duration) bool
+	Duration(milliseconds int) time.Duration
+	ScheduleTimer(context.Context, time.Duration, func()) (cancel func())
 }
 
 type realClock struct{}
 
-func (c *realClock) Duration(milliseconds int) Duration {
+func (c *realClock) Duration(milliseconds int) time.Duration {
 	return time.Duration(milliseconds) * time.Millisecond
 }
-func (c *realClock) Now() Time {
+func (c *realClock) Now() time.Time {
 	return time.Now()
 }
 
@@ -48,16 +42,13 @@ func RealClock() Clock {
 	return &realClock{}
 }
 
-func (c *realClock) HasExpired(start Time, duration Duration) bool {
-	realStart := start.(time.Time)
-	realDuration := duration.(time.Duration)
-	return !time.Now().Before(realStart.Add(realDuration))
+func (c *realClock) HasExpired(start time.Time, duration time.Duration) bool {
+	return !time.Now().Before(start.Add(duration))
 }
 
-func (c *realClock) ScheduleTimer(ctx context.Context, duration Duration, f func()) (cancel func()) {
+func (c *realClock) ScheduleTimer(ctx context.Context, duration time.Duration, f func()) (cancel func()) {
 	timerCtx, cancel := context.WithCancel(ctx)
-	realDuration := duration.(time.Duration)
-	timer := time.NewTimer(realDuration)
+	timer := time.NewTimer(duration)
 	go func() {
 		defer timer.Stop()
 		select {
@@ -68,71 +59,4 @@ func (c *realClock) ScheduleTimer(ctx context.Context, duration Duration, f func
 		}
 	}()
 	return cancel
-}
-
-type FakeClockForTesting struct {
-	currentTime   int
-	pendingTimers []pendingTimer
-}
-
-type pendingTimer struct {
-	fireTime  int
-	callback  func()
-	cancelled *bool
-}
-
-type fakeTime struct {
-	milliseconds int
-}
-
-type fakeDuration struct {
-	milliseconds int
-}
-
-// On the fake clock, time is just a number (milliseconds).
-// Advance adds to currentTime and runs any scheduled timer callbacks whose fire time is now in the past.
-func (c *FakeClockForTesting) Advance(advance int) {
-	c.currentTime += advance
-	var stillPending []pendingTimer
-	for _, pt := range c.pendingTimers {
-		if pt.cancelled != nil && *pt.cancelled {
-			continue
-		}
-		if pt.fireTime <= c.currentTime && pt.callback != nil {
-			pt.callback()
-			continue
-		}
-		stillPending = append(stillPending, pt)
-	}
-	c.pendingTimers = stillPending
-}
-
-func (c *FakeClockForTesting) Now() Time {
-	return &fakeTime{c.currentTime}
-}
-
-func (c *FakeClockForTesting) HasExpired(start Time, duration Duration) bool {
-	startMillis := start.(*fakeTime).milliseconds
-	durationMillis := duration.(*fakeDuration).milliseconds
-	nowMillis := c.currentTime
-	return nowMillis >= startMillis+durationMillis
-}
-
-func (c *FakeClockForTesting) ScheduleTimer(_ context.Context, duration Duration, f func()) (cancel func()) {
-	var durationMillis int
-	if fake, ok := duration.(*fakeDuration); ok {
-		durationMillis = fake.milliseconds
-	} else {
-		durationMillis = int(duration.(time.Duration).Milliseconds())
-	}
-	fireTime := c.currentTime + durationMillis
-	cancelled := false
-	c.pendingTimers = append(c.pendingTimers, pendingTimer{fireTime: fireTime, callback: f, cancelled: &cancelled})
-	return func() {
-		cancelled = true
-	}
-}
-
-func (c *FakeClockForTesting) Duration(milliseconds int) Duration {
-	return &fakeDuration{milliseconds}
 }

--- a/core/go/internal/sequencer/common/clock_test.go
+++ b/core/go/internal/sequencer/common/clock_test.go
@@ -73,16 +73,6 @@ func TestRealClock_HasExpired_FutureStart(t *testing.T) {
 	assert.False(t, expired, "should not be expired when start + duration is in the future")
 }
 
-func TestFakeClock_HasExpired_ExactlyAtExpiry(t *testing.T) {
-	clock := &FakeClockForTesting{}
-	start := clock.Now()
-	duration := clock.Duration(100)
-
-	clock.Advance(100)
-	expired := clock.HasExpired(start, duration)
-	assert.True(t, expired, "should be expired when now is exactly start + duration")
-}
-
 func TestRealClock_ScheduleTimer_FiresAfterDuration(t *testing.T) {
 	clock := RealClock()
 	ctx := context.Background()
@@ -223,110 +213,6 @@ func TestRealClock_ScheduleTimer_ShortDuration(t *testing.T) {
 	mu.Lock()
 	assert.True(t, fired, "timer function should have been called even with short duration")
 	mu.Unlock()
-
-	cancel()
-}
-
-func TestFakeClockForTesting_ScheduleTimer_ReturnsCancelFunction(t *testing.T) {
-	clock := &FakeClockForTesting{}
-	ctx := context.Background()
-	duration := clock.Duration(100)
-	var callbackCalled bool
-
-	cancel := clock.ScheduleTimer(ctx, duration, func() {
-		callbackCalled = true
-	})
-
-	// Verify cancel function is returned and can be called
-	assert.NotNil(t, cancel, "ScheduleTimer should return a cancel function")
-
-	// Call cancel - should not panic
-	cancel()
-
-	// Verify callback was never called (fake clock doesn't actually schedule)
-	assert.False(t, callbackCalled, "callback should not be called in fake clock")
-}
-
-func TestFakeClockForTesting_ScheduleTimer_CallbackNeverFires(t *testing.T) {
-	clock := &FakeClockForTesting{}
-	ctx := context.Background()
-	duration := clock.Duration(50)
-	var callbackCalled bool
-	var mu sync.Mutex
-
-	f := func() {
-		mu.Lock()
-		defer mu.Unlock()
-		callbackCalled = true
-	}
-
-	cancel := clock.ScheduleTimer(ctx, duration, f)
-
-	// Wait a bit to ensure callback would have fired if it were real
-	time.Sleep(100 * time.Millisecond)
-
-	mu.Lock()
-	assert.False(t, callbackCalled, "callback should never fire in fake clock without manual advancement")
-	mu.Unlock()
-
-	cancel()
-}
-
-func TestFakeClockForTesting_ScheduleTimer_MultipleTimers(t *testing.T) {
-	clock := &FakeClockForTesting{}
-	ctx := context.Background()
-
-	var callback1Called, callback2Called bool
-	var mu sync.Mutex
-
-	f1 := func() {
-		mu.Lock()
-		defer mu.Unlock()
-		callback1Called = true
-	}
-
-	f2 := func() {
-		mu.Lock()
-		defer mu.Unlock()
-		callback2Called = true
-	}
-
-	cancel1 := clock.ScheduleTimer(ctx, clock.Duration(50), f1)
-	cancel2 := clock.ScheduleTimer(ctx, clock.Duration(100), f2)
-
-	// Wait to ensure callbacks would have fired if real
-	time.Sleep(150 * time.Millisecond)
-
-	mu.Lock()
-	assert.False(t, callback1Called, "first callback should not fire in fake clock")
-	assert.False(t, callback2Called, "second callback should not fire in fake clock")
-	mu.Unlock()
-
-	cancel1()
-	cancel2()
-}
-
-func TestFakeClockForTesting_ScheduleTimer_CancelCanBeCalledMultipleTimes(t *testing.T) {
-	clock := &FakeClockForTesting{}
-	ctx := context.Background()
-	duration := clock.Duration(100)
-
-	cancel := clock.ScheduleTimer(ctx, duration, func() {})
-
-	// Call cancel multiple times - should not panic
-	cancel()
-	cancel()
-	cancel()
-}
-
-func TestFakeClockForTesting_ScheduleTimer_WithNilCallback(t *testing.T) {
-	clock := &FakeClockForTesting{}
-	ctx := context.Background()
-	duration := clock.Duration(100)
-
-	// Should not panic even with nil callback
-	cancel := clock.ScheduleTimer(ctx, duration, nil)
-	assert.NotNil(t, cancel, "should return cancel function even with nil callback")
 
 	cancel()
 }

--- a/core/go/internal/sequencer/common/commonmocks.go
+++ b/core/go/internal/sequencer/common/commonmocks.go
@@ -41,20 +41,18 @@ func (_m *MockClock) EXPECT() *MockClock_Expecter {
 }
 
 // Duration provides a mock function for the type MockClock
-func (_mock *MockClock) Duration(milliseconds int) Duration {
+func (_mock *MockClock) Duration(milliseconds int) time.Duration {
 	ret := _mock.Called(milliseconds)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Duration")
 	}
 
-	var r0 Duration
-	if returnFunc, ok := ret.Get(0).(func(int) Duration); ok {
+	var r0 time.Duration
+	if returnFunc, ok := ret.Get(0).(func(int) time.Duration); ok {
 		r0 = returnFunc(milliseconds)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(Duration)
-		}
+		r0 = ret.Get(0).(time.Duration)
 	}
 	return r0
 }
@@ -83,27 +81,27 @@ func (_c *MockClock_Duration_Call) Run(run func(milliseconds int)) *MockClock_Du
 	return _c
 }
 
-func (_c *MockClock_Duration_Call) Return(duration Duration) *MockClock_Duration_Call {
+func (_c *MockClock_Duration_Call) Return(duration time.Duration) *MockClock_Duration_Call {
 	_c.Call.Return(duration)
 	return _c
 }
 
-func (_c *MockClock_Duration_Call) RunAndReturn(run func(milliseconds int) Duration) *MockClock_Duration_Call {
+func (_c *MockClock_Duration_Call) RunAndReturn(run func(milliseconds int) time.Duration) *MockClock_Duration_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // HasExpired provides a mock function for the type MockClock
-func (_mock *MockClock) HasExpired(time Time, duration Duration) bool {
-	ret := _mock.Called(time, duration)
+func (_mock *MockClock) HasExpired(time1 time.Time, duration time.Duration) bool {
+	ret := _mock.Called(time1, duration)
 
 	if len(ret) == 0 {
 		panic("no return value specified for HasExpired")
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(Time, Duration) bool); ok {
-		r0 = returnFunc(time, duration)
+	if returnFunc, ok := ret.Get(0).(func(time.Time, time.Duration) bool); ok {
+		r0 = returnFunc(time1, duration)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -116,21 +114,21 @@ type MockClock_HasExpired_Call struct {
 }
 
 // HasExpired is a helper method to define mock.On call
-//   - time Time
-//   - duration Duration
-func (_e *MockClock_Expecter) HasExpired(time interface{}, duration interface{}) *MockClock_HasExpired_Call {
-	return &MockClock_HasExpired_Call{Call: _e.mock.On("HasExpired", time, duration)}
+//   - time1 time.Time
+//   - duration time.Duration
+func (_e *MockClock_Expecter) HasExpired(time1 interface{}, duration interface{}) *MockClock_HasExpired_Call {
+	return &MockClock_HasExpired_Call{Call: _e.mock.On("HasExpired", time1, duration)}
 }
 
-func (_c *MockClock_HasExpired_Call) Run(run func(time Time, duration Duration)) *MockClock_HasExpired_Call {
+func (_c *MockClock_HasExpired_Call) Run(run func(time1 time.Time, duration time.Duration)) *MockClock_HasExpired_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 Time
+		var arg0 time.Time
 		if args[0] != nil {
-			arg0 = args[0].(Time)
+			arg0 = args[0].(time.Time)
 		}
-		var arg1 Duration
+		var arg1 time.Duration
 		if args[1] != nil {
-			arg1 = args[1].(Duration)
+			arg1 = args[1].(time.Duration)
 		}
 		run(
 			arg0,
@@ -145,26 +143,24 @@ func (_c *MockClock_HasExpired_Call) Return(b bool) *MockClock_HasExpired_Call {
 	return _c
 }
 
-func (_c *MockClock_HasExpired_Call) RunAndReturn(run func(time Time, duration Duration) bool) *MockClock_HasExpired_Call {
+func (_c *MockClock_HasExpired_Call) RunAndReturn(run func(time1 time.Time, duration time.Duration) bool) *MockClock_HasExpired_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Now provides a mock function for the type MockClock
-func (_mock *MockClock) Now() Time {
+func (_mock *MockClock) Now() time.Time {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for Now")
 	}
 
-	var r0 Time
-	if returnFunc, ok := ret.Get(0).(func() Time); ok {
+	var r0 time.Time
+	if returnFunc, ok := ret.Get(0).(func() time.Time); ok {
 		r0 = returnFunc()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(Time)
-		}
+		r0 = ret.Get(0).(time.Time)
 	}
 	return r0
 }
@@ -186,18 +182,18 @@ func (_c *MockClock_Now_Call) Run(run func()) *MockClock_Now_Call {
 	return _c
 }
 
-func (_c *MockClock_Now_Call) Return(time Time) *MockClock_Now_Call {
-	_c.Call.Return(time)
+func (_c *MockClock_Now_Call) Return(time1 time.Time) *MockClock_Now_Call {
+	_c.Call.Return(time1)
 	return _c
 }
 
-func (_c *MockClock_Now_Call) RunAndReturn(run func() Time) *MockClock_Now_Call {
+func (_c *MockClock_Now_Call) RunAndReturn(run func() time.Time) *MockClock_Now_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ScheduleTimer provides a mock function for the type MockClock
-func (_mock *MockClock) ScheduleTimer(context1 context.Context, duration Duration, fn func()) func() {
+func (_mock *MockClock) ScheduleTimer(context1 context.Context, duration time.Duration, fn func()) func() {
 	ret := _mock.Called(context1, duration, fn)
 
 	if len(ret) == 0 {
@@ -205,7 +201,7 @@ func (_mock *MockClock) ScheduleTimer(context1 context.Context, duration Duratio
 	}
 
 	var r0 func()
-	if returnFunc, ok := ret.Get(0).(func(context.Context, Duration, func()) func()); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, time.Duration, func()) func()); ok {
 		r0 = returnFunc(context1, duration, fn)
 	} else {
 		if ret.Get(0) != nil {
@@ -222,21 +218,21 @@ type MockClock_ScheduleTimer_Call struct {
 
 // ScheduleTimer is a helper method to define mock.On call
 //   - context1 context.Context
-//   - duration Duration
+//   - duration time.Duration
 //   - fn func()
 func (_e *MockClock_Expecter) ScheduleTimer(context1 interface{}, duration interface{}, fn interface{}) *MockClock_ScheduleTimer_Call {
 	return &MockClock_ScheduleTimer_Call{Call: _e.mock.On("ScheduleTimer", context1, duration, fn)}
 }
 
-func (_c *MockClock_ScheduleTimer_Call) Run(run func(context1 context.Context, duration Duration, fn func())) *MockClock_ScheduleTimer_Call {
+func (_c *MockClock_ScheduleTimer_Call) Run(run func(context1 context.Context, duration time.Duration, fn func())) *MockClock_ScheduleTimer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 Duration
+		var arg1 time.Duration
 		if args[1] != nil {
-			arg1 = args[1].(Duration)
+			arg1 = args[1].(time.Duration)
 		}
 		var arg2 func()
 		if args[2] != nil {
@@ -256,63 +252,9 @@ func (_c *MockClock_ScheduleTimer_Call) Return(cancel func()) *MockClock_Schedul
 	return _c
 }
 
-func (_c *MockClock_ScheduleTimer_Call) RunAndReturn(run func(context1 context.Context, duration Duration, fn func()) func()) *MockClock_ScheduleTimer_Call {
+func (_c *MockClock_ScheduleTimer_Call) RunAndReturn(run func(context1 context.Context, duration time.Duration, fn func()) func()) *MockClock_ScheduleTimer_Call {
 	_c.Call.Return(run)
 	return _c
-}
-
-// NewMockDuration creates a new instance of MockDuration. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-// The first argument is typically a *testing.T value.
-func NewMockDuration(t interface {
-	mock.TestingT
-	Cleanup(func())
-}) *MockDuration {
-	mock := &MockDuration{}
-	mock.Mock.Test(t)
-
-	t.Cleanup(func() { mock.AssertExpectations(t) })
-
-	return mock
-}
-
-// MockDuration is an autogenerated mock type for the Duration type
-type MockDuration struct {
-	mock.Mock
-}
-
-type MockDuration_Expecter struct {
-	mock *mock.Mock
-}
-
-func (_m *MockDuration) EXPECT() *MockDuration_Expecter {
-	return &MockDuration_Expecter{mock: &_m.Mock}
-}
-
-// NewMockTime creates a new instance of MockTime. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-// The first argument is typically a *testing.T value.
-func NewMockTime(t interface {
-	mock.TestingT
-	Cleanup(func())
-}) *MockTime {
-	mock := &MockTime{}
-	mock.Mock.Test(t)
-
-	t.Cleanup(func() { mock.AssertExpectations(t) })
-
-	return mock
-}
-
-// MockTime is an autogenerated mock type for the Time type
-type MockTime struct {
-	mock.Mock
-}
-
-type MockTime_Expecter struct {
-	mock *mock.Mock
-}
-
-func (_m *MockTime) EXPECT() *MockTime_Expecter {
-	return &MockTime_Expecter{mock: &_m.Mock}
 }
 
 // NewMockHooks creates a new instance of MockHooks. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/core/go/internal/sequencer/common/request.go
+++ b/core/go/internal/sequencer/common/request.go
@@ -17,19 +17,21 @@ package common
 import (
 	"context"
 
+	"time"
+
 	"github.com/google/uuid"
 )
 
 type IdempotentRequest struct {
 	idempotencyKey   uuid.UUID                                                 //unique string to identify the request (re-used across retries)
-	requestTime      Time                                                      //time the request was most recently sent
-	firstRequestTime Time                                                      //time the request was first sent
+	requestTime      *time.Time                                                //time the request was most recently sent
+	firstRequestTime *time.Time                                                //time the request was first sent
 	send             func(ctx context.Context, idempotencyKey uuid.UUID) error // function to send the request
 	clock            Clock
-	timeout          Duration
+	timeout          time.Duration
 }
 
-func NewIdempotentRequest(ctx context.Context, clock Clock, timeout Duration, sendRequest func(ctx context.Context, idempotencyKey uuid.UUID) error) *IdempotentRequest {
+func NewIdempotentRequest(ctx context.Context, clock Clock, timeout time.Duration, sendRequest func(ctx context.Context, idempotencyKey uuid.UUID) error) *IdempotentRequest {
 	idempotencyKey := uuid.New()
 	r := &IdempotentRequest{
 		idempotencyKey:   idempotencyKey,
@@ -47,16 +49,17 @@ func (r *IdempotentRequest) IdempotencyKey() uuid.UUID {
 	return r.idempotencyKey
 }
 
-func (r *IdempotentRequest) FirstRequestTime() Time {
+func (r *IdempotentRequest) FirstRequestTime() *time.Time {
 	return r.firstRequestTime
 }
 
 // Prompt to check whether a retry is due and if so, send the request
 func (r *IdempotentRequest) Nudge(ctx context.Context) error {
-	if r.requestTime == nil || r.clock.HasExpired(r.requestTime, r.timeout) {
+	if r.requestTime == nil || r.clock.HasExpired(*r.requestTime, r.timeout) {
 		err := r.send(ctx, r.idempotencyKey)
 		if err == nil {
-			r.requestTime = r.clock.Now()
+			now := r.clock.Now()
+			r.requestTime = &now
 			if r.firstRequestTime == nil {
 				r.firstRequestTime = r.requestTime
 			}

--- a/core/go/internal/sequencer/common/request_test.go
+++ b/core/go/internal/sequencer/common/request_test.go
@@ -17,9 +17,12 @@ package common
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	mock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_IdempotentRequestOK(t *testing.T) {
@@ -48,16 +51,21 @@ func Test_IdempotentRequestErrorFromSend(t *testing.T) {
 
 func Test_IdempotentRequest_RetryOnNudgeIfExpired(t *testing.T) {
 	ctx := context.Background()
-	clock := &FakeClockForTesting{}
+	clock := NewMockClock(t)
+	clock.On("Now").Return(time.Now())
+
 	requested := 0
-	request := NewIdempotentRequest(ctx, clock, clock.Duration(1000), func(ctx context.Context, idempotencyKey uuid.UUID) error {
+	request := NewIdempotentRequest(ctx, clock, time.Duration(1), func(ctx context.Context, idempotencyKey uuid.UUID) error {
 		requested++
 		return nil
 	})
+	// always sends the request for the first time
 	err := request.Nudge(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, requested)
-	clock.Advance(1001) //Just after expiry
+
+	// the second nudge only sends if the request has expired
+	clock.On("HasExpired", mock.Anything, mock.Anything).Return(true)
 	err = request.Nudge(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, requested)
@@ -66,16 +74,22 @@ func Test_IdempotentRequest_RetryOnNudgeIfExpired(t *testing.T) {
 
 func Test_IdempotentRequest_NoRetryOnNudgeIfNotExpired(t *testing.T) {
 	ctx := context.Background()
-	clock := &FakeClockForTesting{}
+	clock := NewMockClock(t)
+	clock.On("Now").Return(time.Now())
+
 	requested := 0
-	request := NewIdempotentRequest(ctx, clock, clock.Duration(1000), func(ctx context.Context, idempotencyKey uuid.UUID) error {
+	request := NewIdempotentRequest(ctx, clock, time.Duration(1), func(ctx context.Context, idempotencyKey uuid.UUID) error {
 		requested++
 		return nil
 	})
+
+	// always sends the request for the first time
 	err := request.Nudge(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, requested)
-	clock.Advance(999) //Just before expiry
+
+	// the second nudge only sends if the request has expired
+	clock.On("HasExpired", mock.Anything, mock.Anything).Return(false)
 	err = request.Nudge(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, requested)
@@ -84,22 +98,27 @@ func Test_IdempotentRequest_NoRetryOnNudgeIfNotExpired(t *testing.T) {
 
 func Test_IdempotentRequest_FirstRequestTime(t *testing.T) {
 	ctx := context.Background()
-	clock := &FakeClockForTesting{}
-	request := NewIdempotentRequest(ctx, clock, clock.Duration(1000), func(ctx context.Context, idempotencyKey uuid.UUID) error {
+	start := time.Now()
+	end := start.Add(time.Duration(1))
+	clock := NewMockClock(t)
+	clock.On("Now").Return(start).Once()
+	clock.On("Now").Return(end).Once()
+	clock.On("HasExpired", mock.Anything, mock.Anything).Return(true)
+
+	request := NewIdempotentRequest(ctx, clock, time.Duration(1), func(ctx context.Context, idempotencyKey uuid.UUID) error {
 		return nil
 	})
+	// send the request twice
 	err := request.Nudge(ctx)
 	assert.NoError(t, err)
-	start := clock.Now()
-	assert.Equal(t, start, request.FirstRequestTime())
-	clock.Advance(1001)
 	err = request.Nudge(ctx)
 	assert.NoError(t, err)
-	end := clock.Now()
-	assert.Equal(t, start, request.FirstRequestTime())
-	assert.Equal(t, end, request.requestTime)
-	assert.NotEqual(t, request.FirstRequestTime(), request.requestTime)
 
+	require.NotNil(t, request.FirstRequestTime())
+	require.NotNil(t, request.requestTime)
+	assert.Equal(t, start, *request.FirstRequestTime())
+	assert.Equal(t, end, *request.requestTime)
+	assert.NotEqual(t, request.FirstRequestTime(), request.requestTime)
 }
 
 func Test_IdempotentRequest_IdempotencyKey(t *testing.T) {

--- a/core/go/internal/sequencer/coordinator/coordinator.go
+++ b/core/go/internal/sequencer/coordinator/coordinator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/config/pkg/confutil"
 	"github.com/LFDT-Paladin/paladin/config/pkg/pldconf"
@@ -70,7 +71,7 @@ type coordinator struct {
 	activeCoordinatorNode                      string
 	activeCoordinatorBlockHeight               uint64
 	heartbeatIntervalsSinceStateChange         int
-	heartbeatInterval                          common.Duration
+	heartbeatInterval                          time.Duration
 	transactionsByID                           map[uuid.UUID]transaction.CoordinatorTransaction
 	pooledTransactions                         []transaction.CoordinatorTransaction
 	currentBlockHeight                         uint64
@@ -83,8 +84,8 @@ type coordinator struct {
 	blockHeightTolerance              uint64
 	closingGracePeriod                int // expressed as a multiple of heartbeat intervals
 	confirmedLockRetentionGracePeriod int // expressed as a multiple of heartbeat intervals
-	requestTimeout                    common.Duration
-	stateTimeout                      common.Duration
+	requestTimeout                    time.Duration
+	stateTimeout                      time.Duration
 	nodeName                          string
 	coordinatorSelectionBlockRange    uint64
 	maxInflightTransactions           int

--- a/core/go/internal/sequencer/coordinator/coordinator_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinator_test.go
@@ -47,7 +47,7 @@ func NewCoordinatorForUnitTest(t *testing.T, ctx context.Context, originatorIden
 	metrics := metrics.InitMetrics(context.Background(), prometheus.NewRegistry())
 	mocks := &coordinatorDependencyMocks{
 		transportWriter:   transport.NewMockTransportWriter(t),
-		clock:             &common.FakeClockForTesting{},
+		clock:             common.NewMockClock(t),
 		engineIntegration: common.NewMockEngineIntegration(t),
 		syncPoints:        &syncpoints.MockSyncPoints{},
 		emit:              func(event common.Event) {},
@@ -106,7 +106,7 @@ func NewCoordinatorForUnitTest(t *testing.T, ctx context.Context, originatorIden
 
 type coordinatorDependencyMocks struct {
 	transportWriter   *transport.MockTransportWriter
-	clock             *common.FakeClockForTesting
+	clock             *common.MockClock
 	engineIntegration *common.MockEngineIntegration
 	emit              common.EmitEvent
 	syncPoints        syncpoints.SyncPoints

--- a/core/go/internal/sequencer/coordinator/coordinator_test_utils.go
+++ b/core/go/internal/sequencer/coordinator/coordinator_test_utils.go
@@ -102,7 +102,6 @@ type CoordinatorBuilderForTesting struct {
 
 type CoordinatorDependencyMocks struct {
 	SentMessageRecorder *SentMessageRecorder
-	Clock               *common.FakeClockForTesting
 	EngineIntegration   *common.FakeEngineIntegrationForTesting
 	SyncPoints          syncpoints.SyncPoints
 	emittedEvents       []common.Event
@@ -303,7 +302,6 @@ func (b *CoordinatorBuilderForTesting) Build(ctx context.Context) (*coordinator,
 	}
 	mocks := &CoordinatorDependencyMocks{
 		SentMessageRecorder: NewSentMessageRecorder(),
-		Clock:               &common.FakeClockForTesting{},
 		EngineIntegration:   &common.FakeEngineIntegrationForTesting{},
 		SyncPoints:          &syncpoints.MockSyncPoints{},
 	}
@@ -339,7 +337,7 @@ func (b *CoordinatorBuilderForTesting) Build(ctx context.Context) (*coordinator,
 		nil,
 		nil,
 		mocks.SentMessageRecorder,
-		mocks.Clock,
+		common.RealClock(),
 		mocks.EngineIntegration,
 		mocks.SyncPoints,
 		b.originatorIdentityPool,

--- a/core/go/internal/sequencer/coordinator/snapshot.go
+++ b/core/go/internal/sequencer/coordinator/snapshot.go
@@ -41,7 +41,7 @@ func (c *coordinator) heartbeatLoop(ctx context.Context) {
 		}
 
 		// Then every N seconds
-		ticker := time.NewTicker(c.heartbeatInterval.(time.Duration))
+		ticker := time.NewTicker(c.heartbeatInterval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/core/go/internal/sequencer/coordinator/transaction/assembling_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
@@ -781,11 +782,12 @@ func Test_revertTransactionFailedAssembly_OnRollbackRetry(t *testing.T) {
 	assert.Equal(t, maxCalls, callCount)
 }
 
-func Test_sendAssembleRequest_RequestTimeoutCallback(t *testing.T) {
+func Test_sendAssembleRequest_schedulesTimer(t *testing.T) {
 	ctx := context.Background()
 	timeoutEventReceived := false
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Assembling).
 		UseMockTransportWriter().
+		UseMockClock().
 		QueueEventForCoordinator(func(ctx context.Context, event common.Event) {
 			if _, ok := event.(*RequestTimeoutIntervalEvent); ok {
 				timeoutEventReceived = true
@@ -793,6 +795,12 @@ func Test_sendAssembleRequest_RequestTimeoutCallback(t *testing.T) {
 		}).
 		RequestTimeout(1).
 		Build()
+
+	mocks.Clock.On("Now").Return(time.Now()).Once()
+	mocks.Clock.On("ScheduleTimer", mock.Anything, time.Duration(1), mock.Anything).Return(func() {}).Run(func(args mock.Arguments) {
+		callback := args.Get(2).(func())
+		callback()
+	})
 
 	mocks.EngineIntegration.EXPECT().GetStateLocks(ctx).Return([]byte("{}"), nil)
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(ctx).Return(int64(100), nil)
@@ -802,37 +810,5 @@ func Test_sendAssembleRequest_RequestTimeoutCallback(t *testing.T) {
 
 	err := txn.sendAssembleRequest(ctx)
 	require.NoError(t, err)
-
-	mocks.Clock.Advance(1)
-	assert.True(t, timeoutEventReceived)
-}
-
-func Test_onTransitionToAssembling_StateTimeoutCallback(t *testing.T) {
-	ctx := context.Background()
-	timeoutEventReceived := false
-	txn, mocks := NewTransactionBuilderForTesting(t, State_Assembling).
-		UseMockTransportWriter().
-		QueueEventForCoordinator(func(ctx context.Context, event common.Event) {
-			if _, ok := event.(*StateTimeoutIntervalEvent); ok {
-				timeoutEventReceived = true
-			}
-		}).
-		StateTimeout(1).
-		Build()
-
-	mocks.EngineIntegration.EXPECT().GetStateLocks(ctx).Return([]byte("{}"), nil)
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(ctx).Return(int64(100), nil)
-	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, []byte("{}"), int64(100),
-	).Return(nil)
-
-	err := action_ScheduleStateTimeout(ctx, txn, nil)
-	require.NoError(t, err)
-	err = action_SendAssembleRequest(ctx, txn, nil)
-	require.NoError(t, err)
-
-	// Wait for timeout to fire
-	mocks.Clock.Advance(1)
-
 	assert.True(t, timeoutEventReceived)
 }

--- a/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch_test.go
@@ -17,6 +17,7 @@ package transaction
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/google/uuid"
@@ -136,7 +137,6 @@ func Test_ConfirmingDispatch_Timeout_TransitionsToPooled_AndClearsPendingRequest
 	require.NotNil(t, txn.pendingPreDispatchRequest)
 	mocks.EngineIntegration.EXPECT().ResetTransactions(ctx, txn.pt.ID).Return()
 
-	mocks.Clock.Advance(builder.GetStateTimeout() + 1)
 	err := txn.HandleEvent(ctx, &StateTimeoutIntervalEvent{
 		BaseCoordinatorEvent: BaseCoordinatorEvent{
 			TransactionID: txn.pt.ID,
@@ -165,6 +165,7 @@ func Test_sendPreDispatchRequest_RequestTimeoutSchedulesTimer_QueueEventCalled(t
 
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Confirming_Dispatchable).
 		UseMockTransportWriter().
+		UseMockClock().
 		QueueEventForCoordinator(func(ctx context.Context, event common.Event) {
 			if _, ok := event.(*RequestTimeoutIntervalEvent); ok {
 				timeoutEventReceived = true
@@ -177,11 +178,14 @@ func Test_sendPreDispatchRequest_RequestTimeoutSchedulesTimer_QueueEventCalled(t
 		ctx, txn.originatorNode, mock.Anything, txn.pt.PreAssembly.TransactionSpecification, mock.Anything,
 	).Return(nil)
 
+	mocks.Clock.On("Now").Return(time.Now()).Once()
+	mocks.Clock.On("ScheduleTimer", mock.Anything, time.Duration(1), mock.Anything).Return(func() {}).Run(func(args mock.Arguments) {
+		callback := args.Get(2).(func())
+		callback()
+	})
+
 	err := txn.sendPreDispatchRequest(ctx)
 	require.NoError(t, err)
-
-	// Wait for the request timeout timer to fire (scheduled with 1ms duration)
-	mocks.Clock.Advance(1)
 
 	assert.True(t, timeoutEventReceived, "queueEventForCoordinator should have been called with RequestTimeoutIntervalEvent")
 }

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing_test.go
@@ -17,6 +17,7 @@ package transaction
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
@@ -69,6 +70,7 @@ func Test_sendEndorsementRequests_WhenPendingNil_SchedulesTimerAndQueueEventOnFi
 	ctx := context.Background()
 	var timeoutEventReceived bool
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
+		UseMockClock().
 		QueueEventForCoordinator(func(ctx context.Context, event common.Event) {
 			if _, ok := event.(*RequestTimeoutIntervalEvent); ok {
 				timeoutEventReceived = true
@@ -77,10 +79,15 @@ func Test_sendEndorsementRequests_WhenPendingNil_SchedulesTimerAndQueueEventOnFi
 		RequestTimeout(1).
 		Build()
 
+	mocks.Clock.On("Now").Return(time.Now())
+	mocks.Clock.On("ScheduleTimer", mock.Anything, time.Duration(1), mock.Anything).Return(func() {}).Run(func(args mock.Arguments) {
+		callback := args.Get(2).(func())
+		callback()
+	})
+
 	err := txn.sendEndorsementRequests(ctx)
 	require.NoError(t, err)
 
-	mocks.Clock.Advance(1)
 	assert.True(t, timeoutEventReceived, "queueEventForCoordinator should have been called with RequestTimeoutIntervalEvent")
 }
 

--- a/core/go/internal/sequencer/coordinator/transaction/timeouts_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/timeouts_test.go
@@ -15,9 +15,14 @@
 package transaction
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_clearTimeoutSchedules_BothNil(t *testing.T) {
@@ -48,4 +53,28 @@ func Test_clearTimeoutSchedules_BothSet(t *testing.T) {
 	assert.True(t, called2)
 	assert.Nil(t, txn.cancelRequestTimeoutSchedule)
 	assert.Nil(t, txn.cancelStateTimeoutSchedule)
+}
+
+func Test_action_ScheduleStateTimeout_schedulesTimer(t *testing.T) {
+	ctx := context.Background()
+	timeoutEventReceived := false
+	txn, mocks := NewTransactionBuilderForTesting(t, State_Assembling).
+		UseMockClock().
+		StateTimeout(1).
+		QueueEventForCoordinator(func(ctx context.Context, event common.Event) {
+			if _, ok := event.(*StateTimeoutIntervalEvent); ok {
+				timeoutEventReceived = true
+			}
+		}).
+		Build()
+
+	mocks.Clock.On("ScheduleTimer", mock.Anything, time.Duration(1), mock.Anything).Return(func() {}).
+		Run(func(args mock.Arguments) {
+			callback := args.Get(2).(func())
+			callback()
+		})
+
+	err := action_ScheduleStateTimeout(ctx, txn, nil)
+	require.NoError(t, err)
+	assert.True(t, timeoutEventReceived)
 }

--- a/core/go/internal/sequencer/coordinator/transaction/transaction.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction.go
@@ -17,6 +17,7 @@ package transaction
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
@@ -61,7 +62,7 @@ type coordinatorTransaction struct {
 
 	//TODO move the fields that are really just fine grained state info.  Move them into the stateMachine struct ( consider separate structs for each concrete state)
 	heartbeatIntervalsSinceStateChange int
-	stateEntryTime                     common.Time
+	stateEntryTime                     time.Time
 	pendingAssembleRequest             *common.IdempotentRequest
 	cancelRequestTimeoutSchedule       func()                                          // Short timeout for retry e.g. network blip
 	cancelStateTimeoutSchedule         func()                                          // Timeout for state completion before repooling
@@ -73,8 +74,8 @@ type coordinatorTransaction struct {
 	dependencies                       *pldapi.TransactionDependencies
 
 	//Configuration
-	requestTimeout                    common.Duration
-	stateTimeout                      common.Duration
+	requestTimeout                    time.Duration
+	stateTimeout                      time.Duration
 	finalizingGracePeriod             int // number of heartbeat intervals that the transaction will remain in one of the terminal states ( Reverted or Confirmed) before it is removed from memory and no longer reported in heartbeats
 	confirmedLockRetentionGracePeriod int // number of heartbeat intervals after confirmation before we clear in-memory state locks
 	confirmedLocksReleased            bool
@@ -106,7 +107,7 @@ func NewTransaction(ctx context.Context,
 	domainAPI components.DomainSmartContract,
 	dCtx components.DomainContext,
 	requestTimeout,
-	stateTimeout common.Duration,
+	stateTimeout time.Duration,
 	finalizingGracePeriod int,
 	confirmedLockRetentionGracePeriod int,
 	grapher Grapher,
@@ -150,7 +151,7 @@ func newTransaction(
 	domainAPI components.DomainSmartContract,
 	dCtx components.DomainContext,
 	requestTimeout,
-	stateTimeout common.Duration,
+	stateTimeout time.Duration,
 	finalizingGracePeriod int,
 	confirmedLockRetentionGracePeriod int,
 	grapher Grapher,

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_test.go
@@ -17,6 +17,7 @@ package transaction
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
@@ -205,7 +206,6 @@ func TestTransaction_AddsItselfToGrapher(t *testing.T) {
 
 func TestNewTransaction_InvalidOriginator_ReturnsError(t *testing.T) {
 	ctx := context.Background()
-	clock := &common.FakeClockForTesting{}
 
 	_, err := newTransaction(
 		ctx,
@@ -214,15 +214,15 @@ func TestNewTransaction_InvalidOriginator_ReturnsError(t *testing.T) {
 		&components.PrivateTransaction{ID: uuid.New()},
 		"coordinator-signer",
 		transport.NewMockTransportWriter(t),
-		clock,
+		common.NewMockClock(t),
 		func(ctx context.Context, event common.Event) {},
 		common.NewMockEngineIntegration(t),
 		&syncpoints.MockSyncPoints{},
 		componentsmocks.NewAllComponents(t),
 		componentsmocks.NewDomainSmartContract(t),
 		nil,
-		clock.Duration(1000),
-		clock.Duration(5000),
+		time.Duration(1000),
+		time.Duration(5000),
 		5,
 		0,
 		NewGrapher(ctx),

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_test_utils.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_test_utils.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
@@ -234,6 +235,7 @@ type TransactionBuilderForTesting struct {
 	dependencies                       *pldapi.TransactionDependencies
 	state                              State
 	useMockTransportWriter             bool
+	useMockClock                       bool
 	grapher                            Grapher
 	txn                                *coordinatorTransaction
 	requestTimeout                     int
@@ -296,6 +298,11 @@ func NewTransactionBuilderForTesting(t *testing.T, state State) *TransactionBuil
 
 func (b *TransactionBuilderForTesting) UseMockTransportWriter() *TransactionBuilderForTesting {
 	b.useMockTransportWriter = true
+	return b
+}
+
+func (b *TransactionBuilderForTesting) UseMockClock() *TransactionBuilderForTesting {
+	b.useMockClock = true
 	return b
 }
 
@@ -552,7 +559,7 @@ func (b *TransactionBuilderForTesting) GetEndorsers() []string {
 
 type transactionDependencyMocks struct {
 	TransportWriter     *transport.MockTransportWriter
-	Clock               *common.FakeClockForTesting
+	Clock               *common.MockClock
 	EngineIntegration   *common.MockEngineIntegration
 	SentMessageRecorder *SentMessageRecorder
 	SyncPoints          *syncpoints.MockSyncPoints
@@ -578,7 +585,7 @@ func (b *TransactionBuilderForTesting) Build() (*coordinatorTransaction, *transa
 
 	mocks := &transactionDependencyMocks{
 		TransportWriter:     transport.NewMockTransportWriter(b.t),
-		Clock:               &common.FakeClockForTesting{},
+		Clock:               common.NewMockClock(b.t),
 		EngineIntegration:   common.NewMockEngineIntegration(b.t),
 		SentMessageRecorder: NewSentMessageRecorder(),
 		SyncPoints:          syncpoints.NewMockSyncPoints(b.t),
@@ -618,6 +625,15 @@ func (b *TransactionBuilderForTesting) Build() (*coordinatorTransaction, *transa
 		transportWriter = mocks.SentMessageRecorder
 	}
 
+	var clock common.Clock
+	if b.useMockClock {
+		clock = mocks.Clock
+		// newTransaction results in a call to clock.Now(), so we need to mock that once
+		mocks.Clock.On("Now").Return(time.Now()).Once()
+	} else {
+		clock = common.RealClock()
+	}
+
 	txn, err := newTransaction(
 		ctx,
 		b.originator,
@@ -625,15 +641,15 @@ func (b *TransactionBuilderForTesting) Build() (*coordinatorTransaction, *transa
 		privateTransaction,
 		b.coordinatorSigningIdentity,
 		transportWriter,
-		mocks.Clock,
+		clock,
 		b.queueEventForCoordinator,
 		mocks.EngineIntegration,
 		mocks.SyncPoints,
 		mocks.AllComponents,
 		mocks.DomainAPI,
 		mocks.DomainContext,
-		mocks.Clock.Duration(b.requestTimeout),
-		mocks.Clock.Duration(b.stateTimeout),
+		time.Duration(b.requestTimeout),
+		time.Duration(b.stateTimeout),
 		b.finalizingGracePeriod,
 		b.confirmedLockRetentionGracePeriod,
 		b.grapher,

--- a/core/go/internal/sequencer/originator/observing.go
+++ b/core/go/internal/sequencer/originator/observing.go
@@ -32,7 +32,8 @@ func action_HeartbeatReceived(ctx context.Context, o *originator, event common.E
 }
 
 func (o *originator) applyHeartbeatReceived(ctx context.Context, event *HeartbeatReceivedEvent) error {
-	o.timeOfMostRecentHeartbeat = o.clock.Now()
+	now := o.clock.Now()
+	o.timeOfMostRecentHeartbeat = &now
 	o.activeCoordinatorNode = event.From
 	o.latestCoordinatorSnapshot = &event.CoordinatorSnapshot
 	for _, dispatchedTransaction := range event.DispatchedTransactions {
@@ -90,7 +91,7 @@ func guard_HeartbeatThresholdExceeded(ctx context.Context, o *originator) bool {
 		//we have never seen a heartbeat so that was a really long time ago, certainly longer than any threshold
 		return true
 	}
-	if o.clock.HasExpired(o.timeOfMostRecentHeartbeat, o.heartbeatThresholdMs) {
+	if o.clock.HasExpired(*o.timeOfMostRecentHeartbeat, o.heartbeatThreshold) {
 		return true
 	}
 	return false

--- a/core/go/internal/sequencer/originator/observing_test.go
+++ b/core/go/internal/sequencer/originator/observing_test.go
@@ -18,6 +18,7 @@ package originator
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/testutil"
@@ -301,18 +302,18 @@ func Test_guard_HeartbeatThresholdExceeded_ThresholdExpiredReturnsTrue(t *testin
 	ctx := context.Background()
 	originatorLocator := "sender@senderNode"
 	coordinatorLocator := "coordinator@coordinatorNode"
-	builder := NewOriginatorBuilderForTesting(State_Observing).CommitteeMembers(originatorLocator, coordinatorLocator)
-	o, mocks, cleanup := builder.Build(ctx)
+
+	clock := common.NewMockClock(t)
+	initialTime := time.Now()
+	clock.On("HasExpired", initialTime, time.Duration(TestDefault_HeartbeatThreshold*TestDefault_HeartbeatIntervalMs)*time.Millisecond).Return(true).Once()
+
+	builder := NewOriginatorBuilderForTesting(State_Observing).
+		Clock(clock).
+		CommitteeMembers(originatorLocator, coordinatorLocator)
+	o, _, cleanup := builder.Build(ctx)
 	defer cleanup()
 
-	// Set timeOfMostRecentHeartbeat to a time in the past (beyond threshold)
-	// For FakeClockForTesting, we need to advance the clock and then set an old time
-	initialTime := mocks.Clock.Now()
-	// Get threshold in milliseconds - for FakeClockForTesting, Duration is *fakeDuration
-	// We'll advance by the threshold + some extra to ensure it's expired
-	thresholdMs := TestDefault_HeartbeatThreshold * TestDefault_HeartbeatIntervalMs
-	mocks.Clock.Advance(thresholdMs + 1000)
-	o.timeOfMostRecentHeartbeat = initialTime
+	o.timeOfMostRecentHeartbeat = &initialTime
 
 	result := guard_HeartbeatThresholdExceeded(ctx, o)
 	assert.True(t, result, "Should return true when threshold has expired")
@@ -322,13 +323,18 @@ func Test_guard_HeartbeatThresholdExceeded_ThresholdNotExpiredReturnsFalse(t *te
 	ctx := context.Background()
 	originatorLocator := "sender@senderNode"
 	coordinatorLocator := "coordinator@coordinatorNode"
-	builder := NewOriginatorBuilderForTesting(State_Observing).CommitteeMembers(originatorLocator, coordinatorLocator)
-	o, mocks, cleanup := builder.Build(ctx)
+
+	clock := common.NewMockClock(t)
+	initialTime := time.Now()
+	clock.On("HasExpired", initialTime, time.Duration(TestDefault_HeartbeatThreshold*TestDefault_HeartbeatIntervalMs)*time.Millisecond).Return(false).Once()
+
+	builder := NewOriginatorBuilderForTesting(State_Observing).
+		Clock(clock).
+		CommitteeMembers(originatorLocator, coordinatorLocator)
+	o, _, cleanup := builder.Build(ctx)
 	defer cleanup()
 
-	// Set timeOfMostRecentHeartbeat to a recent time (within threshold)
-	recentTime := mocks.Clock.Now()
-	o.timeOfMostRecentHeartbeat = recentTime
+	o.timeOfMostRecentHeartbeat = &initialTime
 
 	result := guard_HeartbeatThresholdExceeded(ctx, o)
 	assert.False(t, result, "Should return false when threshold has not expired")

--- a/core/go/internal/sequencer/originator/originating.go
+++ b/core/go/internal/sequencer/originator/originating.go
@@ -66,7 +66,8 @@ func sendDelegationRequest(ctx context.Context, o *originator, includeAlreadyDel
 	privateTransactions := make([]*components.PrivateTransaction, 0)
 	transactionsToDelegate := make([]*transaction.OriginatorTransaction, 0)
 	for _, txn := range o.transactionsOrdered {
-		if includeAlreadyDelegated && txn.GetCurrentState() == transaction.State_Delegated && (ignoreDelegateTimeout || (txn.GetLastDelegatedTime() != nil && common.RealClock().HasExpired(*txn.GetLastDelegatedTime(), o.delegateTimeout))) {
+		if includeAlreadyDelegated && txn.GetCurrentState() == transaction.State_Delegated &&
+			(ignoreDelegateTimeout || (txn.GetLastDelegatedTime() != nil && o.clock.HasExpired(*txn.GetLastDelegatedTime(), o.delegateTimeout))) {
 			// only re-delegate after the delegate timeout
 			privateTransactions = append(privateTransactions, txn.GetPrivateTransaction())
 			transactionsToDelegate = append(transactionsToDelegate, txn)

--- a/core/go/internal/sequencer/originator/originator.go
+++ b/core/go/internal/sequencer/originator/originator.go
@@ -58,18 +58,18 @@ type originator struct {
 	/* State machine - using generic statemachine.StateMachineEventLoop */
 	stateMachineEventLoop     *statemachine.StateMachineEventLoop[State, *originator]
 	activeCoordinatorNode     string
-	timeOfMostRecentHeartbeat common.Time
+	timeOfMostRecentHeartbeat *time.Time
 	transactionsByID          map[uuid.UUID]*transaction.OriginatorTransaction
 	transactionsOrdered       []*transaction.OriginatorTransaction
 	currentBlockHeight        uint64
 	latestCoordinatorSnapshot *common.CoordinatorSnapshot
 
 	/* Config */
-	nodeName             string
-	blockRangeSize       uint64
-	contractAddress      *pldtypes.EthAddress
-	heartbeatThresholdMs common.Duration
-	delegateTimeout      common.Duration
+	nodeName           string
+	blockRangeSize     uint64
+	contractAddress    *pldtypes.EthAddress
+	heartbeatThreshold time.Duration
+	delegateTimeout    time.Duration
 
 	/* Dependencies */
 	transportWriter   transport.TransportWriter
@@ -94,18 +94,18 @@ func NewOriginator(
 	metrics metrics.DistributedSequencerMetrics,
 ) (*originator, error) {
 	o := &originator{
-		ctx:                  ctx,
-		nodeName:             nodeName,
-		transactionsByID:     make(map[uuid.UUID]*transaction.OriginatorTransaction),
-		transportWriter:      transportWriter,
-		blockRangeSize:       confutil.Uint64Min(configuration.BlockRange, pldconf.SequencerMinimum.BlockRange, *pldconf.SequencerDefaults.BlockRange),
-		contractAddress:      contractAddress,
-		clock:                clock,
-		engineIntegration:    engineIntegration,
-		heartbeatThresholdMs: clock.Duration(heartbeatPeriodMs * heartbeatThresholdIntervals),
-		delegateTimeout:      confutil.DurationMin(configuration.DelegateTimeout, pldconf.SequencerMinimum.DelegateTimeout, *pldconf.SequencerDefaults.DelegateTimeout),
-		metrics:              metrics,
-		delegateLoopStopped:  make(chan struct{}),
+		ctx:                 ctx,
+		nodeName:            nodeName,
+		transactionsByID:    make(map[uuid.UUID]*transaction.OriginatorTransaction),
+		transportWriter:     transportWriter,
+		blockRangeSize:      confutil.Uint64Min(configuration.BlockRange, pldconf.SequencerMinimum.BlockRange, *pldconf.SequencerDefaults.BlockRange),
+		contractAddress:     contractAddress,
+		clock:               clock,
+		engineIntegration:   engineIntegration,
+		heartbeatThreshold:  time.Duration(heartbeatPeriodMs*heartbeatThresholdIntervals) * time.Millisecond,
+		delegateTimeout:     confutil.DurationMin(configuration.DelegateTimeout, pldconf.SequencerMinimum.DelegateTimeout, *pldconf.SequencerDefaults.DelegateTimeout),
+		metrics:             metrics,
+		delegateLoopStopped: make(chan struct{}),
 	}
 	originatorEventQueueSize := confutil.IntMin(configuration.OriginatorEventQueueSize, pldconf.SequencerMinimum.OriginatorEventQueueSize, *pldconf.SequencerDefaults.OriginatorEventQueueSize)
 	originatorPriorityEventQueueSize := confutil.IntMin(configuration.OriginatorPriorityEventQueueSize, pldconf.SequencerMinimum.OriginatorPriorityEventQueueSize, *pldconf.SequencerDefaults.OriginatorPriorityEventQueueSize)
@@ -149,7 +149,7 @@ func (o *originator) delegateLoop(ctx context.Context) {
 	log.L(ctx).Debugf("delegate loop started for contract %s", o.contractAddress.String())
 
 	// Check for transactions still waiting to be delegated
-	ticker := time.NewTicker(o.delegateTimeout.(time.Duration))
+	ticker := time.NewTicker(o.delegateTimeout)
 	defer func() {
 		log.L(ctx).Debugf("delegate loop stopping for contract %s", o.contractAddress.String())
 		ticker.Stop()

--- a/core/go/internal/sequencer/originator/test_utils.go
+++ b/core/go/internal/sequencer/originator/test_utils.go
@@ -76,11 +76,11 @@ type OriginatorBuilderForTesting struct {
 	transactionBuilders []*transaction.TransactionBuilderForTesting
 	metrics             metrics.DistributedSequencerMetrics
 	sequencerConfig     *pldconf.SequencerConfig
+	clock               common.Clock
 }
 
 type OriginatorDependencyMocks struct {
 	SentMessageRecorder *SentMessageRecorder
-	Clock               *common.FakeClockForTesting
 	EngineIntegration   *common.FakeEngineIntegrationForTesting
 }
 
@@ -89,6 +89,7 @@ func NewOriginatorBuilderForTesting(state State) *OriginatorBuilderForTesting {
 		state:           state,
 		metrics:         metrics.InitMetrics(context.Background(), prometheus.NewRegistry()),
 		sequencerConfig: &pldconf.SequencerDefaults,
+		clock:           common.RealClock(),
 	}
 }
 
@@ -109,6 +110,11 @@ func (b *OriginatorBuilderForTesting) CommitteeMembers(committeeMembers ...strin
 
 func (b *OriginatorBuilderForTesting) TransactionBuilders(builders ...*transaction.TransactionBuilderForTesting) *OriginatorBuilderForTesting {
 	b.transactionBuilders = builders
+	return b
+}
+
+func (b *OriginatorBuilderForTesting) Clock(clock common.Clock) *OriginatorBuilderForTesting {
+	b.clock = clock
 	return b
 }
 
@@ -143,7 +149,6 @@ func (b *OriginatorBuilderForTesting) Build(ctx context.Context) (*originator, *
 	}
 	mocks := &OriginatorDependencyMocks{
 		SentMessageRecorder: NewSentMessageRecorder(),
-		Clock:               &common.FakeClockForTesting{},
 		EngineIntegration:   &common.FakeEngineIntegrationForTesting{},
 	}
 
@@ -155,7 +160,7 @@ func (b *OriginatorBuilderForTesting) Build(ctx context.Context) (*originator, *
 		buildCtx,
 		*b.nodeName,
 		mocks.SentMessageRecorder,
-		mocks.Clock,
+		b.clock,
 		mocks.EngineIntegration,
 		b.contractAddress,
 		&pldconf.SequencerDefaults,

--- a/core/go/internal/sequencer/originator/transaction/test_utils.go
+++ b/core/go/internal/sequencer/originator/transaction/test_utils.go
@@ -164,7 +164,6 @@ type TransactionBuilderForTesting struct {
 	currentDelegate           string
 	txn                       *OriginatorTransaction
 	sentMessageRecorder       *SentMessageRecorder
-	fakeClock                 *common.FakeClockForTesting
 	fakeEngineIntegration     *common.FakeEngineIntegrationForTesting
 	queueEventForOriginator   func(ctx context.Context, event common.Event)
 
@@ -188,7 +187,6 @@ func NewTransactionBuilderForTesting(t *testing.T, state State) *TransactionBuil
 		state:                     state,
 		currentDelegate:           uuid.New().String(),
 		privateTransactionBuilder: testutil.NewPrivateTransactionBuilderForTesting(),
-		fakeClock:                 &common.FakeClockForTesting{},
 		fakeEngineIntegration:     &common.FakeEngineIntegrationForTesting{},
 		sentMessageRecorder:       NewSentMessageRecorder(),
 		metrics:                   metrics.InitMetrics(context.Background(), prometheus.NewRegistry()),
@@ -241,7 +239,6 @@ func (b *TransactionBuilderForTesting) GetBuiltTransaction() *OriginatorTransact
 
 type TransactionDependencyFakes struct {
 	SentMessageRecorder *SentMessageRecorder
-	Clock               *common.FakeClockForTesting
 	EngineIntegration   *common.FakeEngineIntegrationForTesting
 	transactionBuilder  *TransactionBuilderForTesting
 	emittedEvents       []common.Event
@@ -250,7 +247,6 @@ type TransactionDependencyFakes struct {
 func (b *TransactionBuilderForTesting) BuildWithMocks() (*OriginatorTransaction, *TransactionDependencyFakes) {
 	mocks := &TransactionDependencyFakes{
 		SentMessageRecorder: b.sentMessageRecorder,
-		Clock:               b.fakeClock,
 		EngineIntegration:   b.fakeEngineIntegration,
 		transactionBuilder:  b,
 	}

--- a/core/go/internal/sequencer/originator/transaction/transaction.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction.go
@@ -17,6 +17,7 @@ package transaction
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
@@ -49,7 +50,7 @@ type OriginatorTransaction struct {
 	transportWriter                  transport.TransportWriter
 	queueEventForOriginator          func(context.Context, common.Event)
 	currentDelegate                  string
-	lastDelegatedTime                *common.Time
+	lastDelegatedTime                *time.Time
 	latestAssembleRequest            *assembleRequestFromCoordinator
 	latestFulfilledAssembleRequestID uuid.UUID
 	latestPreDispatchRequestID       uuid.UUID
@@ -205,7 +206,7 @@ func (t *OriginatorTransaction) GetNonce() *uint64 {
 	return t.nonce
 }
 
-func (t *OriginatorTransaction) GetLastDelegatedTime() *common.Time {
+func (t *OriginatorTransaction) GetLastDelegatedTime() *time.Time {
 	t.RLock()
 	defer t.RUnlock()
 	return t.lastDelegatedTime

--- a/core/go/internal/sequencer/originator/transaction/transaction_test.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction_test.go
@@ -110,11 +110,6 @@ func TestTransaction_UpdateLastDelegatedTime_SetsTime(t *testing.T) {
 	// Verify that the time is now set
 	lastDelegatedTime := txn.GetLastDelegatedTime()
 	assert.NotNil(t, lastDelegatedTime, "GetLastDelegatedTime should return a non-nil value after UpdateLastDelegatedTime")
-
-	// Verify that the time is a valid time.Time (since RealClock returns time.Now())
-	realTime, ok := (*lastDelegatedTime).(time.Time)
-	require.True(t, ok, "LastDelegatedTime should be a time.Time")
-	assert.False(t, realTime.IsZero(), "LastDelegatedTime should not be zero")
 }
 
 func TestTransaction_UpdateLastDelegatedTime_UpdatesTime(t *testing.T) {
@@ -136,9 +131,8 @@ func TestTransaction_UpdateLastDelegatedTime_UpdatesTime(t *testing.T) {
 	require.NotNil(t, secondTime, "Second update should set a time")
 
 	// Verify that the times are different
-	firstRealTime := (*firstTime).(time.Time)
-	secondRealTime := (*secondTime).(time.Time)
-	assert.True(t, secondRealTime.After(firstRealTime), "Second time should be after the first time")
+
+	assert.True(t, secondTime.After(*firstTime), "Second time should be after the first time")
 }
 
 func TestTransaction_GetLastDelegatedTime_ReturnsUpdatedTime(t *testing.T) {

--- a/core/go/internal/sequencer/spec/coordinator_transaction_test.go
+++ b/core/go/internal/sequencer/spec/coordinator_transaction_test.go
@@ -166,8 +166,6 @@ func TestCoordinatorTransaction_Assembling_ToPooled_OnStateTimeout_IfStateTimeou
 		Build()
 	mocks.EngineIntegration.EXPECT().ResetTransactions(ctx, txn.GetID()).Return()
 
-	mocks.Clock.Advance(1)
-
 	err := txn.HandleEvent(ctx, &transaction.StateTimeoutIntervalEvent{
 		BaseCoordinatorEvent: transaction.BaseCoordinatorEvent{
 			TransactionID: txn.GetID(),

--- a/core/go/internal/sequencer/spec/originator_test.go
+++ b/core/go/internal/sequencer/spec/originator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/statemachine"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,8 +124,14 @@ func TestStateMachine_Sending_NoTransition_OnTransactionConfirmed_IfHasTransacti
 
 func TestStateMachine_Observing_ToIdle_OnHeartbeatInterval_IfHeartbeatThresholdExpired(t *testing.T) {
 	ctx := context.Background()
-	builder := originator.NewOriginatorBuilderForTesting(originator.State_Observing)
-	o, mocks, cleanup := builder.Build(ctx)
+
+	clock := common.NewMockClock(t)
+	clock.On("Now").Return(time.Now()).Once()
+	clock.On("HasExpired", mock.Anything, mock.Anything).Return(true).Once()
+
+	builder := originator.NewOriginatorBuilderForTesting(originator.State_Observing).
+		Clock(clock)
+	o, _, cleanup := builder.Build(ctx)
 	defer cleanup()
 
 	heartbeatEvent := &originator.HeartbeatReceivedEvent{}
@@ -135,8 +142,6 @@ func TestStateMachine_Observing_ToIdle_OnHeartbeatInterval_IfHeartbeatThresholdE
 	sync := statemachine.NewSyncEvent()
 	o.QueueEvent(ctx, sync)
 	<-sync.Done
-
-	mocks.Clock.Advance(builder.GetCoordinatorHeartbeatThresholdMs() + 1)
 
 	o.QueueEvent(ctx, &originator.HeartbeatIntervalEvent{})
 	assert.Eventually(t, func() bool { return o.GetCurrentState() == originator.State_Idle }, 100*time.Millisecond, 1*time.Millisecond, "current state is %s", o.GetCurrentState().String())
@@ -144,8 +149,14 @@ func TestStateMachine_Observing_ToIdle_OnHeartbeatInterval_IfHeartbeatThresholdE
 
 func TestStateMachine_Observing_NoTransition_OnHeartbeatInterval_IfHeartbeatThresholdNotExpired(t *testing.T) {
 	ctx := context.Background()
-	builder := originator.NewOriginatorBuilderForTesting(originator.State_Observing)
-	o, mocks, cleanup := builder.Build(ctx)
+
+	clock := common.NewMockClock(t)
+	clock.On("Now").Return(time.Now()).Once()
+	clock.On("HasExpired", mock.Anything, mock.Anything).Return(false).Once()
+
+	builder := originator.NewOriginatorBuilderForTesting(originator.State_Observing).
+		Clock(clock)
+	o, _, cleanup := builder.Build(ctx)
 	defer cleanup()
 
 	heartbeatEvent := &originator.HeartbeatReceivedEvent{}
@@ -156,8 +167,6 @@ func TestStateMachine_Observing_NoTransition_OnHeartbeatInterval_IfHeartbeatThre
 	sync := statemachine.NewSyncEvent()
 	o.QueueEvent(ctx, sync)
 	<-sync.Done
-
-	mocks.Clock.Advance(builder.GetCoordinatorHeartbeatThresholdMs() - 1)
 
 	o.QueueEvent(ctx, &originator.HeartbeatIntervalEvent{})
 	sync2 := statemachine.NewSyncEvent()


### PR DESCRIPTION
Addresses part of #933

Replaces all usage of the fake clock with a mock clock. This means we are no longer using `interface` and casting in the place of real time types.