### PR TITLE
Decrease memory retention

### DIFF
--- a/core/go/internal/components/transaction.go
+++ b/core/go/internal/components/transaction.go
@@ -75,7 +75,6 @@ type TransactionPostAssembly struct {
 	DomainData            *string                                    `json:"domain_data"`
 	RevertReason          *string                                    `json:"revert_reason"`
 }
-
 // PrivateTransaction is the critical exchange object between the engine and the domain manager,
 // as it hops between the states in the state machine (on multiple paladin nodes) to reach
 // a state that it can successfully (and anonymously) submitted it to the blockchain.
@@ -101,6 +100,16 @@ type PrivateTransaction struct {
 	PreparedPublicTransaction  *pldapi.TransactionInput `json:"-"`
 	PreparedPrivateTransaction *pldapi.TransactionInput `json:"-"`
 	PreparedMetadata           pldtypes.RawJSON         `json:"-"`
+}
+
+// ReleasePostAssemblyData releases the heavy post-assembly and prepared-dispatch
+// payload data. Shared by re-assembly cleanup (which retains PreAssembly for reuse)
+// and post-dispatch cleanup (which additionally releases PreAssembly).
+func (pt *PrivateTransaction) ReleasePostAssemblyData() {
+	pt.PostAssembly = nil
+	pt.PreparedPublicTransaction = nil
+	pt.PreparedPrivateTransaction = nil
+	pt.PreparedMetadata = nil
 }
 
 // PrivateContractDeploy is a simpler transaction type that constructs new private smart contract instances

--- a/core/go/internal/components/transaction.go
+++ b/core/go/internal/components/transaction.go
@@ -75,6 +75,7 @@ type TransactionPostAssembly struct {
 	DomainData            *string                                    `json:"domain_data"`
 	RevertReason          *string                                    `json:"revert_reason"`
 }
+
 // PrivateTransaction is the critical exchange object between the engine and the domain manager,
 // as it hops between the states in the state machine (on multiple paladin nodes) to reach
 // a state that it can successfully (and anonymously) submitted it to the blockchain.
@@ -102,10 +103,10 @@ type PrivateTransaction struct {
 	PreparedMetadata           pldtypes.RawJSON         `json:"-"`
 }
 
-// ReleasePostAssemblyData releases the heavy post-assembly and prepared-dispatch
+// CleanUpPostAssemblyData releases the heavy post-assembly and prepared-dispatch
 // payload data. Shared by re-assembly cleanup (which retains PreAssembly for reuse)
 // and post-dispatch cleanup (which additionally releases PreAssembly).
