### PR TITLE
fix: re-assemble immediately on endorsement rejection

### DIFF
--- a/core/go/internal/sequencer/coordinator/transaction/endorsed_rejected_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsed_rejected_test.go
@@ -1,0 +1,34 @@
+package transaction
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Verifies that when an endorsement is rejected, the transaction resets pending endorsement requests
+// and transitions back to the pooled state so it can be re-assembled immediately.
+func TestEndorsedRejected_ImmediateRepool(t *testing.T) {
+    // Build a transaction in the EndorsementGathering state with one pending endorsement request
+    builder := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
+        UseMockTransportWriter().
+        UseMockClock().
+        NumberOfRequiredEndorsers(1).
+        AddPendingEndorsementRequest(0)
+
+    txn, _ := builder.Build()
+
+    // Sanity: there should be pending endorsement requests
+    require.NotNil(t, txn.pendingEndorsementRequests)
+
+    // Build and queue an EndorsedRejectedEvent for the pending request
+    event := builder.BuildEndorseRejectedEvent(0)
+
+    err := txn.HandleEvent(context.Background(), event)
+    require.NoError(t, err)
+
+    // After handling rejection, the state should be pooled and pending requests cleared
+    require.Equal(t, State_Pooled, txn.GetCurrentState())
+    require.Nil(t, txn.pendingEndorsementRequests)
+}

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine.go
@@ -252,6 +252,7 @@ var stateDefinitionsMap = StateDefinitions{
 				},
 			},
 			Event_EndorsedRejected: {
+				Actions: []ActionRule{{Action: action_ResetEndorsementRequests}},
 				Transitions: []Transition{
 					{
 						To: State_Pooled,


### PR DESCRIPTION
Fixes #1068 by adding `action_ResetEndorsementRequests` to the `Event_EndorsedRejected` transition.

Changes:
- Fix: Added reset action to `Event_EndorsedRejected` in the transaction state machine.
- Test: Added `TestEndorsedRejected_ImmediateRepool` to verify immediate state transition and request cleanup.