-func (pt *PrivateTransaction) ReleasePostAssemblyData() {
+func (pt *PrivateTransaction) CleanUpPostAssemblyData() {
 	pt.PostAssembly = nil
 	pt.PreparedPublicTransaction = nil
 	pt.PreparedPrivateTransaction = nil

--- a/core/go/internal/components/transaction_test.go
+++ b/core/go/internal/components/transaction_test.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2026 Kaleido, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package components
+
+import (
+	"testing"
+
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
+	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReleasePostAssemblyData(t *testing.T) {
+	pt := &PrivateTransaction{
+		ID:      uuid.New(),
+		Domain:  "test-domain",
+		Address: *pldtypes.RandAddress(),
+		Signer:  "signer@node1",
+		PreAssembly: &TransactionPreAssembly{
+			TransactionSpecification: &prototk.TransactionSpecification{},
+		},
+		PostAssembly: &TransactionPostAssembly{
+			OutputStates: []*FullState{{Data: pldtypes.RawJSON(`{}`)}},
+			InputStates:  []*FullState{{Data: pldtypes.RawJSON(`{}`)}},
+		},
+		PreparedPublicTransaction:  &pldapi.TransactionInput{},
+		PreparedPrivateTransaction: &pldapi.TransactionInput{},
+		PreparedMetadata:           pldtypes.RawJSON(`{"meta":true}`),
+	}
+
+	savedID := pt.ID
+	savedDomain := pt.Domain
+	savedAddress := pt.Address
+	savedSigner := pt.Signer
+
+	pt.ReleasePostAssemblyData()
+
+	assert.Nil(t, pt.PostAssembly)
+	assert.Nil(t, pt.PreparedPublicTransaction)
+	assert.Nil(t, pt.PreparedPrivateTransaction)
+	assert.Nil(t, pt.PreparedMetadata)
+
+	assert.NotNil(t, pt.PreAssembly, "PreAssembly should be preserved")
+	assert.Equal(t, savedID, pt.ID)
+	assert.Equal(t, savedDomain, pt.Domain)
+	assert.Equal(t, savedAddress, pt.Address)
+	assert.Equal(t, savedSigner, pt.Signer)
+}
+
+func TestReleasePostAssemblyData_NilFields(t *testing.T) {
+	pt := &PrivateTransaction{ID: uuid.New()}
+	pt.ReleasePostAssemblyData()
+
+	assert.Nil(t, pt.PostAssembly)
+	assert.Nil(t, pt.PreparedPublicTransaction)
+}

--- a/core/go/internal/components/transaction_test.go
+++ b/core/go/internal/components/transaction_test.go
@@ -48,7 +48,7 @@ func TestReleasePostAssemblyData(t *testing.T) {
 	savedAddress := pt.Address
 	savedSigner := pt.Signer
 
-	pt.ReleasePostAssemblyData()
+	pt.CleanUpPostAssemblyData()
 
 	assert.Nil(t, pt.PostAssembly)
 	assert.Nil(t, pt.PreparedPublicTransaction)
@@ -64,7 +64,7 @@ func TestReleasePostAssemblyData(t *testing.T) {
 
 func TestReleasePostAssemblyData_NilFields(t *testing.T) {
 	pt := &PrivateTransaction{ID: uuid.New()}
-	pt.ReleasePostAssemblyData()
+	pt.CleanUpPostAssemblyData()
 
 	assert.Nil(t, pt.PostAssembly)
 	assert.Nil(t, pt.PreparedPublicTransaction)

--- a/core/go/internal/domainmgr/event_indexer.go
+++ b/core/go/internal/domainmgr/event_indexer.go
@@ -278,7 +278,9 @@ func (d *domain) recoverTransactionID(ctx context.Context, txIDString string) (*
 func (d *domain) handleEventBatchForContract(ctx context.Context, dbTX persistence.DBTX, addr pldtypes.EthAddress, batch *pscEventBatch) (*prototk.HandleEventBatchResponse, error) {
 	// We have a domain context for queries, but we never flush it to DB - as the only updates
 	// we allow in this function are those performed within our dbTX.
-	c := d.newInFlightDomainRequest(dbTX, d.dm.stateStore.NewDomainContext(ctx, d, addr), false /* write enabled */)
+	dCtx := d.dm.stateStore.NewDomainContext(ctx, d, addr)
+	defer dCtx.Close()
+	c := d.newInFlightDomainRequest(dbTX, dCtx, false /* write enabled */)
 	defer c.close()
 
 	batch.StateQueryContext = c.id

--- a/core/go/internal/domainmgr/private_smart_contract.go
+++ b/core/go/internal/domainmgr/private_smart_contract.go
@@ -303,7 +303,6 @@ func (dc *domainContract) WritePotentialStates(dCtx components.DomainContext, re
 		log.L(dCtx.Ctx()).Debugf("WritePotentialStates: Writing %+v info potentialstates", len(postAssembly.InfoStatesPotential))
 		postAssembly.InfoStates, err = dc.upsertPotentialStates(dCtx, readTX, tx, postAssembly.InfoStatesPotential, false)
 	}
-
 	log.L(dCtx.Ctx()).Debugf("WritePotentialStates: %d post assembly output states", len(postAssembly.OutputStates))
 	log.L(dCtx.Ctx()).Debugf("WritePotentialStates: %d post assembly info states", len(postAssembly.InfoStates))
 	return err

--- a/core/go/internal/sequencer/coordinator/coordinating.go
+++ b/core/go/internal/sequencer/coordinator/coordinating.go
@@ -236,6 +236,7 @@ func (c *coordinator) popNextPooledTransaction() transaction.CoordinatorTransact
 		return nil
 	}
 	nextPooledTx := c.pooledTransactions[0]
+	c.pooledTransactions[0] = nil // clear reference so the backing array doesn't pin the transaction from GC
 	c.pooledTransactions = c.pooledTransactions[1:]
 	return nextPooledTx
 }

--- a/core/go/internal/sequencer/coordinator/transaction/assembling.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling.go
@@ -68,11 +68,17 @@ func (t *coordinatorTransaction) applyPostAssembly(ctx context.Context, postAsse
 	err := t.writeLockStates(ctx)
 	if err != nil {
 		// Internal error. Only option is to revert the transaction
-		seqRevertEvent := &AssembleRevertResponseEvent{}
+		revertReason := i18n.ExpandWithCode(ctx, i18n.MessageKey(msgs.MsgSequencerInternalError), err)
+		seqRevertEvent := &AssembleRevertResponseEvent{
+			PostAssembly: &components.TransactionPostAssembly{
+				AssemblyResult: prototk.AssembleTransactionResponse_REVERT,
+				RevertReason:   &revertReason,
+			},
+		}
 		seqRevertEvent.RequestID = requestID // Must match what the state machine thinks the current assemble request ID is
 		seqRevertEvent.TransactionID = t.pt.ID
 		t.queueEventForCoordinator(ctx, seqRevertEvent)
-		t.revertTransactionFailedAssembly(ctx, i18n.ExpandWithCode(ctx, i18n.MessageKey(msgs.MsgSequencerInternalError), err))
+		t.revertTransactionFailedAssembly(ctx, revertReason)
 		// Return the original error
 		return err
 	}

--- a/core/go/internal/sequencer/coordinator/transaction/dispatched.go
+++ b/core/go/internal/sequencer/coordinator/transaction/dispatched.go
@@ -31,6 +31,16 @@ func action_NotifyDispatched(ctx context.Context, t *coordinatorTransaction, _ c
 	return t.transportWriter.SendDispatched(ctx, t.originator, uuid.New(), txSpec)
 }
 
+// action_ReleaseAssemblyPayload releases the heavy post-assembly and prepared-dispatch
+// payload data after dispatch. PreAssembly is preserved because it holds the
+// TransactionSpecification and RequiredVerifiers needed if the transaction reverts
+// and must be re-assembled.
+func action_ReleaseAssemblyPayload(ctx context.Context, t *coordinatorTransaction, _ common.Event) error {
+	log.L(ctx).Debugf("releasing assembly payload for dispatched transaction %s", t.pt.ID.String())
+	t.pt.ReleasePostAssemblyData()
+	return nil
+}
+
 func action_NotifyCollected(_ context.Context, t *coordinatorTransaction, event common.Event) error {
 	e := event.(*CollectedEvent)
 	t.signerAddress = &e.SignerAddress

--- a/core/go/internal/sequencer/coordinator/transaction/dispatched.go
+++ b/core/go/internal/sequencer/coordinator/transaction/dispatched.go
@@ -31,13 +31,13 @@ func action_NotifyDispatched(ctx context.Context, t *coordinatorTransaction, _ c
 	return t.transportWriter.SendDispatched(ctx, t.originator, uuid.New(), txSpec)
 }
 
-// action_ReleaseAssemblyPayload releases the heavy post-assembly and prepared-dispatch
+// action_CleanUpAssemblyPayload releases the heavy post-assembly and prepared-dispatch
 // payload data after dispatch. PreAssembly is preserved because it holds the
 // TransactionSpecification and RequiredVerifiers needed if the transaction reverts
 // and must be re-assembled.
-func action_ReleaseAssemblyPayload(ctx context.Context, t *coordinatorTransaction, _ common.Event) error {
-	log.L(ctx).Debugf("releasing assembly payload for dispatched transaction %s", t.pt.ID.String())
-	t.pt.ReleasePostAssemblyData()
+func action_CleanUpAssemblyPayload(ctx context.Context, t *coordinatorTransaction, _ common.Event) error {
+	log.L(ctx).Debugf("cleaning up assembly payload for dispatched transaction %s", t.pt.ID.String())
+	t.pt.CleanUpPostAssemblyData()
 	return nil
 }
 

--- a/core/go/internal/sequencer/coordinator/transaction/dispatched_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/dispatched_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/LFDT-Paladin/paladin/core/internal/components"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/stretchr/testify/assert"
@@ -146,6 +148,53 @@ func Test_action_NotifySubmitted_PropagatesSendError(t *testing.T) {
 	// State still updated
 	require.NotNil(t, txn.latestSubmissionHash)
 	assert.Equal(t, submissionHash, *txn.latestSubmissionHash)
+}
+
+func Test_action_ReleaseAssemblyPayload_NilsHeavyFields(t *testing.T) {
+	ctx := context.Background()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Dispatched).Build()
+
+	txn.pt.PostAssembly = &components.TransactionPostAssembly{
+		InputStates:  []*components.FullState{{Data: pldtypes.RawJSON(`{}`)}},
+		OutputStates: []*components.FullState{{Data: pldtypes.RawJSON(`{}`)}},
+		Endorsements: []*prototk.AttestationResult{{Payload: []byte("sig")}},
+	}
+	txn.pt.PreparedPublicTransaction = &pldapi.TransactionInput{}
+	txn.pt.PreparedMetadata = pldtypes.RawJSON(`{"meta":true}`)
+	txn.pt.PreAssembly = &components.TransactionPreAssembly{
+		TransactionSpecification: &prototk.TransactionSpecification{},
+	}
+
+	savedID := txn.pt.ID
+	savedDomain := txn.pt.Domain
+	savedAddress := txn.pt.Address
+
+	err := action_ReleaseAssemblyPayload(ctx, txn, nil)
+	require.NoError(t, err)
+
+	assert.Nil(t, txn.pt.PostAssembly)
+	assert.NotNil(t, txn.pt.PreAssembly, "PreAssembly preserved for retryable reverts")
+	assert.Nil(t, txn.pt.PreparedPublicTransaction)
+	assert.Nil(t, txn.pt.PreparedPrivateTransaction)
+	assert.Nil(t, txn.pt.PreparedMetadata)
+
+	assert.Equal(t, savedID, txn.pt.ID)
+	assert.Equal(t, savedDomain, txn.pt.Domain)
+	assert.Equal(t, savedAddress, txn.pt.Address)
+}
+
+func Test_action_ReleaseAssemblyPayload_SafeWithNilFields(t *testing.T) {
+	ctx := context.Background()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Dispatched).Build()
+
+	txn.pt.PostAssembly = nil
+	txn.pt.PreAssembly = nil
+	txn.pt.PreparedPublicTransaction = nil
+	txn.pt.PreparedPrivateTransaction = nil
+	txn.pt.PreparedMetadata = nil
+
+	err := action_ReleaseAssemblyPayload(ctx, txn, nil)
+	require.NoError(t, err)
 }
 
 func Test_action_NotifyDispatched_UsesTransactionSpec(t *testing.T) {

--- a/core/go/internal/sequencer/coordinator/transaction/dispatched_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/dispatched_test.go
@@ -169,7 +169,7 @@ func Test_action_ReleaseAssemblyPayload_NilsHeavyFields(t *testing.T) {
 	savedDomain := txn.pt.Domain
 	savedAddress := txn.pt.Address
 
-	err := action_ReleaseAssemblyPayload(ctx, txn, nil)
+	err := action_CleanUpAssemblyPayload(ctx, txn, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, txn.pt.PostAssembly)
@@ -193,7 +193,7 @@ func Test_action_ReleaseAssemblyPayload_SafeWithNilFields(t *testing.T) {
 	txn.pt.PreparedPrivateTransaction = nil
 	txn.pt.PreparedMetadata = nil
 
-	err := action_ReleaseAssemblyPayload(ctx, txn, nil)
+	err := action_CleanUpAssemblyPayload(ctx, txn, nil)
 	require.NoError(t, err)
 }
 

--- a/core/go/internal/sequencer/coordinator/transaction/finalizing.go
+++ b/core/go/internal/sequencer/coordinator/transaction/finalizing.go
@@ -50,7 +50,12 @@ func action_FinalizeAsUnknownByOriginator(ctx context.Context, txn *coordinatorT
 	return txn.finalizeAsUnknownByOriginator(ctx)
 }
 
-func (t *coordinatorTransaction) finalizeAsUnknownByOriginator(ctx context.Context) error {
+func (t *coordinatorTransaction) finalizeAsUnknownByOriginator(_ context.Context) error {
 	t.clearTimeoutSchedules()
+	// Note: ResetTransactions is not called here because Event_TransactionUnknownByOriginator
+	// is only handled in State_Assembling, which is before WriteLockStatesForTransaction has
+	// been called -- so no creatingStates or txLocks exist in the domain context for this
+	// transaction's current assembly attempt. If the state machine is ever extended to handle
+	// this event in post-assembly states, ResetTransactions must be added here.
 	return nil
 }

--- a/core/go/internal/sequencer/coordinator/transaction/pooled.go
+++ b/core/go/internal/sequencer/coordinator/transaction/pooled.go
@@ -39,9 +39,7 @@ func (t *coordinatorTransaction) initializeForNewAssembly(ctx context.Context) e
 	// Reset anything that might have been updated during an initial attempt to assembly, endorse and dispatch this TX. This is a no-op if this is the first
 	// and only time we pool & assemble this transaction but if we're re-pooling for any reason we must clear the post-assembly and any post-assembly
 	// dependencies from a previous version of the grapher.
-	t.pt.PostAssembly = nil
-	t.pt.PreparedPublicTransaction = nil
-	t.pt.PreparedPrivateTransaction = nil
+	t.pt.ReleasePostAssemblyData()
 	t.dependencies = &pldapi.TransactionDependencies{}
 	t.pendingPreDispatchRequest = nil
 	t.grapher.ForgetMints(t.pt.ID)

--- a/core/go/internal/sequencer/coordinator/transaction/pooled.go
+++ b/core/go/internal/sequencer/coordinator/transaction/pooled.go
@@ -39,7 +39,7 @@ func (t *coordinatorTransaction) initializeForNewAssembly(ctx context.Context) e
 	// Reset anything that might have been updated during an initial attempt to assembly, endorse and dispatch this TX. This is a no-op if this is the first
 	// and only time we pool & assemble this transaction but if we're re-pooling for any reason we must clear the post-assembly and any post-assembly
 	// dependencies from a previous version of the grapher.
-	t.pt.ReleasePostAssemblyData()
+	t.pt.CleanUpPostAssemblyData()
 	t.dependencies = &pldapi.TransactionDependencies{}
 	t.pendingPreDispatchRequest = nil
 	t.grapher.ForgetMints(t.pt.ID)

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine.go
@@ -388,6 +388,7 @@ var stateDefinitionsMap = StateDefinitions{
 	State_Dispatched: {
 		OnTransitionTo: []ActionRule{
 			{Action: action_NotifyDispatched},
+			{Action: action_ReleaseAssemblyPayload},
 		},
 		Events: map[EventType]EventHandler{
 			Event_Collected: {

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine.go
@@ -388,7 +388,7 @@ var stateDefinitionsMap = StateDefinitions{
 	State_Dispatched: {
 		OnTransitionTo: []ActionRule{
 			{Action: action_NotifyDispatched},
-			{Action: action_ReleaseAssemblyPayload},
+			{Action: action_CleanUpAssemblyPayload},
 		},
 		Events: map[EventType]EventHandler{
 			Event_Collected: {

--- a/sdk/go/pkg/pldtypes/rawjson.go
+++ b/sdk/go/pkg/pldtypes/rawjson.go
@@ -138,7 +138,7 @@ func (m *RawJSON) Scan(src interface{}) error {
 		*m = ([]byte)(s)
 		return nil
 	case []byte:
-		*m = s
+		*m = append((*m)[0:0], s...)
 		return nil
 	case nil:
 		*m = nil

--- a/sdk/go/pkg/pldtypes/rawjson_test.go
+++ b/sdk/go/pkg/pldtypes/rawjson_test.go
@@ -89,3 +89,15 @@ func TestRawJSON(t *testing.T) {
 	assert.Nil(t, RawJSON(nil).ToMap()["some"])
 
 }
+
+func TestRawJSON_ScanBytesCopies(t *testing.T) {
+	src := []byte(`{"key":"value"}`)
+	var r RawJSON
+	err := r.Scan(src)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"key":"value"}`, string(r))
+
+	// Mutate the source; the scanned RawJSON must be independent
+	src[2] = 'X'
+	assert.JSONEq(t, `{"key":"value"}`, string(r), "Scan([]byte) must copy, not alias")
+}


### PR DESCRIPTION
Memory leak fixes
* Nil pooled transactions in the underlying array once popped for assembly. This transaction still can't be GCed until other pointers to it have been cleared but `c.pooledTransactions = c.pooledTransactions[1:]` was changing the slice but not the backing array causing a build up of old transactions (inc all their post assembly data) https://github.com/LFDT-Paladin/paladin/pull/1134/commits/fe4fc93c320f82d63dd693bbb0cadd599710d711
* Close domain contexts used for handling event batches https://github.com/LFDT-Paladin/paladin/pull/1134/commits/cda322d93471de9fb0fd836228a821693d5040fe

Changes to make Paladin for garbage collector friendly, by reducing unnecessary memory allocations/freeing large objects as soon as possible.

* Clear post assembly data once dispatched rather than retaining it for the time to confirm plus the grace period before deleting https://github.com/LFDT-Paladin/paladin/pull/1134/commits/6052fc773b150e89e71d552d2f4f3658840742a4
* Copy data received back from DB scans in RawJSON https://github.com/LFDT-Paladin/paladin/pull/1134/commits/f6ba8a834092730c6570dc83144418e58bb608ed

